### PR TITLE
fix(backend): resolve six bugs and add mocked test suite

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -11,8 +11,70 @@ on:
 
 name: Build Tennis Backend
 jobs:
+  test:
+    name: Test & Static Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+          cache-dependency-path: backend/go.sum
+
+      - name: Verify formatting
+        run: |
+          cd backend
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "::error::The following files are not gofmt-formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Verify go.mod is tidy
+        run: |
+          cd backend
+          cp go.mod go.mod.bak
+          cp go.sum go.sum.bak
+          go mod tidy
+          if ! diff -q go.mod go.mod.bak >/dev/null || ! diff -q go.sum go.sum.bak >/dev/null; then
+            echo "::error::go.mod/go.sum are not tidy. Run 'go mod tidy' in ./backend."
+            diff -u go.mod.bak go.mod || true
+            diff -u go.sum.bak go.sum || true
+            exit 1
+          fi
+          rm -f go.mod.bak go.sum.bak
+
+      - name: Vet
+        run: |
+          cd backend
+          go vet ./...
+
+      # The tests mock every external dependency (federation sites and
+      # Nominatim) with httptest servers, so no network access is required.
+      - name: Test with race detector
+        run: |
+          cd backend
+          go test -race -count=1 -coverprofile=coverage.out ./...
+
+      - name: Coverage summary
+        run: |
+          cd backend
+          go tool cover -func=coverage.out | tail -n 20
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: backend/coverage.out
+          if-no-files-found: warn
+
   build:
     name: Build & Deploy
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -22,7 +84,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.23" # The Go version to download (if necessary) and use.
-      
+          cache-dependency-path: backend/go.sum
+
       - name: Build
         run: |
           cd backend
@@ -30,7 +93,7 @@ jobs:
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o tennis-tournament-finder-backend cmd/main.go
           pwd
           ls -la
-      
+
       - name: Deploy
         uses: appleboy/scp-action@v0.1.7
         if: github.event_name != 'pull_request'

--- a/README.md
+++ b/README.md
@@ -56,6 +56,56 @@ cd backend
 go run ./cmd/main.go
 ```
 
+### Running the Tests
+
+Every external dependency (federation websites and the Nominatim geocoding
+service) is mocked with local `httptest` servers, so the suite runs offline and
+deterministically.
+
+```bash
+cd backend
+
+# Full suite with the race detector (requires a C compiler for -race)
+go test -race ./...
+
+# Quick run without the race detector
+go test ./...
+
+# With coverage
+go test -coverprofile=coverage.out ./...
+go tool cover -func=coverage.out
+```
+
+HTML fixtures for the federation parsers live in
+`backend/pkg/tournament/testdata/`. When a federation changes its markup, update
+the corresponding fixture and adjust the expectations in
+`backend/pkg/tournament/tournament_test.go` in the same commit.
+
+By default the tests log at `ERROR` level. Set `TTF_LOG_LEVEL=DEBUG` to see the
+full output while debugging a failure.
+
+### Configuration
+
+| Environment variable | Default | Description |
+| --- | --- | --- |
+| `TTF_LOG_LEVEL` | `INFO` | Log verbosity: `DEBUG`, `INFO`, `WARN`, `ERROR`. |
+| `TTF_CACHE_PATH` | `./data/cache.bolt` | BoltDB file backing the geocoding cache. |
+| `TTF_CACHE_MEMORY` | `true` | Keep an in-memory copy of the cache. |
+| `TTF_HTTP_TIMEOUT_SECONDS` | `20` | Total timeout for federation requests. |
+| `TTF_GEOCODING_TIMEOUT_SECONDS` | `20` | Total timeout for geocoding requests. |
+| `TTF_USER_AGENT` | `TennisTournamentFinder/1.0 (+repo URL)` | `User-Agent` sent upstream. Forks should set their own contact details. |
+| `TTF_NOMINATIM_URL` | `https://nominatim.openstreetmap.org/search.php` | Geocoding endpoint. Point this at a self-hosted Nominatim instance if you need higher throughput. |
+| `TTF_NOMINATIM_INTERVAL_MS` | `1000` | Minimum spacing between uncached geocoding requests. Do not lower this for the shared public instance. |
+
+#### External service usage
+
+The public Nominatim instance requires an identifying `User-Agent` and permits
+at most one request per second. The backend enforces both: requests carry the
+agent above and are serialized process-wide by a rate limiter. Cached lookups
+never reach the network, so they do not consume that budget. See the
+[Nominatim usage policy](https://operations.osmfoundation.org/policies/nominatim/)
+before raising the request rate.
+
 ### Log Level Configuration
 
 The backend supports configurable log levels via the `TTF_LOG_LEVEL` environment variable:

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"expvar"
 	"net/http"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/metrics"
@@ -22,42 +25,50 @@ var (
 	reloadMu          sync.Mutex
 )
 
+// newServer builds an HTTP server with defensive timeouts so slow or
+// malicious clients cannot hold connections open indefinitely.
+func newServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      120 * time.Second,
+		IdleTimeout:       120 * time.Second,
+		MaxHeaderBytes:    1 << 20, // 1 MiB
+	}
+}
+
 func main() {
 	logger.Info("Starting Tennis Tournament Finder backend server...")
 
 	openstreetmap.InitCache()
 	logger.Info("OpenStreetMap cache initialized")
 
-	// Set up graceful shutdown
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		<-c
-		logger.Info("Shutting down gracefully...")
-		openstreetmap.CloseCache()
-		os.Exit(0)
-	}()
-
 	// Lightweight metrics (no Prometheus required)
 	metrics.Init()
 	metrics.SetReloadCallback(ReloadComponents)
 
 	// Start a localhost-only diagnostics server for /stats and /debug/vars
+	diagMux := http.NewServeMux()
+	diagMux.Handle(metrics.StatsPath, http.HandlerFunc(metrics.StatsHandler))
+	diagMux.Handle(metrics.DebugVarsPath, expvar.Handler())
+	diagMux.Handle(metrics.EnvPath, http.HandlerFunc(metrics.EnvHandler))
+	diagAddr := "127.0.0.1:9090"
+	diagServer := newServer(diagAddr, diagMux)
+
 	go func() {
-		diagMux := http.NewServeMux()
-		diagMux.Handle(metrics.StatsPath, http.HandlerFunc(metrics.StatsHandler))
-		diagMux.Handle(metrics.DebugVarsPath, expvar.Handler())
-		diagMux.Handle(metrics.EnvPath, http.HandlerFunc(metrics.EnvHandler))
-		addr := "127.0.0.1:9090"
-		logger.Info("Starting diagnostics server on http://%s%s and http://%s%s", addr, metrics.StatsPath, addr, metrics.DebugVarsPath)
-		if err := http.ListenAndServe(addr, diagMux); err != nil {
-			logger.Error("Diagnostics server failed to start on %s: %v", addr, err)
-			logger.Error("Diagnostics endpoints will NOT be available at http://%s%s, http://%s%s, or http://%s%s for this process lifetime", addr, metrics.StatsPath, addr, metrics.DebugVarsPath, addr, metrics.EnvPath)
+		logger.Info("Starting diagnostics server on http://%s%s and http://%s%s", diagAddr, metrics.StatsPath, diagAddr, metrics.DebugVarsPath)
+		if err := diagServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("Diagnostics server failed to start on %s: %v", diagAddr, err)
+			logger.Error("Diagnostics endpoints will NOT be available at http://%s%s, http://%s%s, or http://%s%s for this process lifetime", diagAddr, metrics.StatsPath, diagAddr, metrics.DebugVarsPath, diagAddr, metrics.EnvPath)
 		}
 	}()
 
 	// Public API with instrumentation (served on :8080)
-	http.Handle("/", metrics.Instrument(http.HandlerFunc(tournament.GetTournaments)))
+	apiMux := http.NewServeMux()
+	apiMux.Handle("/", metrics.Instrument(http.HandlerFunc(tournament.GetTournaments)))
+	apiServer := newServer(":8080", apiMux)
 
 	// In-process scheduler (fully optional; enable with env var)
 	cfg := scheduler.FromEnv()
@@ -76,8 +87,35 @@ func main() {
 		logger.Info("Scheduler disabled (set TTF_SCHEDULER_ENABLED=true to enable)")
 	}
 
+	// Set up graceful shutdown
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-c
+		logger.Info("Shutting down gracefully...")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+
+		if err := apiServer.Shutdown(ctx); err != nil {
+			logger.Error("API server shutdown error: %v", err)
+		}
+		if err := diagServer.Shutdown(ctx); err != nil {
+			logger.Error("Diagnostics server shutdown error: %v", err)
+		}
+
+		globalSchedulerMu.Lock()
+		if globalScheduler != nil {
+			globalScheduler.Stop()
+		}
+		globalSchedulerMu.Unlock()
+
+		openstreetmap.CloseCache()
+		os.Exit(0)
+	}()
+
 	logger.Info("Starting HTTP server on port 8080...")
-	if err := http.ListenAndServe(":8080", nil); err != nil {
+	if err := apiServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		logger.Error("Server failed to start: %v", err)
 	}
 }
@@ -87,22 +125,22 @@ func ReloadComponents() error {
 	// Serialize reload operations to prevent concurrent execution
 	reloadMu.Lock()
 	defer reloadMu.Unlock()
-	
+
 	logger.Info("Reloading application components...")
-	
+
 	// Reload log level
 	if logLevel := os.Getenv("TTF_LOG_LEVEL"); logLevel != "" {
 		level := logger.ParseLogLevel(logLevel)
 		logger.SetLogLevel(level)
 		logger.Info("Log level updated to: %s", logLevel)
 	}
-	
+
 	// Reload scheduler configuration
 	globalSchedulerMu.Lock()
 	cfg := scheduler.FromEnv()
 	currentScheduler := globalScheduler
 	globalSchedulerMu.Unlock()
-	
+
 	if cfg.Enabled {
 		if currentScheduler == nil {
 			// Scheduler was disabled, now enable it
@@ -133,7 +171,7 @@ func ReloadComponents() error {
 			logger.Info("Scheduler disabled during configuration reload")
 		}
 	}
-	
+
 	logger.Info("Component reload completed successfully")
 	return nil
 }

--- a/backend/pkg/cache/store.go
+++ b/backend/pkg/cache/store.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"go.etcd.io/bbolt"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
+	"go.etcd.io/bbolt"
 )
 
 const (

--- a/backend/pkg/httpclient/httpclient.go
+++ b/backend/pkg/httpclient/httpclient.go
@@ -1,0 +1,106 @@
+package httpclient
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// Default timeout values. Every outbound request made by the backend is bounded
+// so a slow or stalled upstream can never block a goroutine indefinitely.
+const (
+	DefaultTimeout               = 20 * time.Second
+	DefaultDialTimeout           = 5 * time.Second
+	DefaultTLSHandshakeTimeout   = 5 * time.Second
+	DefaultResponseHeaderTimeout = 15 * time.Second
+	DefaultIdleConnTimeout       = 90 * time.Second
+
+	// DefaultUserAgent identifies this application to upstream services.
+	// Several public APIs (most notably Nominatim) require a descriptive
+	// User-Agent with a way to contact the operator.
+	DefaultUserAgent = "TennisTournamentFinder/1.0 (+https://github.com/timoknapp/tennis-tournament-finder)"
+)
+
+var (
+	federationOnce   sync.Once
+	federationClient *http.Client
+
+	geocodingOnce   sync.Once
+	geocodingClient *http.Client
+)
+
+// New builds an HTTP client with bounded timeouts at every stage of the
+// request lifecycle.
+func New(timeout time.Duration) *http.Client {
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   DefaultDialTimeout,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout:   DefaultTLSHandshakeTimeout,
+		ResponseHeaderTimeout: DefaultResponseHeaderTimeout,
+		ExpectContinueTimeout: 1 * time.Second,
+		IdleConnTimeout:       DefaultIdleConnTimeout,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   10,
+	}
+
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}
+}
+
+// Federation returns the shared client used for federation scraping requests.
+func Federation() *http.Client {
+	federationOnce.Do(func() {
+		federationClient = New(durationFromEnv("TTF_HTTP_TIMEOUT_SECONDS", DefaultTimeout))
+	})
+	return federationClient
+}
+
+// Geocoding returns the shared client used for geocoding requests.
+func Geocoding() *http.Client {
+	geocodingOnce.Do(func() {
+		geocodingClient = New(durationFromEnv("TTF_GEOCODING_TIMEOUT_SECONDS", DefaultTimeout))
+	})
+	return geocodingClient
+}
+
+// UserAgent returns the User-Agent sent with outbound requests. It can be
+// overridden with TTF_USER_AGENT so operators of a fork can supply their own
+// contact details.
+func UserAgent() string {
+	if ua := os.Getenv("TTF_USER_AGENT"); ua != "" {
+		return ua
+	}
+	return DefaultUserAgent
+}
+
+// ApplyDefaultHeaders sets headers that should accompany every outbound request.
+func ApplyDefaultHeaders(req *http.Request) {
+	if req.Header.Get("User-Agent") == "" {
+		req.Header.Set("User-Agent", UserAgent())
+	}
+	if req.Header.Get("Accept-Language") == "" {
+		req.Header.Set("Accept-Language", "de-DE,de;q=0.9")
+	}
+}
+
+func durationFromEnv(key string, fallback time.Duration) time.Duration {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback
+	}
+
+	seconds, err := strconv.Atoi(raw)
+	if err != nil || seconds <= 0 {
+		return fallback
+	}
+
+	return time.Duration(seconds) * time.Second
+}

--- a/backend/pkg/metrics/simple.go
+++ b/backend/pkg/metrics/simple.go
@@ -226,6 +226,7 @@ func newState() *metricsState {
 		active:          make(map[string]time.Time),
 	}
 }
+
 type statusWriter struct {
 	http.ResponseWriter
 	status int

--- a/backend/pkg/openstreetmap/export_test.go
+++ b/backend/pkg/openstreetmap/export_test.go
@@ -1,0 +1,10 @@
+package openstreetmap
+
+import "sync"
+
+// resetRateLimiterForTest rebuilds the process-wide geocoding limiter so tests
+// can exercise different intervals. It is only compiled into test binaries.
+func resetRateLimiterForTest() {
+	geocodingLimiterOnce = sync.Once{}
+	geocodingLimiter = nil
+}

--- a/backend/pkg/openstreetmap/openstreetmap.go
+++ b/backend/pkg/openstreetmap/openstreetmap.go
@@ -1,17 +1,23 @@
 package openstreetmap
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"net/url"
 	"os"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/timoknapp/tennis-tournament-finder/pkg/cache"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/httpclient"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/ratelimit"
 )
 
 var CachedGeocoordinates map[string]models.Geocoordinates
@@ -20,6 +26,52 @@ var OrganizerCache map[string]models.Geocoordinates
 
 var cacheStore cache.Store
 var useMemoryCache bool
+
+// cacheMu guards the in-memory cache maps above. Geocoding runs concurrently
+// for every selected federation, so unsynchronized map access would be a data
+// race (and can crash the process with "concurrent map writes").
+var cacheMu sync.RWMutex
+
+// defaultNominatimBaseURL is the public Nominatim search endpoint.
+const defaultNominatimBaseURL = "https://nominatim.openstreetmap.org/search.php"
+
+// maxGeocodingResponseBytes bounds how much of an upstream response is read.
+const maxGeocodingResponseBytes = 1 << 20 // 1 MiB
+
+// defaultNominatimInterval honours the Nominatim usage policy of at most one
+// request per second for the shared public instance.
+const defaultNominatimInterval = time.Second
+
+var (
+	geocodingLimiterOnce sync.Once
+	geocodingLimiter     *ratelimit.Limiter
+)
+
+// nominatimBaseURL returns the geocoding endpoint. It is configurable so the
+// service can be pointed at a self-hosted Nominatim instance, and so tests can
+// direct it at a local mock server.
+func nominatimBaseURL() string {
+	if raw := os.Getenv("TTF_NOMINATIM_URL"); raw != "" {
+		return raw
+	}
+	return defaultNominatimBaseURL
+}
+
+// geocodingRateLimiter returns the process-wide limiter for uncached geocoding
+// requests. The interval can be lowered for a self-hosted instance via
+// TTF_NOMINATIM_INTERVAL_MS.
+func geocodingRateLimiter() *ratelimit.Limiter {
+	geocodingLimiterOnce.Do(func() {
+		interval := defaultNominatimInterval
+		if raw := os.Getenv("TTF_NOMINATIM_INTERVAL_MS"); raw != "" {
+			if ms, err := strconv.Atoi(raw); err == nil && ms >= 0 {
+				interval = time.Duration(ms) * time.Millisecond
+			}
+		}
+		geocodingLimiter = ratelimit.New(interval)
+	})
+	return geocodingLimiter
+}
 
 func InitCache() {
 	// Initialize environment-based configuration
@@ -40,13 +92,16 @@ func InitCache() {
 	}
 
 	// Initialize in-memory maps
+	cacheMu.Lock()
 	CachedGeocoordinates = make(map[string]models.Geocoordinates)
 	LocationCache = make(map[string]models.Geocoordinates)
 	OrganizerCache = make(map[string]models.Geocoordinates)
+	cacheMu.Unlock()
 
 	if useMemoryCache && cacheStore != nil {
 		// Preload BoltDB data into memory when memory cache is enabled
 		logger.Info("Loading existing cache data from BoltDB into memory...")
+		cacheMu.Lock()
 		err := cacheStore.ForEach(func(key string, value models.Geocoordinates) error {
 			// Determine which cache map to populate based on key prefix
 			if strings.HasPrefix(key, "loc:") {
@@ -54,16 +109,19 @@ func InitCache() {
 			} else if strings.HasPrefix(key, "org:") {
 				OrganizerCache[key] = value
 			} else {
-				// Tournament-specific cache (no prefix)
+				// Legacy tournament-specific cache (no prefix)
 				CachedGeocoordinates[key] = value
 			}
 			return nil
 		})
+		locations, organizers, tournaments := len(LocationCache), len(OrganizerCache), len(CachedGeocoordinates)
+		cacheMu.Unlock()
+
 		if err != nil {
 			logger.Error("Failed to preload cache data: %v", err)
 		} else {
 			logger.Info("Preloaded %d tournament, %d location, %d organizer entries from BoltDB",
-				len(CachedGeocoordinates), len(LocationCache), len(OrganizerCache))
+				tournaments, locations, organizers)
 		}
 	}
 
@@ -82,6 +140,9 @@ func CloseCache() {
 // getFromCache retrieves a geocoordinates entry from the appropriate cache
 func getFromCache(key string) (models.Geocoordinates, bool) {
 	if useMemoryCache {
+		cacheMu.RLock()
+		defer cacheMu.RUnlock()
+
 		// Determine which memory cache to check based on key prefix
 		var memCache map[string]models.Geocoordinates
 		if strings.HasPrefix(key, "loc:") {
@@ -122,6 +183,9 @@ func setInCache(key string, value models.Geocoordinates) {
 
 	// Also store in memory if memory cache is enabled
 	if useMemoryCache {
+		cacheMu.Lock()
+		defer cacheMu.Unlock()
+
 		// Determine which memory cache to update based on key prefix
 		if strings.HasPrefix(key, "loc:") {
 			LocationCache[key] = value
@@ -131,6 +195,26 @@ func setInCache(key string, value models.Geocoordinates) {
 			CachedGeocoordinates[key] = value
 		}
 	}
+}
+
+// geocodeCacheKeys returns the cache keys describing a tournament's location,
+// in lookup priority order.
+//
+// Successful and failed lookups must use the same keys, otherwise the retry
+// backoff can never observe an earlier failure. Keys are derived from the
+// location/organizer (which are stable and shared between tournaments) rather
+// than the volatile tournament ID.
+func geocodeCacheKeys(state string, tournament models.Tournament) []string {
+	var keys []string
+
+	if len(strings.TrimSpace(tournament.Location)) > 0 {
+		keys = append(keys, generateLocationCacheKey(tournament.Location, state))
+	}
+	if len(strings.TrimSpace(tournament.Organizer)) > 0 {
+		keys = append(keys, generateOrganizerCacheKey(tournament.Organizer, state))
+	}
+
+	return keys
 }
 func generateLocationCacheKey(location, state string) string {
 	// Normalize the location string for better cache hits
@@ -146,65 +230,43 @@ func generateOrganizerCacheKey(organizer, state string) string {
 }
 
 func GetGeocoordinatesFromCache(state string, tournament models.Tournament) models.Geocoordinates {
-	// Priority 1: Check location-based cache if we have a specific location
-	if len(tournament.Location) > 0 {
-		locationKey := generateLocationCacheKey(tournament.Location, state)
-		if cachedGeo, exists := getFromCache(locationKey); exists {
-			if cachedGeo.Lat != "" && cachedGeo.Lon != "" {
-				logger.Debug("Cache HIT (location): %s for tournament %s", locationKey, tournament.Id)
-				return cachedGeo
-			}
-			// Handle failed location cache entries
-			if cachedGeo.IsFailed && !shouldRetryGeocodingRequest(cachedGeo) {
-				logger.Debug("Skipping geocoding retry for location (%s): '%s' (failed %d times)",
-					tournament.Id, tournament.Location, cachedGeo.FailCount)
-				// Don't return failed location cache, try organizer cache next
-			}
-		}
-	}
+	keys := geocodeCacheKeys(state, tournament)
 
-	// Priority 2: Check organizer-based cache
-	if len(tournament.Organizer) > 0 {
-		organizerKey := generateOrganizerCacheKey(tournament.Organizer, state)
-		if cachedGeo, exists := getFromCache(organizerKey); exists {
-			if cachedGeo.Lat != "" && cachedGeo.Lon != "" {
-				logger.Debug("Cache HIT (organizer): %s for tournament %s", organizerKey, tournament.Id)
-				return cachedGeo
-			}
-			// Handle failed organizer cache entries
-			if cachedGeo.IsFailed && !shouldRetryGeocodingRequest(cachedGeo) {
-				logger.Debug("Skipping geocoding retry for organizer (%s): '%s' (failed %d times)",
-					tournament.Id, tournament.Organizer, cachedGeo.FailCount)
-				// Don't return failed organizer cache, try tournament cache next
-			}
+	// Check every candidate key. A successful hit wins immediately.
+	//
+	// A retry is suppressed only when every known key is still inside its
+	// backoff window. If any candidate is unknown or its backoff has expired,
+	// the lookup is allowed to proceed.
+	var knownEntries, blockedEntries int
+	for _, key := range keys {
+		cachedGeo, exists := getFromCache(key)
+		if !exists {
+			continue
 		}
-	}
 
-	// Priority 3: Check tournament-specific cache (existing behavior)
-	if cachedGeo, exists := getFromCache(tournament.Id); exists {
-		// If we have successful coordinates, return them
 		if cachedGeo.Lat != "" && cachedGeo.Lon != "" {
-			logger.Debug("Cache HIT (tournament): %s", tournament.Id)
+			logger.Debug("Cache HIT: %s for tournament %s", key, tournament.Id)
 			return cachedGeo
 		}
 
-		// If this is a failed attempt, check if we should retry
-		if cachedGeo.IsFailed {
-			shouldRetry := shouldRetryGeocodingRequest(cachedGeo)
-			if !shouldRetry {
-				logger.Debug("Skipping geocoding retry for tournament (%s): '%s' (failed %d times, last attempt: %v)",
-					tournament.Id, tournament.Organizer, cachedGeo.FailCount, time.Unix(cachedGeo.LastAttempt, 0))
-				return cachedGeo // Return the failed entry (will fallback to default coords in calling code)
-			}
-			logger.Debug("Retrying geocoding for tournament (%s): '%s' (retry attempt after %d failures)",
-				tournament.Id, tournament.Organizer, cachedGeo.FailCount)
+		knownEntries++
+		if cachedGeo.IsFailed && !shouldRetryGeocodingRequest(cachedGeo) {
+			logger.Debug("Skipping geocoding retry for %s (tournament %s, failed %d times, last attempt %v)",
+				key, tournament.Id, cachedGeo.FailCount, time.Unix(cachedGeo.LastAttempt, 0))
+			blockedEntries++
 		}
+	}
+
+	// Every known key is in backoff: do not hit the upstream service again.
+	// The caller falls back to the federation's default coordinates.
+	if knownEntries > 0 && blockedEntries == knownEntries && blockedEntries == len(keys) {
+		return models.Geocoordinates{}
 	}
 
 	logger.Debug("No Geocoordinate Cache entry found for (%s): '%s' at '%s'. Fetching data from server.",
 		tournament.Id, tournament.Organizer, tournament.Location)
-	geoCoordinates := getGeocoordinates(state, tournament)
-	return geoCoordinates
+
+	return getGeocoordinates(state, tournament)
 }
 
 // shouldRetryGeocodingRequest determines if a failed geocoding request should be retried
@@ -233,21 +295,9 @@ func shouldRetryGeocodingRequest(cachedGeo models.Geocoordinates) bool {
 }
 
 func saveGeocoordinatesInCache(tournament models.Tournament, state string, geoCoordinates models.Geocoordinates) {
-	// Always save to tournament-specific cache (existing behavior)
-	setInCache(tournament.Id, geoCoordinates)
-
-	// Also save to location cache if we have a location
-	if len(tournament.Location) > 0 {
-		locationKey := generateLocationCacheKey(tournament.Location, state)
-		setInCache(locationKey, geoCoordinates)
-		logger.Debug("Cached geocoordinates for location key: %s", locationKey)
-	}
-
-	// Also save to organizer cache if we have an organizer
-	if len(tournament.Organizer) > 0 {
-		organizerKey := generateOrganizerCacheKey(tournament.Organizer, state)
-		setInCache(organizerKey, geoCoordinates)
-		logger.Debug("Cached geocoordinates for organizer key: %s", organizerKey)
+	for _, key := range geocodeCacheKeys(state, tournament) {
+		setInCache(key, geoCoordinates)
+		logger.Debug("Cached geocoordinates for key: %s", key)
 	}
 }
 
@@ -265,26 +315,33 @@ func GetCacheStatistics() map[string]int {
 	}
 
 	if useMemoryCache {
+		cacheMu.RLock()
+		defer cacheMu.RUnlock()
+
 		// Use memory cache statistics
 		stats["location_cache_size"] = len(LocationCache)
 		stats["organizer_cache_size"] = len(OrganizerCache)
 		stats["tournament_cache_size"] = len(CachedGeocoordinates)
 
-		// Count tournament cache statistics
-		for _, geo := range CachedGeocoordinates {
-			stats["total_entries"]++
+		// Count statistics across every memory cache.
+		for _, memCache := range []map[string]models.Geocoordinates{
+			CachedGeocoordinates, LocationCache, OrganizerCache,
+		} {
+			for _, geo := range memCache {
+				stats["total_entries"]++
 
-			if geo.IsFailed {
-				stats["failed"]++
+				if geo.IsFailed {
+					stats["failed"]++
 
-				// Check if this failed entry should be retried
-				if shouldRetryGeocodingRequest(geo) {
-					stats["pending_retry"]++
-				} else if geo.FailCount >= 4 {
-					stats["permanently_failed"]++
+					// Check if this failed entry should be retried
+					if shouldRetryGeocodingRequest(geo) {
+						stats["pending_retry"]++
+					} else if geo.FailCount >= 4 {
+						stats["permanently_failed"]++
+					}
+				} else if geo.Lat != "" && geo.Lon != "" {
+					stats["successful"]++
 				}
-			} else if geo.Lat != "" && geo.Lon != "" {
-				stats["successful"]++
 			}
 		}
 	} else if cacheStore != nil {
@@ -323,17 +380,27 @@ func CleanupOldFailedEntries() int {
 	cutoffTime := time.Now().Unix() - (30 * 24 * 3600) // 30 days
 
 	if useMemoryCache {
-		// Clean from memory cache
-		for tournamentId, geo := range CachedGeocoordinates {
-			if geo.IsFailed && geo.FailCount >= 4 && geo.LastAttempt < cutoffTime {
-				delete(CachedGeocoordinates, tournamentId)
-				// Also remove from BoltDB if available
-				if cacheStore != nil {
-					cacheStore.Delete(tournamentId)
+		cacheMu.Lock()
+
+		// Clean from every memory cache.
+		for _, memCache := range []map[string]models.Geocoordinates{
+			CachedGeocoordinates, LocationCache, OrganizerCache,
+		} {
+			for key, geo := range memCache {
+				if geo.IsFailed && geo.FailCount >= 4 && geo.LastAttempt < cutoffTime {
+					delete(memCache, key)
+					// Also remove from BoltDB if available
+					if cacheStore != nil {
+						if err := cacheStore.Delete(key); err != nil {
+							logger.Error("Failed to delete key %s during cleanup: %v", key, err)
+						}
+					}
+					cleaned++
 				}
-				cleaned++
 			}
 		}
+
+		cacheMu.Unlock()
 	} else if cacheStore != nil {
 		// Clean from BoltDB directly
 		var keysToDelete []string
@@ -608,69 +675,151 @@ func isCommonClubWord(word string) bool {
 }
 
 func getGeocoordinates(state string, tournament models.Tournament) models.Geocoordinates {
-	// 1. Get Coordinates by tournament.Location if Location does not exists
+	// 1. Get Coordinates by tournament.Location if it exists
 	// 2. Get Coordinates by tournament.Organizer if this does not work out
-	// 3. Set Default Coords
+	// 3. Let the caller fall back to the federation default coordinates
 	var tournamentId string = tournament.Id
 	var tournamentOrganizer string = tournament.Organizer
-	// https://nominatim.openstreetmap.org/search.php?q=MTV+Karlsruhe&limit=1&format=jsonv2
-	const urlOSM string = "https://nominatim.openstreetmap.org/search.php?limit=3&accept-language=de&format=jsonv2&q="
-	// query := tournamentOrganizer
-	var query string = ""
-	if len(tournament.Location) > 0 {
+
+	var query string
+	if len(strings.TrimSpace(tournament.Location)) > 0 {
 		query = tournament.Location
 	} else {
 		query = extractCityFromOrganizerName(tournamentOrganizer)
 	}
-	urlFormattedQuery := strings.ReplaceAll(query, " ", "+")
 
-	// Get previous failure count for progressive backoff
-	var previousFailCount int
-	if cachedGeo, exists := getFromCache(tournamentId); exists && cachedGeo.IsFailed {
-		previousFailCount = cachedGeo.FailCount
+	query = strings.TrimSpace(query)
+	if query == "" {
+		logger.Warn("Empty geocoding query for tournament %s; skipping request", tournamentId)
+		saveFailedGeocodingAttempt(state, tournament)
+		return models.Geocoordinates{}
 	}
 
-	res, err := http.Get(urlOSM + urlFormattedQuery)
+	// Previous failure count drives the progressive backoff.
+	previousFailCount := previousFailCountFor(state, tournament)
+
+	ctx, cancel := context.WithTimeout(context.Background(), httpclient.DefaultTimeout)
+	defer cancel()
+
+	// Honour the Nominatim usage policy: at most one request per second.
+	// Cache hits never reach this point, so cached lookups do not consume
+	// rate-limit capacity.
+	if err := geocodingRateLimiter().Wait(ctx); err != nil {
+		logger.Error("Geocoding rate limiter aborted for tournament %s: %v", tournamentId, err)
+		return models.Geocoordinates{}
+	}
+
+	reqURL, err := buildNominatimURL(query)
+	if err != nil {
+		logger.Error("Failed to build geocoding URL for tournament %s: %v", tournamentId, err)
+		saveFailedGeocodingAttemptWithCount(state, tournament, previousFailCount)
+		return models.Geocoordinates{}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		logger.Error("Failed to create geocoding request for tournament %s: %v", tournamentId, err)
+		saveFailedGeocodingAttemptWithCount(state, tournament, previousFailCount)
+		return models.Geocoordinates{}
+	}
+	// Nominatim requires an identifying User-Agent.
+	httpclient.ApplyDefaultHeaders(req)
+	req.Header.Set("Accept", "application/json")
+
+	res, err := httpclient.Geocoding().Do(req)
 	if err != nil {
 		logger.Error("HTTP error for tournament %s: %v", tournamentId, err)
-		saveFailedGeocodingAttempt(tournamentId, previousFailCount)
+		saveFailedGeocodingAttemptWithCount(state, tournament, previousFailCount)
 		return models.Geocoordinates{}
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	if res.StatusCode != http.StatusOK {
+		if retryAfter := res.Header.Get("Retry-After"); retryAfter != "" {
+			logger.Warn("Geocoding throttled for tournament %s: status %d, Retry-After: %s",
+				tournamentId, res.StatusCode, retryAfter)
+		} else {
+			logger.Error("Geocoding failed for tournament %s: unexpected status %d", tournamentId, res.StatusCode)
+		}
+		// Drain a bounded amount so the connection can be reused.
+		_, _ = io.Copy(io.Discard, io.LimitReader(res.Body, maxGeocodingResponseBytes))
+		saveFailedGeocodingAttemptWithCount(state, tournament, previousFailCount)
+		return models.Geocoordinates{}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(res.Body, maxGeocodingResponseBytes))
 	if err != nil {
 		logger.Error("Read error for tournament %s: %v", tournamentId, err)
-		saveFailedGeocodingAttempt(tournamentId, previousFailCount)
+		saveFailedGeocodingAttemptWithCount(state, tournament, previousFailCount)
 		return models.Geocoordinates{}
 	}
 
 	var geoCoords []models.Geocoordinates
-	var result models.Geocoordinates
-	json.Unmarshal([]byte(string(body)), &geoCoords)
-	if len(geoCoords) > 0 {
-		// Check if coordinates belong to the correct states (region).
-		for i := 0; i < len(geoCoords); i++ {
-			if strings.Contains(geoCoords[i].DisplayName, state) {
-				result = geoCoords[i]
-				// Reset failure tracking on success
-				result.IsFailed = false
-				result.FailCount = 0
-				result.LastAttempt = 0
-				saveGeocoordinatesInCache(tournament, state, result)
-				return result
-			}
+	if err := json.Unmarshal(body, &geoCoords); err != nil {
+		logger.Error("Failed to decode geocoding response for tournament %s: %v", tournamentId, err)
+		saveFailedGeocodingAttemptWithCount(state, tournament, previousFailCount)
+		return models.Geocoordinates{}
+	}
+
+	// Check if coordinates belong to the correct state (region).
+	for i := 0; i < len(geoCoords); i++ {
+		if strings.Contains(geoCoords[i].DisplayName, state) {
+			result := geoCoords[i]
+			// Reset failure tracking on success
+			result.IsFailed = false
+			result.FailCount = 0
+			result.LastAttempt = 0
+			saveGeocoordinatesInCache(tournament, state, result)
+			return result
 		}
 	}
 
 	// No suitable coordinates found - cache this as a failed attempt
 	logger.Warn("No suitable geocoordinates found for tournament %s in state %s", tournamentId, state)
-	saveFailedGeocodingAttempt(tournamentId, previousFailCount)
+	saveFailedGeocodingAttemptWithCount(state, tournament, previousFailCount)
 	return models.Geocoordinates{}
 }
 
-// saveFailedGeocodingAttempt caches a failed geocoding attempt with retry metadata
-func saveFailedGeocodingAttempt(tournamentId string, previousFailCount int) {
+// buildNominatimURL assembles the geocoding request URL with proper encoding.
+func buildNominatimURL(query string) (string, error) {
+	u, err := url.Parse(nominatimBaseURL())
+	if err != nil {
+		return "", fmt.Errorf("invalid Nominatim base URL: %w", err)
+	}
+
+	q := u.Query()
+	q.Set("limit", "3")
+	q.Set("accept-language", "de")
+	q.Set("format", "jsonv2")
+	q.Set("q", query)
+	u.RawQuery = q.Encode()
+
+	return u.String(), nil
+}
+
+// previousFailCountFor returns the highest recorded failure count across the
+// cache keys belonging to this tournament.
+func previousFailCountFor(state string, tournament models.Tournament) int {
+	var previous int
+	for _, key := range geocodeCacheKeys(state, tournament) {
+		if cachedGeo, exists := getFromCache(key); exists && cachedGeo.IsFailed {
+			if cachedGeo.FailCount > previous {
+				previous = cachedGeo.FailCount
+			}
+		}
+	}
+	return previous
+}
+
+// saveFailedGeocodingAttempt records a failure using the currently known count.
+func saveFailedGeocodingAttempt(state string, tournament models.Tournament) {
+	saveFailedGeocodingAttemptWithCount(state, tournament, previousFailCountFor(state, tournament))
+}
+
+// saveFailedGeocodingAttemptWithCount caches a failed geocoding attempt with
+// retry metadata under the same keys used for successful lookups, so the
+// progressive backoff actually takes effect on the next run.
+func saveFailedGeocodingAttemptWithCount(state string, tournament models.Tournament, previousFailCount int) {
 	failedEntry := models.Geocoordinates{
 		Lat:         "",
 		Lon:         "",
@@ -679,5 +828,13 @@ func saveFailedGeocodingAttempt(tournamentId string, previousFailCount int) {
 		FailCount:   previousFailCount + 1,
 		IsFailed:    true,
 	}
-	setInCache(tournamentId, failedEntry)
+
+	keys := geocodeCacheKeys(state, tournament)
+	if len(keys) == 0 {
+		return
+	}
+
+	for _, key := range keys {
+		setInCache(key, failedEntry)
+	}
 }

--- a/backend/pkg/openstreetmap/openstreetmap_test.go
+++ b/backend/pkg/openstreetmap/openstreetmap_test.go
@@ -1,0 +1,535 @@
+package openstreetmap
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
+)
+
+// TestMain keeps test output readable; assertions never depend on log lines.
+func TestMain(m *testing.M) {
+	if os.Getenv("TTF_LOG_LEVEL") == "" {
+		os.Setenv("TTF_LOG_LEVEL", "ERROR")
+		logger.SetLogLevel(logger.ErrorLevel)
+	}
+
+	os.Exit(m.Run())
+}
+
+// initTestCache points the cache at a throwaway BoltDB file and resets the
+// package-level state between tests.
+func initTestCache(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("TTF_CACHE_PATH", t.TempDir()+"/cache.bolt")
+	t.Setenv("TTF_NOMINATIM_INTERVAL_MS", "0")
+
+	InitCache()
+	t.Cleanup(CloseCache)
+}
+
+// mockGeocodingServer serves a canned response and records the requests it saw.
+type mockGeocodingServer struct {
+	server    *httptest.Server
+	calls     int64
+	mu        sync.Mutex
+	userAgent string
+	queries   []string
+	times     []time.Time
+}
+
+func newMockGeocodingServer(t *testing.T, handler http.HandlerFunc) *mockGeocodingServer {
+	t.Helper()
+
+	m := &mockGeocodingServer{}
+	m.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&m.calls, 1)
+
+		m.mu.Lock()
+		m.userAgent = r.Header.Get("User-Agent")
+		m.queries = append(m.queries, r.URL.Query().Get("q"))
+		m.times = append(m.times, time.Now())
+		m.mu.Unlock()
+
+		handler(w, r)
+	}))
+	t.Cleanup(m.server.Close)
+
+	t.Setenv("TTF_NOMINATIM_URL", m.server.URL)
+
+	return m
+}
+
+func (m *mockGeocodingServer) callCount() int64 { return atomic.LoadInt64(&m.calls) }
+
+func (m *mockGeocodingServer) lastUserAgent() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.userAgent
+}
+
+func (m *mockGeocodingServer) recordedQueries() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.queries))
+	copy(out, m.queries)
+	return out
+}
+
+// respondWith writes a Nominatim-style JSON array.
+func respondWith(coords ...models.Geocoordinates) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(coords)
+	}
+}
+
+func TestGeocodingSendsIdentifyingUserAgent(t *testing.T) {
+	initTestCache(t)
+
+	mock := newMockGeocodingServer(t, respondWith(models.Geocoordinates{
+		Lat: "49.0069", Lon: "8.4037", DisplayName: "Karlsruhe, Baden-Württemberg, Deutschland",
+	}))
+
+	got := GetGeocoordinatesFromCache("Baden-Württemberg", models.Tournament{
+		Id: "1", Location: "Karlsruhe", Organizer: "TC Karlsruhe",
+	})
+
+	if got.Lat != "49.0069" {
+		t.Errorf("Lat = %q, want 49.0069", got.Lat)
+	}
+
+	ua := mock.lastUserAgent()
+	if ua == "" {
+		t.Fatal("no User-Agent sent")
+	}
+	// The Nominatim policy rejects generic/default agents.
+	if strings.HasPrefix(ua, "Go-http-client") {
+		t.Errorf("User-Agent = %q, want an application-specific agent", ua)
+	}
+	if !strings.Contains(ua, "TennisTournamentFinder") {
+		t.Errorf("User-Agent = %q, want it to identify the application", ua)
+	}
+	// A contact/project URL lets upstream operators reach the maintainer.
+	if !strings.Contains(ua, "http") {
+		t.Errorf("User-Agent = %q, want it to include a contact URL", ua)
+	}
+}
+
+func TestGeocodingUserAgentIsConfigurable(t *testing.T) {
+	initTestCache(t)
+	t.Setenv("TTF_USER_AGENT", "MyFork/2.0 (+https://example.test/contact)")
+
+	mock := newMockGeocodingServer(t, respondWith(models.Geocoordinates{
+		Lat: "1", Lon: "2", DisplayName: "Hessen",
+	}))
+
+	GetGeocoordinatesFromCache("Hessen", models.Tournament{Id: "1", Location: "Frankfurt"})
+
+	if got := mock.lastUserAgent(); got != "MyFork/2.0 (+https://example.test/contact)" {
+		t.Errorf("User-Agent = %q, want the configured override", got)
+	}
+}
+
+func TestGeocodingRespectsRateLimit(t *testing.T) {
+	initTestCache(t)
+	// Restore the policy-compliant interval for this test.
+	t.Setenv("TTF_NOMINATIM_INTERVAL_MS", "120")
+	resetRateLimiterForTest()
+
+	mock := newMockGeocodingServer(t, respondWith(models.Geocoordinates{
+		Lat: "1", Lon: "2", DisplayName: "Bayern",
+	}))
+
+	const requests = 4
+	start := time.Now()
+	for i := 0; i < requests; i++ {
+		// Distinct locations so every call misses the cache.
+		GetGeocoordinatesFromCache("Bayern", models.Tournament{
+			Id: fmt.Sprint(i), Location: fmt.Sprintf("Stadt-%d", i),
+		})
+	}
+	elapsed := time.Since(start)
+
+	if got := mock.callCount(); got != requests {
+		t.Fatalf("made %d requests, want %d", got, requests)
+	}
+
+	// Three gaps between four requests.
+	minExpected := 3 * 120 * time.Millisecond
+	if elapsed < minExpected {
+		t.Errorf("elapsed %v, want at least %v (rate limit not enforced)", elapsed, minExpected)
+	}
+}
+
+func TestGeocodingCacheHitsSkipUpstreamAndRateLimit(t *testing.T) {
+	initTestCache(t)
+
+	mock := newMockGeocodingServer(t, respondWith(models.Geocoordinates{
+		Lat: "49.0069", Lon: "8.4037", DisplayName: "Karlsruhe, Baden-Württemberg",
+	}))
+
+	tournamentA := models.Tournament{Id: "1", Location: "Karlsruhe", Organizer: "TC Karlsruhe"}
+	// A different tournament at the same location must reuse the cached entry.
+	tournamentB := models.Tournament{Id: "2", Location: "Karlsruhe", Organizer: "TC Karlsruhe"}
+
+	for i := 0; i < 5; i++ {
+		GetGeocoordinatesFromCache("Baden-Württemberg", tournamentA)
+		GetGeocoordinatesFromCache("Baden-Württemberg", tournamentB)
+	}
+
+	if got := mock.callCount(); got != 1 {
+		t.Errorf("made %d upstream requests, want 1 (rest served from cache)", got)
+	}
+}
+
+// TestFailedLookupsUseTheSameCacheKeys is the regression test for the bug where
+// failures were stored under the tournament ID while lookups used
+// location/organizer keys, so the backoff never took effect.
+func TestFailedLookupsUseTheSameCacheKeys(t *testing.T) {
+	initTestCache(t)
+
+	// Always responds with a location in the wrong state -> no usable match.
+	mock := newMockGeocodingServer(t, respondWith(models.Geocoordinates{
+		Lat: "52.5", Lon: "13.4", DisplayName: "Berlin, Berlin, Deutschland",
+	}))
+
+	tournament := models.Tournament{Id: "1", Location: "Unbekanntstadt", Organizer: "TC Unbekannt"}
+
+	// First attempt performs the lookup and records the failure.
+	if got := GetGeocoordinatesFromCache("Baden-Württemberg", tournament); got.Lat != "" {
+		t.Errorf("expected no coordinates, got %+v", got)
+	}
+	if got := mock.callCount(); got != 1 {
+		t.Fatalf("made %d requests on first attempt, want 1", got)
+	}
+
+	// The failure must be visible under the location key.
+	locKey := generateLocationCacheKey(tournament.Location, "Baden-Württemberg")
+	cached, found := getFromCache(locKey)
+	if !found {
+		t.Fatalf("no cache entry stored under location key %q", locKey)
+	}
+	if !cached.IsFailed || cached.FailCount != 1 {
+		t.Errorf("cached entry = %+v, want IsFailed with FailCount 1", cached)
+	}
+
+	// Subsequent attempts must be suppressed by the backoff.
+	for i := 0; i < 3; i++ {
+		GetGeocoordinatesFromCache("Baden-Württemberg", tournament)
+	}
+	if got := mock.callCount(); got != 1 {
+		t.Errorf("made %d requests total, want 1 (backoff not honoured)", got)
+	}
+
+	// A different tournament at the same location must also be suppressed.
+	other := models.Tournament{Id: "999", Location: "Unbekanntstadt", Organizer: "TC Unbekannt"}
+	GetGeocoordinatesFromCache("Baden-Württemberg", other)
+	if got := mock.callCount(); got != 1 {
+		t.Errorf("made %d requests, want 1 (per-location backoff not shared)", got)
+	}
+}
+
+func TestFailureCountIncrementsAcrossRetries(t *testing.T) {
+	initTestCache(t)
+
+	mock := newMockGeocodingServer(t, respondWith(models.Geocoordinates{
+		Lat: "52.5", Lon: "13.4", DisplayName: "Berlin, Berlin, Deutschland",
+	}))
+
+	tournament := models.Tournament{Id: "1", Location: "Nirgendwo", Organizer: "TC Nirgendwo"}
+	locKey := generateLocationCacheKey(tournament.Location, "Baden-Württemberg")
+
+	for attempt := 1; attempt <= 3; attempt++ {
+		GetGeocoordinatesFromCache("Baden-Württemberg", tournament)
+
+		cached, found := getFromCache(locKey)
+		if !found {
+			t.Fatalf("attempt %d: no cache entry", attempt)
+		}
+		if cached.FailCount != attempt {
+			t.Errorf("attempt %d: FailCount = %d, want %d", attempt, cached.FailCount, attempt)
+		}
+
+		// Expire the backoff so the next attempt is allowed through.
+		cached.LastAttempt = time.Now().Add(-30 * 24 * time.Hour).Unix()
+		setInCache(locKey, cached)
+		if orgKey := generateOrganizerCacheKey(tournament.Organizer, "Baden-Württemberg"); orgKey != "" {
+			if orgCached, ok := getFromCache(orgKey); ok {
+				orgCached.LastAttempt = cached.LastAttempt
+				setInCache(orgKey, orgCached)
+			}
+		}
+	}
+
+	if got := mock.callCount(); got != 3 {
+		t.Errorf("made %d requests, want 3", got)
+	}
+}
+
+func TestSuccessAfterFailureClearsFailureState(t *testing.T) {
+	initTestCache(t)
+
+	var succeed atomic.Bool
+	mock := newMockGeocodingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if succeed.Load() {
+			_ = json.NewEncoder(w).Encode([]models.Geocoordinates{
+				{Lat: "49.0069", Lon: "8.4037", DisplayName: "Karlsruhe, Baden-Württemberg"},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]models.Geocoordinates{})
+	})
+
+	tournament := models.Tournament{Id: "1", Location: "Karlsruhe", Organizer: "TC Karlsruhe"}
+	locKey := generateLocationCacheKey(tournament.Location, "Baden-Württemberg")
+
+	// First attempt fails.
+	GetGeocoordinatesFromCache("Baden-Württemberg", tournament)
+	cached, _ := getFromCache(locKey)
+	if !cached.IsFailed {
+		t.Fatal("first attempt was not recorded as failed")
+	}
+
+	// Expire the backoff, then let the upstream succeed.
+	cached.LastAttempt = time.Now().Add(-30 * 24 * time.Hour).Unix()
+	setInCache(locKey, cached)
+	succeed.Store(true)
+
+	got := GetGeocoordinatesFromCache("Baden-Württemberg", tournament)
+	if got.Lat != "49.0069" {
+		t.Fatalf("retry returned %+v, want successful coordinates", got)
+	}
+
+	stored, found := getFromCache(locKey)
+	if !found {
+		t.Fatal("no cache entry after success")
+	}
+	if stored.IsFailed || stored.FailCount != 0 {
+		t.Errorf("stored entry = %+v, want failure state cleared", stored)
+	}
+
+	if got := mock.callCount(); got != 2 {
+		t.Errorf("made %d requests, want 2", got)
+	}
+}
+
+func TestGeocodingHandlesUpstreamErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			name: "http 500",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "boom", http.StatusInternalServerError)
+			},
+		},
+		{
+			name: "rate limited with retry-after",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Retry-After", "30")
+				http.Error(w, "slow down", http.StatusTooManyRequests)
+			},
+		},
+		{
+			name: "invalid json",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, "{not json")
+			},
+		},
+		{
+			name: "empty array",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, "[]")
+			},
+		},
+		{
+			name: "html error page",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html")
+				fmt.Fprint(w, "<html><body>error</body></html>")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initTestCache(t)
+			newMockGeocodingServer(t, tt.handler)
+
+			// Must not panic and must report "no coordinates".
+			got := GetGeocoordinatesFromCache("Baden-Württemberg", models.Tournament{
+				Id: "1", Location: "Karlsruhe", Organizer: "TC Karlsruhe",
+			})
+
+			if got.Lat != "" || got.Lon != "" {
+				t.Errorf("got %+v, want empty coordinates", got)
+			}
+
+			// The failure must be recorded so the backoff can take effect.
+			locKey := generateLocationCacheKey("Karlsruhe", "Baden-Württemberg")
+			if cached, found := getFromCache(locKey); !found || !cached.IsFailed {
+				t.Errorf("failure was not cached (found=%v, entry=%+v)", found, cached)
+			}
+		})
+	}
+}
+
+func TestGeocodingRejectsWrongState(t *testing.T) {
+	initTestCache(t)
+
+	// Returns three candidates; only the last is in the requested state.
+	newMockGeocodingServer(t, respondWith(
+		models.Geocoordinates{Lat: "52.5", Lon: "13.4", DisplayName: "Berlin, Berlin, Deutschland"},
+		models.Geocoordinates{Lat: "48.1", Lon: "11.5", DisplayName: "München, Bayern, Deutschland"},
+		models.Geocoordinates{Lat: "49.0", Lon: "8.4", DisplayName: "Karlsruhe, Baden-Württemberg, Deutschland"},
+	))
+
+	got := GetGeocoordinatesFromCache("Baden-Württemberg", models.Tournament{
+		Id: "1", Location: "Karlsruhe",
+	})
+
+	if got.Lat != "49.0" {
+		t.Errorf("got %+v, want the Baden-Württemberg candidate", got)
+	}
+}
+
+func TestGeocodingSkipsRequestWithoutQuery(t *testing.T) {
+	initTestCache(t)
+
+	mock := newMockGeocodingServer(t, respondWith())
+
+	// Neither a location nor an organizer: nothing sensible to ask for.
+	got := GetGeocoordinatesFromCache("Hessen", models.Tournament{Id: "1"})
+
+	if got.Lat != "" {
+		t.Errorf("got %+v, want empty", got)
+	}
+	if calls := mock.callCount(); calls != 0 {
+		t.Errorf("made %d upstream requests, want 0", calls)
+	}
+}
+
+func TestGeocodingFallsBackToOrganizerQuery(t *testing.T) {
+	initTestCache(t)
+
+	mock := newMockGeocodingServer(t, respondWith(models.Geocoordinates{
+		Lat: "49.0", Lon: "8.4", DisplayName: "Karlsruhe, Baden-Württemberg",
+	}))
+
+	// No location, so the city is derived from the organizer name.
+	GetGeocoordinatesFromCache("Baden-Württemberg", models.Tournament{
+		Id: "1", Organizer: "TC Rot-Weiß Karlsruhe e.V.",
+	})
+
+	queries := mock.recordedQueries()
+	if len(queries) != 1 {
+		t.Fatalf("recorded %d queries, want 1", len(queries))
+	}
+	if !strings.Contains(queries[0], "Karlsruhe") {
+		t.Errorf("query = %q, want it to contain the extracted city", queries[0])
+	}
+}
+
+func TestConcurrentGeocodingIsRaceFree(t *testing.T) {
+	initTestCache(t)
+
+	newMockGeocodingServer(t, respondWith(models.Geocoordinates{
+		Lat: "49.0", Lon: "8.4", DisplayName: "Karlsruhe, Baden-Württemberg",
+	}))
+
+	// Hammer the cache from many goroutines, mixing reads, writes and stats.
+	var wg sync.WaitGroup
+	for i := 0; i < 24; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 8; j++ {
+				GetGeocoordinatesFromCache("Baden-Württemberg", models.Tournament{
+					Id:        fmt.Sprintf("%d-%d", i, j),
+					Location:  fmt.Sprintf("Ort-%d", (i+j)%5),
+					Organizer: fmt.Sprintf("TC %d", i%3),
+				})
+				GetCacheStatistics()
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	stats := GetCacheStatistics()
+	if stats["total_entries"] == 0 {
+		t.Error("expected cache entries after concurrent geocoding")
+	}
+}
+
+func TestBuildNominatimURL(t *testing.T) {
+	t.Setenv("TTF_NOMINATIM_URL", "https://nominatim.example.test/search.php")
+
+	raw, err := buildNominatimURL("Bad Homburg vor der Höhe")
+	if err != nil {
+		t.Fatalf("buildNominatimURL() error = %v", err)
+	}
+
+	if !strings.HasPrefix(raw, "https://nominatim.example.test/search.php?") {
+		t.Errorf("URL = %q, want the configured base", raw)
+	}
+	// Spaces and umlauts must be percent-encoded, not naively replaced.
+	for _, want := range []string{"format=jsonv2", "limit=3", "accept-language=de", "q=Bad+Homburg+vor+der+H%C3%B6he"} {
+		if !strings.Contains(raw, want) {
+			t.Errorf("URL %q does not contain %q", raw, want)
+		}
+	}
+
+	t.Setenv("TTF_NOMINATIM_URL", "://broken")
+	if _, err := buildNominatimURL("x"); err == nil {
+		t.Error("expected an error for an invalid base URL")
+	}
+}
+
+func TestShouldRetryGeocodingRequestBackoff(t *testing.T) {
+	now := time.Now().Unix()
+
+	tests := []struct {
+		name      string
+		failCount int
+		age       time.Duration
+		want      bool
+	}{
+		{"first failure too recent", 1, time.Hour, false},
+		{"first failure after a day", 1, 25 * time.Hour, true},
+		{"second failure too recent", 2, 2 * 24 * time.Hour, false},
+		{"second failure after three days", 2, 4 * 24 * time.Hour, true},
+		{"third failure too recent", 3, 5 * 24 * time.Hour, false},
+		{"third failure after a week", 3, 8 * 24 * time.Hour, true},
+		{"fourth failure too recent", 4, 10 * 24 * time.Hour, false},
+		{"fourth failure after two weeks", 4, 15 * 24 * time.Hour, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			geo := models.Geocoordinates{
+				IsFailed:    true,
+				FailCount:   tt.failCount,
+				LastAttempt: now - int64(tt.age.Seconds()),
+			}
+			if got := shouldRetryGeocodingRequest(geo); got != tt.want {
+				t.Errorf("shouldRetryGeocodingRequest(fail=%d, age=%v) = %v, want %v",
+					tt.failCount, tt.age, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/pkg/ratelimit/ratelimit.go
+++ b/backend/pkg/ratelimit/ratelimit.go
@@ -1,0 +1,79 @@
+package ratelimit
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Limiter enforces a minimum interval between successive operations across all
+// goroutines. It is used to honour the Nominatim usage policy, which permits at
+// most one request per second for the public endpoint.
+type Limiter struct {
+	mu       sync.Mutex
+	interval time.Duration
+	last     time.Time
+
+	// now and sleep are injectable for deterministic tests.
+	now   func() time.Time
+	sleep func(context.Context, time.Duration) error
+}
+
+// New creates a Limiter allowing one operation per interval.
+// A non-positive interval disables rate limiting.
+func New(interval time.Duration) *Limiter {
+	return &Limiter{
+		interval: interval,
+		now:      time.Now,
+		sleep:    sleepContext,
+	}
+}
+
+// Wait blocks until the caller may proceed or ctx is done.
+//
+// The reservation is made while holding the lock, so concurrent callers are
+// spaced out by interval instead of all waking up at the same time.
+func (l *Limiter) Wait(ctx context.Context) error {
+	if l == nil || l.interval <= 0 {
+		return ctx.Err()
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	l.mu.Lock()
+	now := l.now()
+	var wait time.Duration
+	if l.last.IsZero() {
+		// First call may proceed immediately.
+		l.last = now
+	} else {
+		next := l.last.Add(l.interval)
+		if next.After(now) {
+			wait = next.Sub(now)
+			l.last = next
+		} else {
+			l.last = now
+		}
+	}
+	l.mu.Unlock()
+
+	if wait <= 0 {
+		return nil
+	}
+
+	return l.sleep(ctx, wait)
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/backend/pkg/ratelimit/ratelimit_test.go
+++ b/backend/pkg/ratelimit/ratelimit_test.go
@@ -1,0 +1,176 @@
+package ratelimit
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClock lets the limiter be tested deterministically without real sleeping.
+type fakeClock struct {
+	mu    sync.Mutex
+	now   time.Time
+	slept []time.Duration
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Unix(1700000000, 0)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) Sleep(ctx context.Context, d time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.slept = append(c.slept, d)
+	c.now = c.now.Add(d)
+	return nil
+}
+
+func (c *fakeClock) sleeps() []time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]time.Duration, len(c.slept))
+	copy(out, c.slept)
+	return out
+}
+
+func newTestLimiter(interval time.Duration) (*Limiter, *fakeClock) {
+	clock := newFakeClock()
+	l := New(interval)
+	l.now = clock.Now
+	l.sleep = clock.Sleep
+	return l, clock
+}
+
+func TestFirstCallDoesNotWait(t *testing.T) {
+	l, clock := newTestLimiter(time.Second)
+
+	if err := l.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+
+	if got := clock.sleeps(); len(got) != 0 {
+		t.Errorf("first call slept %v, want no sleep", got)
+	}
+}
+
+func TestSuccessiveCallsAreSpacedByInterval(t *testing.T) {
+	l, clock := newTestLimiter(time.Second)
+	ctx := context.Background()
+
+	for i := 0; i < 4; i++ {
+		if err := l.Wait(ctx); err != nil {
+			t.Fatalf("Wait() error = %v", err)
+		}
+	}
+
+	got := clock.sleeps()
+	if len(got) != 3 {
+		t.Fatalf("got %d sleeps (%v), want 3", len(got), got)
+	}
+	for i, d := range got {
+		if d != time.Second {
+			t.Errorf("sleep %d = %v, want 1s", i, d)
+		}
+	}
+}
+
+func TestNoWaitWhenIntervalAlreadyElapsed(t *testing.T) {
+	l, clock := newTestLimiter(time.Second)
+	ctx := context.Background()
+
+	if err := l.Wait(ctx); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+
+	// Simulate time passing between requests (e.g. slow upstream response).
+	clock.mu.Lock()
+	clock.now = clock.now.Add(5 * time.Second)
+	clock.mu.Unlock()
+
+	if err := l.Wait(ctx); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+
+	if got := clock.sleeps(); len(got) != 0 {
+		t.Errorf("slept %v, want no sleep after interval elapsed", got)
+	}
+}
+
+func TestZeroIntervalDisablesLimiting(t *testing.T) {
+	l, clock := newTestLimiter(0)
+	ctx := context.Background()
+
+	for i := 0; i < 10; i++ {
+		if err := l.Wait(ctx); err != nil {
+			t.Fatalf("Wait() error = %v", err)
+		}
+	}
+
+	if got := clock.sleeps(); len(got) != 0 {
+		t.Errorf("slept %v, want no sleep when disabled", got)
+	}
+}
+
+func TestWaitRespectsCancelledContext(t *testing.T) {
+	l, _ := newTestLimiter(time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := l.Wait(ctx); err == nil {
+		t.Fatal("Wait() with cancelled context returned nil, want error")
+	}
+}
+
+func TestWaitUnblocksWhenContextIsCancelledDuringSleep(t *testing.T) {
+	// Uses the real clock to verify the select in sleepContext.
+	l := New(time.Hour)
+
+	if err := l.Wait(context.Background()); err != nil {
+		t.Fatalf("first Wait() error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := l.Wait(ctx)
+	if err == nil {
+		t.Fatal("Wait() returned nil, want context deadline error")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("Wait() blocked for %v, want prompt cancellation", elapsed)
+	}
+}
+
+func TestConcurrentCallersAreSerialized(t *testing.T) {
+	const callers = 5
+	l, clock := newTestLimiter(time.Second)
+
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			if err := l.Wait(context.Background()); err != nil {
+				t.Errorf("Wait() error = %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// One caller proceeds immediately, the rest each reserve a distinct slot.
+	if got := len(clock.sleeps()); got != callers-1 {
+		t.Errorf("got %d sleeps, want %d", got, callers-1)
+	}
+}

--- a/backend/pkg/scheduler/scheduler.go
+++ b/backend/pkg/scheduler/scheduler.go
@@ -65,9 +65,9 @@ func (s *Scheduler) Stop() {
 func (s *Scheduler) Reload() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	
+
 	newConfig := FromEnv()
-	
+
 	// If configuration hasn't changed, no need to restart
 	if s.config.CronSpec == newConfig.CronSpec &&
 		s.config.CompType == newConfig.CompType &&
@@ -76,15 +76,15 @@ func (s *Scheduler) Reload() error {
 		logger.Info("Scheduler configuration unchanged, no restart needed")
 		return nil
 	}
-	
+
 	// Keep backup of old cron and config in case reload fails
 	oldCron := s.c
 	oldConfig := s.config
-	
+
 	// Stop current scheduler
 	oldCron.Stop()
 	logger.Info("Stopped scheduler for configuration reload")
-	
+
 	// Create new cron scheduler with updated config only if enabled
 	if newConfig.Enabled {
 		newCron := cron.New()
@@ -104,7 +104,7 @@ func (s *Scheduler) Reload() error {
 		newCron.Start()
 		logger.Info("Scheduler restarted with new configuration (cron=%s, compType=%s, federations=%s)",
 			newConfig.CronSpec, newConfig.CompType, newConfig.Federations)
-		
+
 		// Update to new configuration
 		s.c = newCron
 		s.config = newConfig
@@ -114,7 +114,7 @@ func (s *Scheduler) Reload() error {
 		s.config = newConfig
 		logger.Info("Scheduler disabled via configuration reload")
 	}
-	
+
 	return nil
 }
 

--- a/backend/pkg/tournament/e2e_test.go
+++ b/backend/pkg/tournament/e2e_test.go
@@ -1,0 +1,596 @@
+package tournament_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/openstreetmap"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/tournament"
+)
+
+// TestMain wires the package's external dependencies to local mocks so the
+// end-to-end tests never touch the real federation sites or Nominatim.
+func TestMain(m *testing.M) {
+	// Speed up the geocoding limiter; the policy interval is asserted
+	// separately in the openstreetmap package tests.
+	os.Setenv("TTF_NOMINATIM_INTERVAL_MS", "0")
+
+	// Keep test output readable; assertions never depend on log lines.
+	if os.Getenv("TTF_LOG_LEVEL") == "" {
+		os.Setenv("TTF_LOG_LEVEL", "ERROR")
+		logger.SetLogLevel(logger.ErrorLevel)
+	}
+
+	os.Exit(m.Run())
+}
+
+// initIsolatedCache points the geocoding cache at a throwaway BoltDB file.
+func initIsolatedCache(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("TTF_CACHE_PATH", t.TempDir()+"/cache.bolt")
+	openstreetmap.InitCache()
+	t.Cleanup(openstreetmap.CloseCache)
+}
+
+// mockNominatim serves a canned geocoding response and counts requests.
+func mockNominatim(t *testing.T, displayName, lat, lon string) (*httptest.Server, *int64) {
+	t.Helper()
+
+	var calls int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&calls, 1)
+
+		// The Nominatim usage policy requires an identifying User-Agent.
+		if ua := r.Header.Get("User-Agent"); ua == "" || strings.HasPrefix(ua, "Go-http-client") {
+			t.Errorf("geocoding request sent unacceptable User-Agent %q", ua)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]models.Geocoordinates{
+			{Lat: lat, Lon: lon, DisplayName: displayName},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("TTF_NOMINATIM_URL", srv.URL)
+
+	return srv, &calls
+}
+
+const oldAPIResponse = `<html><body>
+<table class="result-set">
+  <tr><th>Datum</th><th>Turnier</th><th>Konkurrenz</th><th>LK</th></tr>
+  <tr>
+    <td rowspan="2">01.08.2026 - 03.08.2026</td>
+    <td rowspan="2">
+      <a href="https://www.tennis.de/spielen/turniersuche.html#detail/700001">Sommer Open</a>
+      TC Karlsruhe
+    </td>
+    <td>Herren Einzel</td>
+    <td>LK 12,0</td>
+  </tr>
+  <tr><td>Damen Einzel</td><td>LK 14,0</td></tr>
+</table>
+</body></html>`
+
+// newAPIPage renders a page of the new API containing count tournaments,
+// numbered from startID.
+func newAPIPage(startID, count int) string {
+	var sb strings.Builder
+	sb.WriteString(`<html><body><table class="responsive-individual"><tbody>`)
+	for i := 0; i < count; i++ {
+		id := startID + i
+		fmt.Fprintf(&sb, `
+    <tr>
+      <td class="daterange">0%d.09.2026</td>
+      <td>
+        <h2><a href="https://www.tennis.de/spielen/turniersuche.html#detail/%d">Turnier %d</a></h2>
+        <p>Veranstalter: TC %d Austragungsort: Stuttgart Meldeschluss: 01.09.2026</p>
+      </td>
+      <td class="competitionAbbr">
+        <table><tbody>
+          <tr><td class="name"><span>Herren Einzel</span></td><td class="fedRank">LK 10,0</td><td class="result"></td></tr>
+        </tbody></table>
+      </td>
+    </tr>`, (i%9)+1, id, id, id)
+	}
+	sb.WriteString(`</tbody></table></body></html>`)
+	return sb.String()
+}
+
+// firstResultParam extracts the pagination offset from a request.
+func firstResultParam(t *testing.T, r *http.Request) int {
+	t.Helper()
+
+	for key, values := range r.URL.Query() {
+		if strings.Contains(key, "[firstResult]") && len(values) > 0 {
+			n, err := strconv.Atoi(values[0])
+			if err != nil {
+				t.Fatalf("invalid firstResult %q: %v", values[0], err)
+			}
+			return n
+		}
+	}
+
+	t.Fatalf("request %s has no firstResult parameter", r.URL.RawQuery)
+	return 0
+}
+
+func TestEndToEndOldApiFederation(t *testing.T) {
+	initIsolatedCache(t)
+	_, geoCalls := mockNominatim(t, "Karlsruhe, Baden-Württemberg, Deutschland", "49.0069", "8.4037")
+
+	var gotMethod, gotContentType, gotBody string
+	fedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		buf := make([]byte, 2048)
+		n, _ := r.Body.Read(buf)
+		gotBody = string(buf[:n])
+
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, oldAPIResponse)
+	}))
+	defer fedSrv.Close()
+
+	fed := models.Federation{
+		Id:             "BAD",
+		Url:            fedSrv.URL,
+		Name:           "Badischer Tennisverband",
+		State:          "Baden-Württemberg",
+		ApiVersion:     "old",
+		Geocoordinates: models.Geocoordinates{Lat: "49.0", Lon: "8.4"},
+	}
+
+	tournaments, results := tournament.CollectTournaments(
+		context.Background(), []models.Federation{fed}, "01.08.2026", "15.08.2026", "Herren+Einzel")
+
+	if len(results) != 1 || results[0].Err != nil {
+		t.Fatalf("federation result error: %+v", results)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotContentType != "application/x-www-form-urlencoded" {
+		t.Errorf("content type = %q", gotContentType)
+	}
+	for _, want := range []string{"queryDateFrom=01.08.2026", "federation=BAD", "compType=Herren%2BEinzel"} {
+		if !strings.Contains(gotBody, want) {
+			t.Errorf("request body %q missing %q", gotBody, want)
+		}
+	}
+
+	if len(tournaments) != 1 {
+		t.Fatalf("got %d tournaments, want 1", len(tournaments))
+	}
+
+	got := tournaments[0]
+	if got.Id != "700001" || got.Title != "Sommer Open" {
+		t.Errorf("tournament = %+v", got)
+	}
+	if got.Organizer != "TC Karlsruhe" {
+		t.Errorf("organizer = %q, want %q", got.Organizer, "TC Karlsruhe")
+	}
+	// Coordinates must come from the mocked geocoder, not the federation default.
+	if got.Lat != "49.0069" || got.Lon != "8.4037" {
+		t.Errorf("coordinates = (%q,%q), want mocked geocoding result", got.Lat, got.Lon)
+	}
+	if len(got.Entries) != 2 {
+		t.Errorf("entries = %d, want 2", len(got.Entries))
+	}
+	if atomic.LoadInt64(geoCalls) == 0 {
+		t.Error("expected at least one geocoding request")
+	}
+}
+
+func TestEndToEndNewApiPaginatesBeyondPageSize(t *testing.T) {
+	initIsolatedCache(t)
+	mockNominatim(t, "Stuttgart, Baden-Württemberg, Deutschland", "48.7758", "9.1829")
+
+	// 250 tournaments across three pages (100 + 100 + 50).
+	const total = 250
+
+	var mu sync.Mutex
+	var offsets []int
+
+	fedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		offset := firstResultParam(t, r)
+
+		mu.Lock()
+		offsets = append(offsets, offset)
+		mu.Unlock()
+
+		remaining := total - offset
+		if remaining < 0 {
+			remaining = 0
+		}
+		count := remaining
+		if count > 100 {
+			count = 100
+		}
+
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, newAPIPage(1000+offset, count))
+	}))
+	defer fedSrv.Close()
+
+	fed := models.Federation{
+		Id:             "WTB",
+		Url:            fedSrv.URL,
+		State:          "Baden-Württemberg",
+		ApiVersion:     "new",
+		Geocoordinates: models.Geocoordinates{Lat: "48.85", Lon: "9.13"},
+	}
+
+	tournaments, results := tournament.CollectTournaments(
+		context.Background(), []models.Federation{fed}, "01.09.2026", "30.09.2026", "")
+
+	if results[0].Err != nil {
+		t.Fatalf("federation error: %v", results[0].Err)
+	}
+
+	// Regression for the truncation bug: all pages must be fetched.
+	if len(tournaments) != total {
+		t.Errorf("got %d tournaments, want %d", len(tournaments), total)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	wantOffsets := []int{0, 100, 200}
+	if len(offsets) != len(wantOffsets) {
+		t.Fatalf("requested offsets = %v, want %v", offsets, wantOffsets)
+	}
+	for i, want := range wantOffsets {
+		if offsets[i] != want {
+			t.Errorf("offset %d = %d, want %d", i, offsets[i], want)
+		}
+	}
+
+	// IDs must be unique.
+	seen := make(map[string]bool)
+	for _, tr := range tournaments {
+		if seen[tr.Id] {
+			t.Errorf("duplicate tournament id %q", tr.Id)
+		}
+		seen[tr.Id] = true
+	}
+}
+
+func TestEndToEndNewApiStopsOnExactPageBoundary(t *testing.T) {
+	initIsolatedCache(t)
+	mockNominatim(t, "Stuttgart, Baden-Württemberg, Deutschland", "48.7758", "9.1829")
+
+	// Exactly one full page: a second (empty) request is expected, then stop.
+	var requests int64
+	fedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&requests, 1)
+		offset := firstResultParam(t, r)
+
+		count := 0
+		if offset == 0 {
+			count = 100
+		}
+		fmt.Fprint(w, newAPIPage(2000+offset, count))
+	}))
+	defer fedSrv.Close()
+
+	fed := models.Federation{
+		Id: "WTB", Url: fedSrv.URL, State: "Baden-Württemberg", ApiVersion: "new",
+		Geocoordinates: models.Geocoordinates{Lat: "48.85", Lon: "9.13"},
+	}
+
+	tournaments, _ := tournament.CollectTournaments(
+		context.Background(), []models.Federation{fed}, "01.09.2026", "30.09.2026", "")
+
+	if len(tournaments) != 100 {
+		t.Errorf("got %d tournaments, want 100", len(tournaments))
+	}
+	if got := atomic.LoadInt64(&requests); got != 2 {
+		t.Errorf("made %d requests, want 2", got)
+	}
+}
+
+func TestEndToEndNewApiTerminatesWhenUpstreamIgnoresOffset(t *testing.T) {
+	initIsolatedCache(t)
+	mockNominatim(t, "Stuttgart, Baden-Württemberg, Deutschland", "48.7758", "9.1829")
+
+	// A broken upstream that always returns the same full page would loop
+	// forever without the "no new results" guard.
+	var requests int64
+	fedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&requests, 1)
+		fmt.Fprint(w, newAPIPage(3000, 100))
+	}))
+	defer fedSrv.Close()
+
+	fed := models.Federation{
+		Id: "WTB", Url: fedSrv.URL, State: "Baden-Württemberg", ApiVersion: "new",
+		Geocoordinates: models.Geocoordinates{Lat: "48.85", Lon: "9.13"},
+	}
+
+	done := make(chan struct{})
+	var tournaments []models.Tournament
+	go func() {
+		tournaments, _ = tournament.CollectTournaments(
+			context.Background(), []models.Federation{fed}, "01.09.2026", "30.09.2026", "")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("pagination did not terminate for a repeating upstream")
+	}
+
+	if len(tournaments) != 100 {
+		t.Errorf("got %d tournaments, want 100 unique", len(tournaments))
+	}
+	if got := atomic.LoadInt64(&requests); got > 3 {
+		t.Errorf("made %d requests, want to stop quickly on repeated data", got)
+	}
+}
+
+func TestEndToEndPartialFailureKeepsHealthyFederations(t *testing.T) {
+	initIsolatedCache(t)
+	mockNominatim(t, "Karlsruhe, Baden-Württemberg, Deutschland", "49.0069", "8.4037")
+
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, oldAPIResponse)
+	}))
+	defer healthy.Close()
+
+	broken := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream exploded", http.StatusInternalServerError)
+	}))
+	defer broken.Close()
+
+	feds := []models.Federation{
+		{Id: "BROKEN", Url: broken.URL, State: "Hessen", ApiVersion: "old",
+			Geocoordinates: models.Geocoordinates{Lat: "50.1", Lon: "8.6"}},
+		{Id: "BAD", Url: healthy.URL, State: "Baden-Württemberg", ApiVersion: "old",
+			Geocoordinates: models.Geocoordinates{Lat: "49.0", Lon: "8.4"}},
+		{Id: "UNKNOWN_API", Url: healthy.URL, State: "Bayern", ApiVersion: "bogus",
+			Geocoordinates: models.Geocoordinates{Lat: "48.1", Lon: "11.5"}},
+	}
+
+	tournaments, results := tournament.CollectTournaments(
+		context.Background(), feds, "01.08.2026", "15.08.2026", "")
+
+	// The healthy federation's data must survive its neighbours' failures.
+	if len(tournaments) != 1 {
+		t.Fatalf("got %d tournaments, want 1 from the healthy federation", len(tournaments))
+	}
+	if tournaments[0].Id != "700001" {
+		t.Errorf("tournament id = %q", tournaments[0].Id)
+	}
+
+	if results[0].Err == nil {
+		t.Error("broken federation reported no error")
+	}
+	if results[1].Err != nil {
+		t.Errorf("healthy federation reported error: %v", results[1].Err)
+	}
+	if results[2].Err == nil {
+		t.Error("unknown API version reported no error")
+	}
+}
+
+func TestEndToEndResultOrderIsDeterministic(t *testing.T) {
+	initIsolatedCache(t)
+	mockNominatim(t, "Stuttgart, Baden-Württemberg, Deutschland", "48.7758", "9.1829")
+
+	// Each federation replies with a distinct tournament; the slowest one is
+	// listed first to prove ordering follows the input, not completion order.
+	makeServer := func(id int, delay time.Duration) *httptest.Server {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(delay)
+			fmt.Fprint(w, newAPIPage(id, 1))
+		}))
+		t.Cleanup(srv.Close)
+		return srv
+	}
+
+	slow := makeServer(5001, 150*time.Millisecond)
+	fast := makeServer(5002, 0)
+	medium := makeServer(5003, 60*time.Millisecond)
+
+	feds := []models.Federation{
+		{Id: "SLOW", Url: slow.URL, State: "Baden-Württemberg", ApiVersion: "new"},
+		{Id: "FAST", Url: fast.URL, State: "Baden-Württemberg", ApiVersion: "new"},
+		{Id: "MEDIUM", Url: medium.URL, State: "Baden-Württemberg", ApiVersion: "new"},
+	}
+
+	// Repeat to make scheduling-dependent ordering bugs visible.
+	for i := 0; i < 3; i++ {
+		tournaments, _ := tournament.CollectTournaments(
+			context.Background(), feds, "01.09.2026", "30.09.2026", "")
+
+		if len(tournaments) != 3 {
+			t.Fatalf("run %d: got %d tournaments, want 3", i, len(tournaments))
+		}
+
+		want := []string{"5001", "5002", "5003"}
+		for j, id := range want {
+			if tournaments[j].Id != id {
+				t.Errorf("run %d: tournament %d = %q, want %q (input order)", i, j, tournaments[j].Id, id)
+			}
+		}
+	}
+}
+
+func TestEndToEndConcurrentFederationsAreRaceFree(t *testing.T) {
+	initIsolatedCache(t)
+	mockNominatim(t, "Stuttgart, Baden-Württemberg, Deutschland", "48.7758", "9.1829")
+
+	// Many federations returning many tournaments each maximises the chance of
+	// the race detector observing unsynchronized access.
+	const fedCount = 12
+	const perFed = 25
+
+	var feds []models.Federation
+	for i := 0; i < fedCount; i++ {
+		start := 10000 + i*1000
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, newAPIPage(start, perFed))
+		}))
+		t.Cleanup(srv.Close)
+
+		feds = append(feds, models.Federation{
+			Id:             fmt.Sprintf("FED%02d", i),
+			Url:            srv.URL,
+			State:          "Baden-Württemberg",
+			ApiVersion:     "new",
+			Geocoordinates: models.Geocoordinates{Lat: "48.85", Lon: "9.13"},
+		})
+	}
+
+	tournaments, results := tournament.CollectTournaments(
+		context.Background(), feds, "01.09.2026", "30.09.2026", "")
+
+	for _, res := range results {
+		if res.Err != nil {
+			t.Errorf("federation %s error: %v", res.Federation.Id, res.Err)
+		}
+	}
+
+	// Regression for the lost-update race: every tournament must be present.
+	if want := fedCount * perFed; len(tournaments) != want {
+		t.Errorf("got %d tournaments, want %d", len(tournaments), want)
+	}
+}
+
+func TestEndToEndHandlerServesJSON(t *testing.T) {
+	initIsolatedCache(t)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/?dateFrom=01.08.2026&dateTo=02.08.2026&federations=DOES_NOT_EXIST", nil)
+	rec := httptest.NewRecorder()
+
+	tournament.GetTournaments(rec, req)
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", res.StatusCode)
+	}
+	if got := res.Header.Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("CORS header = %q, want *", got)
+	}
+	if ct := res.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Errorf("content type = %q, want JSON", ct)
+	}
+
+	// An unknown federation filter must yield an empty JSON array, never null.
+	var decoded []models.Tournament
+	if err := json.NewDecoder(res.Body).Decode(&decoded); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if len(decoded) != 0 {
+		t.Errorf("got %d tournaments, want 0", len(decoded))
+	}
+}
+
+func TestEndToEndSlowUpstreamIsBoundedByContext(t *testing.T) {
+	initIsolatedCache(t)
+
+	release := make(chan struct{})
+	stalled := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	defer stalled.Close()
+	defer close(release)
+
+	fed := models.Federation{
+		Id: "STALLED", Url: stalled.URL, State: "Hessen", ApiVersion: "old",
+		Geocoordinates: models.Geocoordinates{Lat: "50.1", Lon: "8.6"},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	var results []tournament.FederationResult
+	go func() {
+		_, results = tournament.CollectTournaments(ctx, []models.Federation{fed}, "", "", "")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("request was not bounded by the context deadline")
+	}
+
+	if results[0].Err == nil {
+		t.Error("stalled upstream reported no error")
+	}
+}
+
+func TestEndToEndGeocodingResultsAreCached(t *testing.T) {
+	initIsolatedCache(t)
+	_, geoCalls := mockNominatim(t, "Karlsruhe, Baden-Württemberg, Deutschland", "49.0069", "8.4037")
+
+	fedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, oldAPIResponse)
+	}))
+	defer fedSrv.Close()
+
+	fed := models.Federation{
+		Id: "BAD", Url: fedSrv.URL, State: "Baden-Württemberg", ApiVersion: "old",
+		Geocoordinates: models.Geocoordinates{Lat: "49.0", Lon: "8.4"},
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, results := tournament.CollectTournaments(
+			context.Background(), []models.Federation{fed}, "01.08.2026", "15.08.2026", ""); results[0].Err != nil {
+			t.Fatalf("run %d error: %v", i, results[0].Err)
+		}
+	}
+
+	// The same organizer/location must only be geocoded once; cache hits must
+	// not consume upstream rate-limit capacity.
+	if got := atomic.LoadInt64(geoCalls); got != 1 {
+		t.Errorf("made %d geocoding requests across 3 runs, want 1", got)
+	}
+}
+
+func TestEndToEndWarmupPopulatesCache(t *testing.T) {
+	initIsolatedCache(t)
+
+	// Warmup uses the real federation list, so restrict it to an ID that does
+	// not exist. This verifies the plumbing without hitting the network.
+	if got := tournament.Warmup("01.08.2026", "02.08.2026", "", "DOES_NOT_EXIST"); got != 0 {
+		t.Errorf("Warmup() = %d, want 0 for an unknown federation", got)
+	}
+}
+
+// Ensure the mocked federation URL is a valid absolute URL, guarding against
+// accidental use of a relative path in the fixtures above.
+func TestMockServersUseAbsoluteURLs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil || !u.IsAbs() {
+		t.Fatalf("httptest server URL %q is not absolute: %v", srv.URL, err)
+	}
+}

--- a/backend/pkg/tournament/testdata/new_api_rlp.html
+++ b/backend/pkg/tournament/testdata/new_api_rlp.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<!--
+  Fixture: new API, RLP flavour.
+
+  Differs from the WTB fixture in two ways that the parser must tolerate:
+    - the title link lives in an <h3> instead of an <h2>
+    - the "Austragungsort:" value is terminated by "Offen für" instead of
+      "Meldeschluss"
+
+  Also covers a tournament whose location is missing entirely, which must fall
+  back to the federation's default coordinates.
+-->
+<html lang="de">
+<head><meta charset="utf-8"><title>Turnierkalender</title></head>
+<body>
+<table class="responsive-individual">
+  <tbody>
+    <tr>
+      <td class="daterange">05.10.2026 - 07.10.2026</td>
+      <td>
+        <h3><a href="https://www.tennis.de/spielen/turniersuche.html#detail/900001">Mainz Cup</a></h3>
+        <p>
+          Veranstalter: TC Mainz Austragungsort: Mainz Offen für: Alle
+        </p>
+      </td>
+      <td class="competitionAbbr">
+        <table>
+          <tbody>
+            <tr>
+              <td class="name"><span>Herren Einzel</span></td>
+              <td class="fedRank">LK 9,0</td>
+              <td class="result"></td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+
+    <tr>
+      <td class="daterange">20.10.2026</td>
+      <td>
+        <h3><a href="https://www.tennis.de/spielen/turniersuche.html#detail/900002">Turnier ohne Ort</a></h3>
+        <p>
+          Veranstalter: TC Ohne Ort Offen für: Alle
+        </p>
+      </td>
+      <td class="competitionAbbr">
+        <table>
+          <tbody>
+            <tr>
+              <td class="name"><span>Damen Doppel</span></td>
+              <td class="fedRank">LK 16,0</td>
+              <td class="result"></td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/backend/pkg/tournament/testdata/new_api_wtb.html
+++ b/backend/pkg/tournament/testdata/new_api_wtb.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<!--
+  Fixture: new (TYPO3 / nuPortal) tournament calendar response, WTB flavour.
+
+  Covers:
+    - the ".responsive-individual tbody tr" row structure
+    - td.daterange for the tournament date
+    - an <h2> title link (WTB); see new_api_rlp.html for the <h3> variant
+    - "Veranstalter:" / "Austragungsort:" parsing terminated by "Meldeschluss"
+    - a nested competition table in td.competitionAbbr
+    - a continuation row that adds competitions to an existing tournament
+    - an empty row that must be skipped
+-->
+<html lang="de">
+<head><meta charset="utf-8"><title>Turnierkalender</title></head>
+<body>
+<table class="responsive-individual">
+  <tbody>
+    <tr>
+      <td class="daterange">01.09.2026 - 03.09.2026</td>
+      <td>
+        <h2><a href="https://www.tennis.de/spielen/turniersuche.html#detail/800001">Stuttgart   Open</a></h2>
+        <p>
+          Veranstalter: TC Stuttgart Austragungsort: Stuttgart Meldeschluss: 20.08.2026
+        </p>
+      </td>
+      <td class="competitionAbbr">
+        <table>
+          <tbody>
+            <tr>
+              <td class="name"><span>Herren Einzel</span></td>
+              <td class="fedRank">LK 10,0</td>
+              <td class="result"></td>
+            </tr>
+            <tr>
+              <td class="name"><span>Damen Einzel</span></td>
+              <td class="fedRank">LK 11,5</td>
+              <td class="result"></td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+
+    <tr>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+
+    <tr>
+      <td class="daterange"></td>
+      <td>
+        <a href="https://www.tennis.de/spielen/turniersuche.html#detail/800001">Stuttgart Open</a>
+      </td>
+      <td class="competitionAbbr">
+        <table>
+          <tbody>
+            <tr>
+              <td class="name"><span>Herren Doppel</span></td>
+              <td class="fedRank">LK 13,0</td>
+              <td class="result"></td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+
+    <tr>
+      <td class="daterange">12.09.2026</td>
+      <td>
+        <h2><a href="https://www.tennis.de/spielen/turniersuche.html#detail/800002">Ulmer
+          Herbstturnier</a></h2>
+        <p>
+          Veranstalter: TC Ulm Austragungsort: Ulm Meldeschluss: 01.09.2026
+        </p>
+      </td>
+      <td class="competitionAbbr">
+        <table>
+          <tbody>
+            <tr>
+              <td class="name"><span>Senioren Einzel</span></td>
+              <td class="fedRank">LK 15,0</td>
+              <td class="result"></td>
+            </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/backend/pkg/tournament/testdata/old_api_basic.html
+++ b/backend/pkg/tournament/testdata/old_api_basic.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<!--
+  Fixture: old (liga.nu) tournament calendar response.
+
+  Sanitized and reduced by hand from a real federation response. It covers:
+    - the header row that must be skipped
+    - a tournament whose first row carries rowspan on the date/title cells
+    - continuation rows that add further competitions to the previous tournament
+    - a "&nbsp;" placeholder in the LK column
+    - an organizer separated from the tournament link by markup/whitespace
+    - a tournament without a parsable ID (link without "detail/")
+-->
+<html lang="de">
+<head><meta charset="utf-8"><title>Turnierkalender</title></head>
+<body>
+<table class="result-set">
+  <tr>
+    <th>Datum</th>
+    <th>Turnier</th>
+    <th>Konkurrenz</th>
+    <th>LK</th>
+  </tr>
+
+  <tr>
+    <td rowspan="3">01.08.2026 - 03.08.2026</td>
+    <td rowspan="3">
+      <a href="https://www.tennis.de/spielen/turniersuche.html#detail/700001">LK-Turnier Sommer Open</a>
+      <br/>
+      TC Rot-Weiß   Karlsruhe
+    </td>
+    <td>Herren Einzel</td>
+    <td>LK 12,0</td>
+  </tr>
+  <tr>
+    <td>Damen Einzel</td>
+    <td>LK 14,5</td>
+  </tr>
+  <tr>
+    <td>Herren Doppel</td>
+    <td>&nbsp;</td>
+  </tr>
+
+  <tr>
+    <td rowspan="1">10.08.2026</td>
+    <td rowspan="1">
+      <a href="https://www.tennis.de/spielen/turniersuche.html#detail/700002">Jugendturnier
+        Heidelberg</a>
+      TC Heidelberg
+    </td>
+    <td>Jugend Einzel</td>
+    <td>LK 20,0</td>
+  </tr>
+
+  <tr>
+    <td rowspan="1">15.08.2026</td>
+    <td rowspan="1">
+      <a href="https://example.invalid/turnier/ohne-id">Turnier ohne ID</a>
+      TC Ohne Kennung
+    </td>
+    <td>Senioren Einzel</td>
+    <td>LK 18,0</td>
+  </tr>
+</table>
+</body>
+</html>

--- a/backend/pkg/tournament/tournament.go
+++ b/backend/pkg/tournament/tournament.go
@@ -1,16 +1,20 @@
 package tournament
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/federation"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/httpclient"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/openstreetmap"
@@ -20,11 +24,36 @@ import (
 // Debug flag to control debug output - set to true to enable debug logs
 const debugEnabled = false
 
+const (
+	// pageSize is the number of results requested per page from the new API.
+	pageSize = 100
+	// maxPages bounds pagination so a malformed or endlessly repeating
+	// upstream response can never loop forever.
+	maxPages = 20
+	// maxResponseBytes bounds how much HTML is read from an upstream response.
+	maxResponseBytes = 16 << 20 // 16 MiB
+)
+
+// geocoder resolves tournament coordinates. The indirection lets tests supply a
+// deterministic implementation instead of performing network lookups.
+type geocoder func(state string, tournament models.Tournament) models.Geocoordinates
+
+// defaultGeocoder delegates to the OpenStreetMap cache/lookup.
+func defaultGeocoder(state string, tournament models.Tournament) models.Geocoordinates {
+	return openstreetmap.GetGeocoordinatesFromCache(state, tournament)
+}
+
+// FederationResult carries a single federation's outcome.
+type FederationResult struct {
+	Federation  models.Federation
+	Tournaments []models.Tournament
+	Err         error
+}
+
 func GetTournaments(w http.ResponseWriter, r *http.Request) {
 	federations := federation.GetFederations()
 
 	util.EnableCors(&w)
-	Tournaments := []models.Tournament{}
 
 	// Print cache statistics
 	cacheStats := openstreetmap.GetCacheStatistics()
@@ -52,125 +81,324 @@ func GetTournaments(w http.ResponseWriter, r *http.Request) {
 
 	logger.Info("Get Tournaments from: %s to: %s, compType: %s, federations: %s", dateFrom, dateTo, compType, selectedFederations)
 
-	// Filter federations based on selection
-	var filteredFederations []models.Federation
-	if selectedFederations != "" {
-		selectedFedIds := strings.Split(selectedFederations, ",")
-		for _, federation := range federations {
-			for _, selectedId := range selectedFedIds {
-				if federation.Id == strings.TrimSpace(selectedId) {
-					filteredFederations = append(filteredFederations, federation)
-					break
-				}
-			}
-		}
-	} else {
-		// If no specific federations selected, use all
-		filteredFederations = federations
+	filteredFederations := FilterFederations(federations, selectedFederations)
+
+	tournaments, _ := CollectTournaments(r.Context(), filteredFederations, dateFrom, dateTo, compType)
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(tournaments); err != nil {
+		logger.Error("Failed to encode tournaments response: %v", err)
+	}
+}
+
+// FilterFederations returns the federations selected by a comma-separated list
+// of IDs. An empty selection means "all federations".
+func FilterFederations(federations []models.Federation, selectedFederations string) []models.Federation {
+	if strings.TrimSpace(selectedFederations) == "" {
+		return federations
 	}
 
+	selected := make(map[string]struct{})
+	for _, id := range strings.Split(selectedFederations, ",") {
+		if trimmed := strings.TrimSpace(id); trimmed != "" {
+			selected[trimmed] = struct{}{}
+		}
+	}
+
+	var filtered []models.Federation
+	for _, fed := range federations {
+		if _, ok := selected[fed.Id]; ok {
+			filtered = append(filtered, fed)
+		}
+	}
+
+	return filtered
+}
+
+// CollectTournaments fetches all federations concurrently and merges the
+// results deterministically.
+//
+// Every goroutine writes only to its own result slot, so no shared slice is
+// mutated concurrently. Results are ordered by the federation's input position,
+// which keeps responses stable regardless of goroutine scheduling. A failure in
+// one federation never discards results from the others.
+func CollectTournaments(ctx context.Context, federations []models.Federation, dateFrom, dateTo, compType string) ([]models.Tournament, []FederationResult) {
+	results := make([]FederationResult, len(federations))
+
 	var wg sync.WaitGroup
-	for i := 0; i < len(filteredFederations); i++ {
+	for i, fed := range federations {
 		wg.Add(1)
-		go func(fed models.Federation) {
+		go func(idx int, fed models.Federation) {
 			defer wg.Done()
-			if fed.ApiVersion == "old" {
-				tournaments := getTournamentsFromFederationOldApi(fed, dateFrom, dateTo, compType)
-				Tournaments = append(Tournaments, tournaments...)
-			} else if fed.ApiVersion == "new" {
-				tournaments := getTournamentsFromFederationNewApi(fed, dateFrom, dateTo, compType)
-				Tournaments = append(Tournaments, tournaments...)
+
+			results[idx].Federation = fed
+
+			defer func() {
+				// A panic in one federation parser must not take down the
+				// whole request.
+				if rec := recover(); rec != nil {
+					logger.Error("Recovered from panic while processing federation %s: %v", fed.Id, rec)
+					results[idx].Err = fmt.Errorf("panic while processing federation %s: %v", fed.Id, rec)
+				}
+			}()
+
+			tournaments, err := fetchFederation(ctx, fed, dateFrom, dateTo, compType)
+			if err != nil {
+				logger.Error("Federation %s failed: %v", fed.Id, err)
 			}
-		}(filteredFederations[i])
+
+			results[idx].Tournaments = tournaments
+			results[idx].Err = err
+		}(i, fed)
 	}
 	wg.Wait()
 
-	json.NewEncoder(w).Encode(Tournaments)
+	tournaments := []models.Tournament{}
+	for _, res := range results {
+		tournaments = append(tournaments, res.Tournaments...)
+	}
+
+	return tournaments, results
 }
 
-func getTournamentsFromFederationNewApi(federation models.Federation, dateFrom string, dateTo string, compType string) []models.Tournament {
-	logger.Info("Get Tournaments in: %s from: %s to: %s, compType: %s", federation.Id, dateFrom, dateTo, compType)
-	var tournaments []models.Tournament
-
-	var baseURL = federation.Url
-	var trustedProperties = federation.TrustedProperties
-	var defaultGeocoords = federation.Geocoordinates
-	var state = federation.State
-
-	var fedRankValuation = "true"
-	// var fedRank = "20"
-	var firstResult = "0"
-	var maxResults = "100"
-	var ageCategory = "" // ""= Alle, "general" = Aktive, "juniors" = Jugend, "seniors" = Senioren
-	if compType != "" {
-		// Switch case
-		switch compType {
-		case "Herren+Einzel", "Herren+Doppel", "Damen+Einzel", "Damen+Doppel":
-			ageCategory = "general"
-		case "Senioren+Einzel", "Senioren+Doppel":
-			ageCategory = "seniors"
-		case "Jugend+Einzel", "Jugend+Doppel":
-			ageCategory = "juniors"
-		default:
-			logger.Warn("Unknown competition type: %s. Using default age category", compType)
-			ageCategory = ""
-		}
-	} else {
-		ageCategory = "" // No filter for all competitions
+// fetchFederation dispatches to the correct API implementation.
+func fetchFederation(ctx context.Context, fed models.Federation, dateFrom, dateTo, compType string) ([]models.Tournament, error) {
+	switch fed.ApiVersion {
+	case "old":
+		return getTournamentsFromFederationOldApi(ctx, fed, dateFrom, dateTo, compType)
+	case "new":
+		return getTournamentsFromFederationNewApi(ctx, fed, dateFrom, dateTo, compType)
+	default:
+		return nil, fmt.Errorf("unknown API version %q for federation %s", fed.ApiVersion, fed.Id)
 	}
+}
 
-	// Parse the base URL
-	reqURL, err := url.Parse(baseURL)
+// ageCategoryForCompType maps a competition type to the new API's age category.
+func ageCategoryForCompType(compType string) string {
+	switch compType {
+	case "":
+		// No filter for all competitions
+		return ""
+	case "Herren+Einzel", "Herren+Doppel", "Damen+Einzel", "Damen+Doppel":
+		return "general"
+	case "Senioren+Einzel", "Senioren+Doppel":
+		return "seniors"
+	case "Jugend+Einzel", "Jugend+Doppel":
+		return "juniors"
+	default:
+		logger.Warn("Unknown competition type: %s. Using default age category", compType)
+		return ""
+	}
+}
+
+// buildNewApiURL assembles a request URL for one page of the new API.
+func buildNewApiURL(fed models.Federation, dateFrom, dateTo, compType string, firstResult int) (string, error) {
+	reqURL, err := url.Parse(fed.Url)
 	if err != nil {
-		logger.Error("Failed to parse URL: %v", err)
-		return tournaments
+		return "", fmt.Errorf("failed to parse URL: %w", err)
 	}
-
-	// Add query parameters using proper URL encoding
-	q := reqURL.Query()
 
 	// Use different parameter prefixes based on federation
-	var paramPrefix string
-	if federation.Id == "RLP" {
+	paramPrefix := "tx_nuportalrs_tournaments"
+	if fed.Id == "RLP" {
 		paramPrefix = "tx_nuportalrs_nuportalrs"
-	} else {
-		paramPrefix = "tx_nuportalrs_tournaments"
 	}
 
-	q.Set(fmt.Sprintf("%s[__trustedProperties]", paramPrefix), trustedProperties)
-	q.Set(fmt.Sprintf("%s[tournamentsFilter][ageCategory]", paramPrefix), ageCategory)
-	q.Set(fmt.Sprintf("%s[tournamentsFilter][fedRankValuation]", paramPrefix), fedRankValuation)
+	q := reqURL.Query()
+	q.Set(fmt.Sprintf("%s[__trustedProperties]", paramPrefix), fed.TrustedProperties)
+	q.Set(fmt.Sprintf("%s[tournamentsFilter][ageCategory]", paramPrefix), ageCategoryForCompType(compType))
+	q.Set(fmt.Sprintf("%s[tournamentsFilter][fedRankValuation]", paramPrefix), "true")
 	q.Set(fmt.Sprintf("%s[tournamentsFilter][startDate]", paramPrefix), dateFrom)
 	q.Set(fmt.Sprintf("%s[tournamentsFilter][endDate]", paramPrefix), dateTo)
-	q.Set(fmt.Sprintf("%s[tournamentsFilter][firstResult]", paramPrefix), firstResult)
-	q.Set(fmt.Sprintf("%s[tournamentsFilter][maxResults]", paramPrefix), maxResults)
+	q.Set(fmt.Sprintf("%s[tournamentsFilter][firstResult]", paramPrefix), strconv.Itoa(firstResult))
+	q.Set(fmt.Sprintf("%s[tournamentsFilter][maxResults]", paramPrefix), strconv.Itoa(pageSize))
 	reqURL.RawQuery = q.Encode()
 
-	// Create HTTP client and request
-	client := &http.Client{}
-	req, err := http.NewRequest("GET", reqURL.String(), nil)
-	if err != nil {
-		logger.Error("Failed to create request: %v", err)
-		return tournaments
+	return reqURL.String(), nil
+}
+
+// getTournamentsFromFederationNewApi fetches every result page for a federation
+// using the new (TYPO3/nuPortal) API.
+//
+// The upstream API caps a single response at maxResults entries, so pagination
+// is required to avoid silently truncating larger result sets.
+func getTournamentsFromFederationNewApi(ctx context.Context, fed models.Federation, dateFrom string, dateTo string, compType string) ([]models.Tournament, error) {
+	logger.Info("Get Tournaments in: %s from: %s to: %s, compType: %s", fed.Id, dateFrom, dateTo, compType)
+
+	var all []models.Tournament
+	seen := make(map[string]struct{})
+	var firstErr error
+
+	for page := 0; page < maxPages; page++ {
+		reqURL, err := buildNewApiURL(fed, dateFrom, dateTo, compType, page*pageSize)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			break
+		}
+
+		body, err := doRequest(ctx, http.MethodGet, reqURL, nil, "")
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			// Keep the pages fetched so far instead of discarding everything.
+			break
+		}
+
+		pageTournaments, parseErr := ParseNewApiDocument(body, fed, defaultGeocoder)
+		body.Close()
+
+		if parseErr != nil {
+			if firstErr == nil {
+				firstErr = parseErr
+			}
+			break
+		}
+
+		newOnPage := 0
+		for _, t := range pageTournaments {
+			key := t.Id
+			if key == "" {
+				// Fall back to a composite key when no ID could be parsed.
+				key = t.Title + "|" + t.Date
+			}
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			all = append(all, t)
+			newOnPage++
+		}
+
+		logger.Debug("Federation %s page %d: %d parsed, %d new", fed.Id, page, len(pageTournaments), newOnPage)
+
+		// Stop on a short page (the last one) or when a page adds nothing new.
+		// The latter guards against upstreams that ignore the offset parameter.
+		if len(pageTournaments) < pageSize || newOnPage == 0 {
+			break
+		}
 	}
 
-	res, err := client.Do(req)
-	if err != nil {
-		logger.Error("HTTP request failed: %v", err)
-		return tournaments
-	}
-	defer res.Body.Close()
+	logger.Info("Federation %s: Found %d tournaments total", fed.Id, len(all))
 
-	doc, err := goquery.NewDocumentFromReader(res.Body)
+	return all, firstErr
+}
+
+// getTournamentsFromFederationOldApi fetches tournaments using the old
+// (liga.nu) form-post API.
+func getTournamentsFromFederationOldApi(ctx context.Context, fed models.Federation, dateFrom string, dateTo string, compType string) ([]models.Tournament, error) {
+	logger.Info("Get Tournaments in: %s from: %s to: %s, compType: %s", fed.Id, dateFrom, dateTo, compType)
+
+	body, err := doRequest(ctx, http.MethodPost, fed.Url,
+		strings.NewReader(buildOldApiPayload(fed, dateFrom, dateTo, compType)),
+		"application/x-www-form-urlencoded")
 	if err != nil {
-		logger.Error("Failed to parse HTML document: %v", err)
+		return nil, err
+	}
+	defer body.Close()
+
+	tournaments, err := ParseOldApiDocument(body, fed, defaultGeocoder)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Info("Federation %s: Found %d tournaments total", fed.Id, len(tournaments))
+
+	return tournaments, nil
+}
+
+// buildOldApiPayload builds the form-encoded request body for the old API.
+func buildOldApiPayload(fed models.Federation, dateFrom, dateTo, compType string) string {
+	const valuationState = "1" // 0=No-LK-Status, 1=LK-Status, 2=DTB-Status
+	const region = "DE"
+
+	form := url.Values{}
+	form.Set("queryName", "")
+	form.Set("queryDateFrom", dateFrom)
+	form.Set("queryDateTo", dateTo)
+	form.Set("valuationState", valuationState)
+	form.Set("federation", fed.Id)
+	form.Set("region", region)
+	if compType != "" {
+		// compType uses "+" to separate the two words (e.g. "Herren+Einzel").
+		// url.Values encodes it safely as %2B.
+		form.Set("compType", compType)
+	}
+
+	return form.Encode()
+}
+
+// doRequest performs a bounded HTTP request and returns the response body.
+// The caller is responsible for closing the returned ReadCloser.
+func doRequest(ctx context.Context, method, reqURL string, body io.Reader, contentType string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpclient.ApplyDefaultHeaders(req)
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+
+	res, err := httpclient.Federation().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(res.Body, maxResponseBytes))
+		res.Body.Close()
+		return nil, fmt.Errorf("unexpected HTTP status %d", res.StatusCode)
+	}
+
+	return newLimitedReadCloser(res.Body, maxResponseBytes), nil
+}
+
+// limitedReadCloser bounds how much of a response body can be read while still
+// closing the underlying connection correctly.
+type limitedReadCloser struct {
+	reader io.Reader
+	closer io.Closer
+}
+
+func newLimitedReadCloser(rc io.ReadCloser, limit int64) io.ReadCloser {
+	return &limitedReadCloser{reader: io.LimitReader(rc, limit), closer: rc}
+}
+
+func (l *limitedReadCloser) Read(p []byte) (int, error) { return l.reader.Read(p) }
+func (l *limitedReadCloser) Close() error               { return l.closer.Close() }
+
+// resolveGeocoordinates looks up coordinates and falls back to the federation
+// default when nothing suitable is found.
+func resolveGeocoordinates(fed models.Federation, tournament models.Tournament, geocode geocoder, subject string) models.Geocoordinates {
+	if geocode == nil {
+		geocode = defaultGeocoder
+	}
+
+	geoCoords := geocode(fed.State, tournament)
+	if geoCoords.Lat == "" || geoCoords.Lon == "" {
+		logger.Warn("No Geocoordinates could be found for (%s): '%s'. Falling back to default in '%s'",
+			tournament.Id, subject, fed.State)
+		return fed.Geocoordinates
+	}
+
+	return geoCoords
+}
+
+// ParseNewApiDocument parses one page of the new API's HTML into tournaments.
+func ParseNewApiDocument(r io.Reader, fed models.Federation, geocode geocoder) ([]models.Tournament, error) {
+	doc, err := goquery.NewDocumentFromReader(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse HTML document: %w", err)
 	}
 
 	// Track tournaments by ID to group competition entries from multiple rows
 	tournamentMap := make(map[string]*models.Tournament)
-	var orderedTournaments []models.Tournament
+	var orderedTournaments []*models.Tournament
 
-	// Find the tournament items
 	doc.Find(".responsive-individual tbody tr").Each(func(idxRow int, rowTournament *goquery.Selection) {
 		var currentTournament *models.Tournament
 		var tournamentDate string
@@ -182,10 +410,10 @@ func getTournamentsFromFederationNewApi(federation models.Federation, dateFrom s
 
 		rowTournament.Find("td").Each(func(idxColumn int, columnTournament *goquery.Selection) {
 			// Column 0: Date, Column 1: Title; Column 2: Competition
-			value := util.RemoveFormatFromString(columnTournament.Text())
+			value := util.NormalizeWhitespace(columnTournament.Text())
 
-			if idxColumn == 0 && columnTournament.HasClass("daterange") && strings.TrimSpace(value) != "" {
-				tournamentDate = strings.TrimSpace(value)
+			if idxColumn == 0 && columnTournament.HasClass("daterange") && value != "" {
+				tournamentDate = value
 			}
 
 			if idxColumn == 1 && strings.Contains(columnTournament.Text(), "Veranstalter") {
@@ -206,7 +434,7 @@ func getTournamentsFromFederationNewApi(federation models.Federation, dateFrom s
 				}
 
 				if urlElement.Length() > 0 {
-					tournament.Title = strings.TrimSpace(util.RemoveFormatFromString(urlElement.Text()))
+					tournament.Title = util.NormalizeWhitespace(urlElement.Text())
 					tournament.URL, _ = urlElement.Attr("href")
 					tournament.Id = getTournamentIdByUrl(tournament.URL)
 				}
@@ -221,7 +449,7 @@ func getTournamentsFromFederationNewApi(federation models.Federation, dateFrom s
 						// Extract organizer - everything between "Veranstalter: " and " Austragungsort"
 						extractedOrganizer, organizerExists := util.GetStringInBetweenTwoString(paragraphText, "Veranstalter: ", " Austragungsort")
 						if organizerExists {
-							tournament.Organizer = strings.TrimSpace(extractedOrganizer)
+							tournament.Organizer = util.NormalizeWhitespace(extractedOrganizer)
 						}
 					}
 
@@ -237,7 +465,7 @@ func getTournamentsFromFederationNewApi(federation models.Federation, dateFrom s
 							extractedLocation, locationExists = util.GetStringInBetweenTwoString(paragraphText, "Austragungsort: ", " Offen für")
 						}
 						if locationExists {
-							tournament.Location = strings.TrimSpace(extractedLocation)
+							tournament.Location = util.NormalizeWhitespace(extractedLocation)
 						}
 					}
 
@@ -250,26 +478,24 @@ func getTournamentsFromFederationNewApi(federation models.Federation, dateFrom s
 
 				// Get geocoordinates if we have a location
 				if tournament.Location != "" {
-					geoCoords := openstreetmap.GetGeocoordinatesFromCache(state, tournament)
-					if geoCoords.Lat == "" || geoCoords.Lon == "" {
-						logger.Warn("No Geocoordinates could be found for (%s): '%s'. Falling back to default in '%s'", tournament.Id, tournament.Location, state)
-						geoCoords = defaultGeocoords
-					}
+					geoCoords := resolveGeocoordinates(fed, tournament, geocode, tournament.Location)
 					tournament.Lat = geoCoords.Lat
 					tournament.Lon = geoCoords.Lon
 				} else {
-					logger.Warn("Tournament location missing: %s ; Date: %s", util.RemoveFormatFromString(tournament.Title), tournament.Date)
+					logger.Warn("Tournament location missing: %s ; Date: %s", tournament.Title, tournament.Date)
 				}
 
 				if len(tournament.Title) > 0 && tournament.Id != "" {
 					if debugEnabled {
 						logger.Debug("Created tournament: ID='%s', Title='%s', Date='%s'", tournament.Id, tournament.Title, tournament.Date)
 					}
-					// Store in map for grouping and in ordered slice for maintaining order
-					tournamentMap[tournament.Id] = &tournament
-					orderedTournaments = append(orderedTournaments, tournament)
-					// Update the reference to point to the tournament in the ordered slice
-					currentTournament = &orderedTournaments[len(orderedTournaments)-1]
+
+					stored := tournament
+					// Store the same pointer in the map and the ordered slice so
+					// competition entries appended later are visible in both.
+					tournamentMap[stored.Id] = &stored
+					orderedTournaments = append(orderedTournaments, &stored)
+					currentTournament = &stored
 				}
 			} else if idxColumn == 1 && len(tournamentMap) > 0 {
 				// This might be a continuation row - try to find tournament by URL
@@ -285,7 +511,7 @@ func getTournamentsFromFederationNewApi(federation models.Federation, dateFrom s
 				}
 				// If no URL found, use the most recent tournament
 				if currentTournament == nil && len(orderedTournaments) > 0 {
-					currentTournament = &orderedTournaments[len(orderedTournaments)-1]
+					currentTournament = orderedTournaments[len(orderedTournaments)-1]
 				}
 			}
 
@@ -295,18 +521,8 @@ func getTournamentsFromFederationNewApi(federation models.Federation, dateFrom s
 				columnTournament.Find("table tbody tr").Each(func(competitionIdx int, competitionRow *goquery.Selection) {
 					var competition models.CompetitionEntry
 
-					if debugEnabled {
-						rowText := strings.TrimSpace(competitionRow.Text())
-						logger.Debug("Processing competition row %d: '%s'", competitionIdx, rowText)
-					}
-
 					competitionRow.Find("td").Each(func(colIdx int, competitionCell *goquery.Selection) {
-						cellValue := strings.TrimSpace(util.RemoveFormatFromString(competitionCell.Text()))
-
-						if debugEnabled {
-							cellClasses, _ := competitionCell.Attr("class")
-							logger.Debug("Cell %d: value='%s', classes='%s'", colIdx, cellValue, cellClasses)
-						}
+						cellValue := util.NormalizeWhitespace(competitionCell.Text())
 
 						switch colIdx {
 						case 0: // Competition name (td.name or first column)
@@ -314,76 +530,41 @@ func getTournamentsFromFederationNewApi(federation models.Federation, dateFrom s
 								// Extract text from span inside td.name
 								spanText := competitionCell.Find("span").Text()
 								if spanText != "" {
-									competition.Competition = strings.TrimSpace(util.RemoveFormatFromString(spanText))
+									competition.Competition = util.NormalizeWhitespace(spanText)
 								} else {
 									competition.Competition = cellValue
 								}
-							} else if colIdx == 0 && cellValue != "" {
-								// Fallback: if first column has content but no "name" class
+							} else if cellValue != "" {
+								// Fallback: first column has content but no "name" class
 								competition.Competition = cellValue
 							}
 						case 1: // Skill level (td.fedRank or second column)
-							// Check if this cell has fedRank class OR if it's the second column with content
-							if competitionCell.HasClass("fedRank") || colIdx == 1 {
-								if cellValue != "" {
-									competition.SkillLevel = cellValue
-								}
+							if cellValue != "" {
+								competition.SkillLevel = cellValue
 							}
 						case 2: // Result (td.result) - can be ignored
-							// Skip result column
 						}
 					})
 
 					// Add the competition entry if we have valid data
 					if competition.Competition != "" {
-						// Clean up skill level - remove extra whitespace
-						competition.SkillLevel = strings.TrimSpace(competition.SkillLevel)
-
-						if debugEnabled {
-							logger.Debug("Found competition: '%s' with skill level: '%s'", competition.Competition, competition.SkillLevel)
+						target := currentTournament
+						if target == nil && len(orderedTournaments) > 0 {
+							target = orderedTournaments[len(orderedTournaments)-1]
 						}
-
-						// Add to current tournament if we have one, otherwise try to find the most recent tournament
-						if currentTournament != nil {
-							currentTournament.Entries = append(currentTournament.Entries, competition)
-							// Also update the tournament in the map
-							if currentTournament.Id != "" {
-								tournamentMap[currentTournament.Id] = currentTournament
-							}
-							if debugEnabled {
-								logger.Debug("Added competition to current tournament ID='%s', now has %d entries", currentTournament.Id, len(currentTournament.Entries))
-							}
-						} else if len(orderedTournaments) > 0 {
-							// Add to the most recent tournament
-							lastTournament := &orderedTournaments[len(orderedTournaments)-1]
-							lastTournament.Entries = append(lastTournament.Entries, competition)
-							// Update in map as well
-							if lastTournament.Id != "" {
-								tournamentMap[lastTournament.Id] = lastTournament
-							}
-							if debugEnabled {
-								logger.Debug("Added competition to last tournament ID='%s', now has %d entries", lastTournament.Id, len(lastTournament.Entries))
-							}
+						if target != nil {
+							target.Entries = append(target.Entries, competition)
 						}
 					}
 				})
 			}
 		})
-
-		// No need to add competition entry here anymore since we handle them directly in the competitionAbbr column
 	})
 
-	// Convert back to slice, ensuring we have the updated tournaments with all competition entries
-	tournaments = []models.Tournament{}
-	for _, tournament := range orderedTournaments {
-		if updatedTournament, exists := tournamentMap[tournament.Id]; exists {
-			tournaments = append(tournaments, *updatedTournament)
-		} else {
-			tournaments = append(tournaments, tournament)
-		}
+	tournaments := make([]models.Tournament, 0, len(orderedTournaments))
+	for _, t := range orderedTournaments {
+		tournaments = append(tournaments, *t)
 	}
-
-	logger.Info("Federation %s: Found %d tournaments total", federation.Id, len(tournaments))
 
 	if debugEnabled {
 		for i, t := range tournaments {
@@ -391,54 +572,18 @@ func getTournamentsFromFederationNewApi(federation models.Federation, dateFrom s
 		}
 	}
 
-	return tournaments
+	return tournaments, nil
 }
 
-func getTournamentsFromFederationOldApi(federation models.Federation, dateFrom string, dateTo string, compType string) []models.Tournament {
-	logger.Info("Get Tournaments in: %s from: %s to: %s, compType: %s", federation.Id, dateFrom, dateTo, compType)
+// ParseOldApiDocument parses the old API's result table into tournaments.
+func ParseOldApiDocument(r io.Reader, fed models.Federation, geocode geocoder) ([]models.Tournament, error) {
+	doc, err := goquery.NewDocumentFromReader(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse HTML document: %w", err)
+	}
+
 	var tournaments []models.Tournament
 
-	var url = federation.Url
-	var defaultGeocoords = federation.Geocoordinates
-	var state = federation.State
-
-	var valuationState = "1" // 0=No-LK-Status, 1=LK-Status, 2=DTB-Status
-	// var queryYoungOld = "2"  			// 1=Youth, 2=Adult, 3=Senior
-	// Tournament Type: Herren%2BEinzel, Herren%2BDoppel, Damen%2BEinzel, Damen%2BDoppel, Senioren%2BEinzel, Senioren%2BDoppel, Jugend%2BEinzel, Jugend%2BDoppel
-	// var fedRank = "16"               	// LK Rank: 1-23
-	var region = "DE" // Region: DE
-
-	// Build payload with optional competition type filter
-	payloadStr := "queryName=&queryDateFrom=" + dateFrom + "&queryDateTo=" + dateTo + "&valuationState=" + valuationState + "&federation=" + federation.Id + "&region=" + region
-	if compType != "" {
-		// URL encode the competition type (e.g., "Herren+Einzel" -> "Herren%2BEinzel")
-		encodedCompType := strings.ReplaceAll(compType, "+", "%2B")
-		payloadStr += "&compType=" + encodedCompType
-	}
-	payload := strings.NewReader(payloadStr)
-
-	client := &http.Client{}
-	req, err := http.NewRequest("POST", url, payload)
-
-	if err != nil {
-		logger.Error("Failed to create HTTP request: %v", err)
-		return tournaments
-	}
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-	res, err := client.Do(req)
-	if err != nil {
-		logger.Error("HTTP request failed: %v", err)
-		return tournaments
-	}
-	defer res.Body.Close()
-
-	doc, err := goquery.NewDocumentFromReader(res.Body)
-	if err != nil {
-		logger.Error("Failed to parse HTML document: %v", err)
-	}
-
-	// Find the tournament items
 	doc.Find(".result-set tr").Each(func(idxRow int, rowTournament *goquery.Selection) {
 		// Skip header row
 		if idxRow == 0 {
@@ -452,50 +597,33 @@ func getTournamentsFromFederationOldApi(federation models.Federation, dateFrom s
 		if dateCell.AttrOr("rowspan", "") != "" && titleCell.AttrOr("rowspan", "") != "" {
 			// This is a new tournament
 			var tournament models.Tournament
-
-			// Initialize slice for competition entries
 			tournament.Entries = []models.CompetitionEntry{}
 
 			var currentEntry models.CompetitionEntry
 
 			rowTournament.Find("td").Each(func(idxColumn int, columnTournament *goquery.Selection) {
-				value := util.RemoveFormatFromString(columnTournament.Text())
+				value := util.NormalizeWhitespace(columnTournament.Text())
 
 				switch idxColumn {
 				case 0: // Date
 					tournament.Date = value
 				case 1: // Title and Organizer
 					urlElement := columnTournament.Find("a")
-					tournament.Title = util.RemoveFormatFromString(urlElement.Text())
+					tournament.Title = util.NormalizeWhitespace(urlElement.Text())
 					tournament.URL, _ = urlElement.Attr("href")
 					tournament.Id = getTournamentIdByUrl(tournament.URL)
 
 					if len(tournament.Title) > 0 {
-						array := strings.Split(columnTournament.Text(), "\n\t\n\n\n")
-						var extractedOrganizer = ""
-						if len(array) > 1 {
-							extractedOrganizer = array[1]
-						} else {
-							logger.Warn("Tournament organizer missing: %s ; Date: %s", util.RemoveFormatFromString(columnTournament.Find("a").Text()), tournament.Date)
-						}
-						organizer := util.RemoveFormatFromString(extractedOrganizer)
-						tournament.Organizer = organizer
+						tournament.Organizer = extractOldApiOrganizer(columnTournament, tournament)
 
-						geoCoords := openstreetmap.GetGeocoordinatesFromCache(state, tournament)
-						if geoCoords.Lat == "" || geoCoords.Lon == "" {
-							logger.Warn("No Geocoordinates could be found for (%s): '%s'. Falling back to default in '%s'", tournament.Id, tournament.Organizer, state)
-							geoCoords = defaultGeocoords
-						}
+						geoCoords := resolveGeocoordinates(fed, tournament, geocode, tournament.Organizer)
 						tournament.Lat = geoCoords.Lat
 						tournament.Lon = geoCoords.Lon
 					}
 				case 2: // Competition (Konkurrenz)
-					currentEntry.Competition = strings.TrimSpace(value)
+					currentEntry.Competition = value
 				case 3: // Skill Level (LK)
-					currentEntry.SkillLevel = strings.TrimSpace(value)
-					if currentEntry.SkillLevel == "&nbsp;" {
-						currentEntry.SkillLevel = ""
-					}
+					currentEntry.SkillLevel = normalizeSkillLevel(value)
 				}
 			})
 
@@ -516,16 +644,13 @@ func getTournamentsFromFederationOldApi(federation models.Federation, dateFrom s
 				var additionalEntry models.CompetitionEntry
 
 				rowTournament.Find("td").Each(func(idxColumn int, columnTournament *goquery.Selection) {
-					value := util.RemoveFormatFromString(columnTournament.Text())
+					value := util.NormalizeWhitespace(columnTournament.Text())
 
 					switch idxColumn {
 					case 0: // Competition (Konkurrenz) - first column in continuation rows
-						additionalEntry.Competition = strings.TrimSpace(value)
+						additionalEntry.Competition = value
 					case 1: // Skill Level (LK) - second column in continuation rows
-						additionalEntry.SkillLevel = strings.TrimSpace(value)
-						if additionalEntry.SkillLevel == "&nbsp;" {
-							additionalEntry.SkillLevel = ""
-						}
+						additionalEntry.SkillLevel = normalizeSkillLevel(value)
 					}
 				})
 
@@ -537,9 +662,35 @@ func getTournamentsFromFederationOldApi(federation models.Federation, dateFrom s
 		}
 	})
 
-	logger.Info("Federation %s: Found %d tournaments total", federation.Id, len(tournaments))
+	return tournaments, nil
+}
 
-	return tournaments
+// extractOldApiOrganizer pulls the organizer out of the title cell, which
+// contains the tournament link followed by the organizing club.
+func extractOldApiOrganizer(columnTournament *goquery.Selection, tournament models.Tournament) string {
+	cellText := columnTournament.Text()
+	linkText := columnTournament.Find("a").Text()
+
+	// The organizer is the cell text with the link text removed.
+	remainder := strings.Replace(cellText, linkText, "", 1)
+	organizer := util.NormalizeWhitespace(remainder)
+
+	if organizer == "" {
+		logger.Warn("Tournament organizer missing: %s ; Date: %s",
+			util.NormalizeWhitespace(linkText), tournament.Date)
+	}
+
+	return organizer
+}
+
+// normalizeSkillLevel cleans up an LK value, dropping non-breaking-space
+// placeholders that some federations emit for "no LK".
+func normalizeSkillLevel(value string) string {
+	cleaned := util.NormalizeWhitespace(value)
+	if cleaned == "&nbsp;" {
+		return ""
+	}
+	return cleaned
 }
 
 func getTournamentIdByUrl(tournamentUrl string) string {
@@ -548,7 +699,6 @@ func getTournamentIdByUrl(tournamentUrl string) string {
 	array := strings.Split(tournamentUrl, "detail/")
 	if len(array) > 1 {
 		return array[1]
-	} else {
-		return ""
 	}
+	return ""
 }

--- a/backend/pkg/tournament/tournament_test.go
+++ b/backend/pkg/tournament/tournament_test.go
@@ -1,0 +1,477 @@
+package tournament
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
+)
+
+// testFederationOld is a stand-in for a liga.nu based federation.
+var testFederationOld = models.Federation{
+	Id:             "BAD",
+	Name:           "Badischer Tennisverband",
+	State:          "Baden-Württemberg",
+	ApiVersion:     "old",
+	Geocoordinates: models.Geocoordinates{Lat: "49.0", Lon: "8.4"},
+}
+
+// testFederationNew is a stand-in for a TYPO3/nuPortal based federation.
+var testFederationNew = models.Federation{
+	Id:             "WTB",
+	Name:           "Württembergischer Tennisbund",
+	State:          "Baden-Württemberg",
+	ApiVersion:     "new",
+	Geocoordinates: models.Geocoordinates{Lat: "48.85", Lon: "9.13"},
+}
+
+var testFederationRLP = models.Federation{
+	Id:             "RLP",
+	Name:           "Rheinland-Pfälzischer Tennisverband",
+	State:          "Rheinland-Pfalz",
+	ApiVersion:     "new",
+	Geocoordinates: models.Geocoordinates{Lat: "49.99", Lon: "8.27"},
+}
+
+// staticGeocoder returns fixed coordinates so parser tests never touch the
+// network and stay deterministic.
+func staticGeocoder(lat, lon string) geocoder {
+	return func(state string, tournament models.Tournament) models.Geocoordinates {
+		return models.Geocoordinates{Lat: lat, Lon: lon, DisplayName: state}
+	}
+}
+
+// failingGeocoder simulates a lookup that cannot resolve coordinates.
+func failingGeocoder() geocoder {
+	return func(string, models.Tournament) models.Geocoordinates {
+		return models.Geocoordinates{}
+	}
+}
+
+func loadFixture(t *testing.T, name string) *os.File {
+	t.Helper()
+
+	f, err := os.Open(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("failed to open fixture %s: %v", name, err)
+	}
+	t.Cleanup(func() { f.Close() })
+
+	return f
+}
+
+func findTournament(t *testing.T, tournaments []models.Tournament, id string) models.Tournament {
+	t.Helper()
+
+	for _, tournament := range tournaments {
+		if tournament.Id == id {
+			return tournament
+		}
+	}
+
+	t.Fatalf("tournament with id %q not found in %d results", id, len(tournaments))
+	return models.Tournament{}
+}
+
+func competitions(tournament models.Tournament) []string {
+	out := make([]string, 0, len(tournament.Entries))
+	for _, e := range tournament.Entries {
+		out = append(out, e.Competition)
+	}
+	return out
+}
+
+func TestParseOldApiDocument(t *testing.T) {
+	tournaments, err := ParseOldApiDocument(
+		loadFixture(t, "old_api_basic.html"),
+		testFederationOld,
+		staticGeocoder("49.0069", "8.4037"),
+	)
+	if err != nil {
+		t.Fatalf("ParseOldApiDocument() error = %v", err)
+	}
+
+	if len(tournaments) != 3 {
+		t.Fatalf("got %d tournaments, want 3", len(tournaments))
+	}
+
+	first := tournaments[0]
+	if first.Id != "700001" {
+		t.Errorf("first.Id = %q, want %q", first.Id, "700001")
+	}
+	if first.Title != "LK-Turnier Sommer Open" {
+		t.Errorf("first.Title = %q", first.Title)
+	}
+	if first.Date != "01.08.2026 - 03.08.2026" {
+		t.Errorf("first.Date = %q", first.Date)
+	}
+	// Regression for the whitespace normalization fix: the organizer contains a
+	// run of spaces in the fixture and must come back collapsed.
+	if first.Organizer != "TC Rot-Weiß Karlsruhe" {
+		t.Errorf("first.Organizer = %q, want %q", first.Organizer, "TC Rot-Weiß Karlsruhe")
+	}
+	if first.Lat != "49.0069" || first.Lon != "8.4037" {
+		t.Errorf("first coordinates = (%q,%q), want geocoder result", first.Lat, first.Lon)
+	}
+
+	// The two continuation rows must be attached to the first tournament.
+	wantComps := []string{"Herren Einzel", "Damen Einzel", "Herren Doppel"}
+	gotComps := competitions(first)
+	if len(gotComps) != len(wantComps) {
+		t.Fatalf("first competitions = %v, want %v", gotComps, wantComps)
+	}
+	for i := range wantComps {
+		if gotComps[i] != wantComps[i] {
+			t.Errorf("competition %d = %q, want %q", i, gotComps[i], wantComps[i])
+		}
+	}
+
+	if got := first.Entries[0].SkillLevel; got != "LK 12,0" {
+		t.Errorf("first entry skill level = %q, want %q", got, "LK 12,0")
+	}
+	// "&nbsp;" is a placeholder for "no LK" and must be normalized away.
+	if got := first.Entries[2].SkillLevel; got != "" {
+		t.Errorf("doubles skill level = %q, want empty", got)
+	}
+
+	// A title split across lines must not lose its word boundary.
+	second := findTournament(t, tournaments, "700002")
+	if second.Title != "Jugendturnier Heidelberg" {
+		t.Errorf("second.Title = %q, want %q", second.Title, "Jugendturnier Heidelberg")
+	}
+	if second.Organizer != "TC Heidelberg" {
+		t.Errorf("second.Organizer = %q, want %q", second.Organizer, "TC Heidelberg")
+	}
+
+	// A URL without "detail/" yields an empty ID but must still be returned.
+	third := tournaments[2]
+	if third.Id != "" {
+		t.Errorf("third.Id = %q, want empty", third.Id)
+	}
+	if third.Title != "Turnier ohne ID" {
+		t.Errorf("third.Title = %q", third.Title)
+	}
+}
+
+func TestParseOldApiDocumentFallsBackToFederationCoordinates(t *testing.T) {
+	tournaments, err := ParseOldApiDocument(
+		loadFixture(t, "old_api_basic.html"),
+		testFederationOld,
+		failingGeocoder(),
+	)
+	if err != nil {
+		t.Fatalf("ParseOldApiDocument() error = %v", err)
+	}
+	if len(tournaments) == 0 {
+		t.Fatal("no tournaments parsed")
+	}
+
+	for _, tournament := range tournaments {
+		if tournament.Lat != testFederationOld.Geocoordinates.Lat ||
+			tournament.Lon != testFederationOld.Geocoordinates.Lon {
+			t.Errorf("tournament %s coordinates = (%q,%q), want federation default (%q,%q)",
+				tournament.Id, tournament.Lat, tournament.Lon,
+				testFederationOld.Geocoordinates.Lat, testFederationOld.Geocoordinates.Lon)
+		}
+	}
+}
+
+func TestParseNewApiDocumentWTB(t *testing.T) {
+	tournaments, err := ParseNewApiDocument(
+		loadFixture(t, "new_api_wtb.html"),
+		testFederationNew,
+		staticGeocoder("48.7758", "9.1829"),
+	)
+	if err != nil {
+		t.Fatalf("ParseNewApiDocument() error = %v", err)
+	}
+
+	if len(tournaments) != 2 {
+		t.Fatalf("got %d tournaments, want 2", len(tournaments))
+	}
+
+	first := findTournament(t, tournaments, "800001")
+	if first.Title != "Stuttgart Open" {
+		t.Errorf("first.Title = %q, want %q", first.Title, "Stuttgart Open")
+	}
+	if first.Date != "01.09.2026 - 03.09.2026" {
+		t.Errorf("first.Date = %q", first.Date)
+	}
+	if first.Organizer != "TC Stuttgart" {
+		t.Errorf("first.Organizer = %q, want %q", first.Organizer, "TC Stuttgart")
+	}
+	if first.Location != "Stuttgart" {
+		t.Errorf("first.Location = %q, want %q", first.Location, "Stuttgart")
+	}
+	if first.Lat != "48.7758" || first.Lon != "9.1829" {
+		t.Errorf("first coordinates = (%q,%q)", first.Lat, first.Lon)
+	}
+
+	// The continuation row must append to the existing tournament rather than
+	// creating a duplicate entry.
+	wantComps := []string{"Herren Einzel", "Damen Einzel", "Herren Doppel"}
+	gotComps := competitions(first)
+	if len(gotComps) != len(wantComps) {
+		t.Fatalf("first competitions = %v, want %v", gotComps, wantComps)
+	}
+	for i := range wantComps {
+		if gotComps[i] != wantComps[i] {
+			t.Errorf("competition %d = %q, want %q", i, gotComps[i], wantComps[i])
+		}
+	}
+
+	second := findTournament(t, tournaments, "800002")
+	if second.Title != "Ulmer Herbstturnier" {
+		t.Errorf("second.Title = %q, want %q", second.Title, "Ulmer Herbstturnier")
+	}
+	if len(second.Entries) != 1 {
+		t.Errorf("second entries = %d, want 1", len(second.Entries))
+	}
+}
+
+func TestParseNewApiDocumentRLPVariant(t *testing.T) {
+	tournaments, err := ParseNewApiDocument(
+		loadFixture(t, "new_api_rlp.html"),
+		testFederationRLP,
+		staticGeocoder("49.9929", "8.2473"),
+	)
+	if err != nil {
+		t.Fatalf("ParseNewApiDocument() error = %v", err)
+	}
+
+	if len(tournaments) != 2 {
+		t.Fatalf("got %d tournaments, want 2", len(tournaments))
+	}
+
+	// h3 title and "Offen für" location terminator.
+	first := findTournament(t, tournaments, "900001")
+	if first.Title != "Mainz Cup" {
+		t.Errorf("first.Title = %q", first.Title)
+	}
+	if first.Location != "Mainz" {
+		t.Errorf("first.Location = %q, want %q", first.Location, "Mainz")
+	}
+	if first.Organizer != "TC Mainz" {
+		t.Errorf("first.Organizer = %q", first.Organizer)
+	}
+
+	// Without a location the parser must not call the geocoder, so the
+	// coordinates stay empty here (the caller shows the federation default).
+	second := findTournament(t, tournaments, "900002")
+	if second.Location != "" {
+		t.Errorf("second.Location = %q, want empty", second.Location)
+	}
+	if second.Lat != "" || second.Lon != "" {
+		t.Errorf("second coordinates = (%q,%q), want empty", second.Lat, second.Lon)
+	}
+}
+
+func TestParseDocumentsHandleEmptyAndMalformedInput(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+	}{
+		{"empty", ""},
+		{"no matching table", "<html><body><p>Keine Turniere</p></body></html>"},
+		{"empty result set", `<table class="result-set"><tr><th>Datum</th></tr></table>`},
+		{"empty responsive table", `<table class="responsive-individual"><tbody></tbody></table>`},
+		{"unclosed tags", `<table class="result-set"><tr><td rowspan="1">01.01.2026`},
+		{"not html at all", "%%%not-html%%%"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"/old", func(t *testing.T) {
+			got, err := ParseOldApiDocument(strings.NewReader(tt.html), testFederationOld, staticGeocoder("1", "2"))
+			if err != nil {
+				t.Fatalf("ParseOldApiDocument() error = %v", err)
+			}
+			if len(got) != 0 {
+				t.Errorf("got %d tournaments, want 0", len(got))
+			}
+		})
+
+		t.Run(tt.name+"/new", func(t *testing.T) {
+			got, err := ParseNewApiDocument(strings.NewReader(tt.html), testFederationNew, staticGeocoder("1", "2"))
+			if err != nil {
+				t.Fatalf("ParseNewApiDocument() error = %v", err)
+			}
+			if len(got) != 0 {
+				t.Errorf("got %d tournaments, want 0", len(got))
+			}
+		})
+	}
+}
+
+func TestParseNewApiDocumentUsesDefaultGeocoderWhenNil(t *testing.T) {
+	// A nil geocoder must not panic; it falls back to the default lookup.
+	// The fixture without a location never triggers a network call.
+	tournaments, err := ParseNewApiDocument(
+		strings.NewReader(`<table class="responsive-individual"><tbody></tbody></table>`),
+		testFederationNew,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("ParseNewApiDocument() error = %v", err)
+	}
+	if len(tournaments) != 0 {
+		t.Errorf("got %d tournaments, want 0", len(tournaments))
+	}
+}
+
+func TestGetTournamentIdByUrl(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"https://www.tennis.de/spielen/turniersuche.html#detail/699982", "699982"},
+		{"https://mybigpoint.tennis.de/web/guest/turniersuche?tournamentId=484582", ""},
+		{"", ""},
+		{"detail/", ""},
+		{"https://example.com/detail/12345", "12345"},
+	}
+
+	for _, tt := range tests {
+		if got := getTournamentIdByUrl(tt.url); got != tt.want {
+			t.Errorf("getTournamentIdByUrl(%q) = %q, want %q", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestNormalizeSkillLevel(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"LK 12,0", "LK 12,0"},
+		{"  LK   12,0  ", "LK 12,0"},
+		{"&nbsp;", ""},
+		{"", ""},
+		{"\u00a0", ""},
+	}
+
+	for _, tt := range tests {
+		if got := normalizeSkillLevel(tt.in); got != tt.want {
+			t.Errorf("normalizeSkillLevel(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestAgeCategoryForCompType(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"", ""},
+		{"Herren+Einzel", "general"},
+		{"Damen+Doppel", "general"},
+		{"Senioren+Einzel", "seniors"},
+		{"Jugend+Doppel", "juniors"},
+		{"Unsinn", ""},
+	}
+
+	for _, tt := range tests {
+		if got := ageCategoryForCompType(tt.in); got != tt.want {
+			t.Errorf("ageCategoryForCompType(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestFilterFederations(t *testing.T) {
+	all := []models.Federation{
+		{Id: "BAD"}, {Id: "WTB"}, {Id: "HTV"},
+	}
+
+	tests := []struct {
+		name      string
+		selection string
+		want      []string
+	}{
+		{"empty selects all", "", []string{"BAD", "WTB", "HTV"}},
+		{"whitespace selects all", "   ", []string{"BAD", "WTB", "HTV"}},
+		{"single", "WTB", []string{"WTB"}},
+		{"multiple keeps source order", "HTV,BAD", []string{"BAD", "HTV"}},
+		{"tolerates spaces", " BAD , HTV ", []string{"BAD", "HTV"}},
+		{"unknown ids ignored", "BAD,NOPE", []string{"BAD"}},
+		{"duplicates collapse", "BAD,BAD", []string{"BAD"}},
+		{"only unknown", "NOPE", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilterFederations(all, tt.selection)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d federations, want %d (%v)", len(got), len(tt.want), tt.want)
+			}
+			for i := range tt.want {
+				if got[i].Id != tt.want[i] {
+					t.Errorf("federation %d = %q, want %q", i, got[i].Id, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBuildOldApiPayload(t *testing.T) {
+	payload := buildOldApiPayload(testFederationOld, "01.08.2026", "15.08.2026", "Herren+Einzel")
+
+	for _, want := range []string{
+		"queryDateFrom=01.08.2026",
+		"queryDateTo=15.08.2026",
+		"federation=BAD",
+		"valuationState=1",
+		"region=DE",
+	} {
+		if !strings.Contains(payload, want) {
+			t.Errorf("payload %q does not contain %q", payload, want)
+		}
+	}
+
+	// The "+" in the competition type must survive as an encoded plus rather
+	// than being interpreted as a space.
+	if !strings.Contains(payload, "compType=Herren%2BEinzel") {
+		t.Errorf("payload %q does not contain encoded compType", payload)
+	}
+
+	// Without a competition type the parameter must be omitted entirely.
+	if got := buildOldApiPayload(testFederationOld, "01.08.2026", "15.08.2026", ""); strings.Contains(got, "compType") {
+		t.Errorf("payload %q should not contain compType", got)
+	}
+}
+
+func TestBuildNewApiURL(t *testing.T) {
+	fed := testFederationNew
+	fed.Url = "https://example.test/turnierkalender"
+	fed.TrustedProperties = "trusted-value"
+
+	raw, err := buildNewApiURL(fed, "01.09.2026", "30.09.2026", "Jugend+Einzel", 200)
+	if err != nil {
+		t.Fatalf("buildNewApiURL() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"tx_nuportalrs_tournaments%5BtournamentsFilter%5D%5BstartDate%5D=01.09.2026",
+		"tx_nuportalrs_tournaments%5BtournamentsFilter%5D%5BendDate%5D=30.09.2026",
+		"tx_nuportalrs_tournaments%5BtournamentsFilter%5D%5BageCategory%5D=juniors",
+		"tx_nuportalrs_tournaments%5BtournamentsFilter%5D%5BfirstResult%5D=200",
+		"tx_nuportalrs_tournaments%5BtournamentsFilter%5D%5BmaxResults%5D=100",
+		"trusted-value",
+	} {
+		if !strings.Contains(raw, want) {
+			t.Errorf("URL %q does not contain %q", raw, want)
+		}
+	}
+
+	// RLP uses a different parameter prefix.
+	rlp := testFederationRLP
+	rlp.Url = "https://example.test/turnierkalender"
+	rlpURL, err := buildNewApiURL(rlp, "01.09.2026", "30.09.2026", "", 0)
+	if err != nil {
+		t.Fatalf("buildNewApiURL(RLP) error = %v", err)
+	}
+	if !strings.Contains(rlpURL, "tx_nuportalrs_nuportalrs") {
+		t.Errorf("RLP URL %q does not use the nuportalrs prefix", rlpURL)
+	}
+
+	// An invalid base URL must surface as an error.
+	broken := testFederationNew
+	broken.Url = "://not a url"
+	if _, err := buildNewApiURL(broken, "", "", "", 0); err == nil {
+		t.Error("buildNewApiURL() with invalid URL returned nil error")
+	}
+}

--- a/backend/pkg/tournament/warmup.go
+++ b/backend/pkg/tournament/warmup.go
@@ -1,13 +1,11 @@
 package tournament
 
 import (
-	"strings"
-	"sync"
+	"context"
 	"time"
 
 	"github.com/timoknapp/tennis-tournament-finder/pkg/federation"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
-	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
 )
 
 // Warmup preloads tournaments for the given date range and optional filters.
@@ -15,8 +13,11 @@ import (
 // dateFrom/dateTo format: "02.01.2006". Empty values default to today..today+14d.
 // compType and selectedFederations are optional (comma-separated IDs).
 func Warmup(dateFrom, dateTo, compType, selectedFederations string) int {
-	federations := federation.GetFederations()
+	return WarmupContext(context.Background(), dateFrom, dateTo, compType, selectedFederations)
+}
 
+// WarmupContext behaves like Warmup but honours cancellation via ctx.
+func WarmupContext(ctx context.Context, dateFrom, dateTo, compType, selectedFederations string) int {
 	// Defaults
 	today := time.Now()
 	if dateFrom == "" {
@@ -26,50 +27,20 @@ func Warmup(dateFrom, dateTo, compType, selectedFederations string) int {
 		dateTo = today.Add(14 * 24 * time.Hour).Format("02.01.2006")
 	}
 
-	// Federation filtering (same behavior as in GetTournaments)
-	var filteredFederations []models.Federation
-	if selectedFederations != "" {
-		selectedFedIds := strings.Split(selectedFederations, ",")
-		for _, fed := range federations {
-			for _, sel := range selectedFedIds {
-				if fed.Id == strings.TrimSpace(sel) {
-					filteredFederations = append(filteredFederations, fed)
-					break
-				}
-			}
-		}
-	} else {
-		filteredFederations = federations
-	}
+	filteredFederations := FilterFederations(federation.GetFederations(), selectedFederations)
 
 	logger.Info("Warmup: from %s to %s, compType: %s, federations: %s",
 		dateFrom, dateTo, compType, selectedFederations)
 
-	var total int
-	var mu sync.Mutex
-	var wg sync.WaitGroup
+	tournaments, results := CollectTournaments(ctx, filteredFederations, dateFrom, dateTo, compType)
 
-	for i := 0; i < len(filteredFederations); i++ {
-		wg.Add(1)
-		go func(fed models.Federation) {
-			defer wg.Done()
-
-			var tournaments []models.Tournament
-			if fed.ApiVersion == "old" {
-				tournaments = getTournamentsFromFederationOldApi(fed, dateFrom, dateTo, compType)
-			} else if fed.ApiVersion == "new" {
-				tournaments = getTournamentsFromFederationNewApi(fed, dateFrom, dateTo, compType)
-			}
-
-			if len(tournaments) > 0 {
-				mu.Lock()
-				total += len(tournaments)
-				mu.Unlock()
-			}
-		}(filteredFederations[i])
+	for _, res := range results {
+		if res.Err != nil {
+			logger.Warn("Warmup: federation %s reported an error: %v", res.Federation.Id, res.Err)
+		}
 	}
-	wg.Wait()
 
-	logger.Info("Warmup finished. Tournaments fetched: %d", total)
-	return total
+	logger.Info("Warmup finished. Tournaments fetched: %d", len(tournaments))
+
+	return len(tournaments)
 }

--- a/backend/pkg/util/util.go
+++ b/backend/pkg/util/util.go
@@ -5,11 +5,37 @@ import (
 	"strings"
 )
 
-func RemoveFormatFromString(input string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(input, "  ", ""), "\n", ""), "\t", "")
+// NormalizeWhitespace collapses every run of Unicode whitespace (spaces, tabs,
+// newlines, non-breaking spaces, ...) into a single ASCII space and trims the
+// result.
+//
+// Scraped markup frequently contains indentation, hard line breaks and
+// non-breaking spaces. Replacing separators with a single space (instead of
+// deleting them) guarantees that words on different source lines never get
+// concatenated into one token.
+func NormalizeWhitespace(input string) string {
+	// Non-breaking spaces are not covered by unicode.IsSpace, so translate the
+	// common variants into ordinary spaces before splitting.
+	replacer := strings.NewReplacer(
+		"\u00a0", " ", // NO-BREAK SPACE (often decoded from &nbsp;)
+		"\u2007", " ", // FIGURE SPACE
+		"\u202f", " ", // NARROW NO-BREAK SPACE
+		"\ufeff", " ", // ZERO WIDTH NO-BREAK SPACE / BOM
+	)
+
+	return strings.Join(strings.Fields(replacer.Replace(input)), " ")
 }
 
-func Delete_empty(s []string) []string {
+// RemoveFormatFromString normalizes scraped text.
+//
+// Deprecated: use NormalizeWhitespace. Retained as a thin alias so existing
+// call sites keep compiling.
+func RemoveFormatFromString(input string) string {
+	return NormalizeWhitespace(input)
+}
+
+// DeleteEmpty returns a copy of s without empty strings.
+func DeleteEmpty(s []string) []string {
 	var r []string
 	for _, str := range s {
 		if str != "" {
@@ -19,10 +45,19 @@ func Delete_empty(s []string) []string {
 	return r
 }
 
+// Delete_empty returns a copy of s without empty strings.
+//
+// Deprecated: use DeleteEmpty.
+func Delete_empty(s []string) []string {
+	return DeleteEmpty(s)
+}
+
 func EnableCors(w *http.ResponseWriter) {
 	(*w).Header().Set("Access-Control-Allow-Origin", "*")
 }
 
+// GetStringInBetweenTwoString returns the substring between startS and endS.
+// found reports whether both delimiters were present.
 func GetStringInBetweenTwoString(str string, startS string, endS string) (result string, found bool) {
 	s := strings.Index(str, startS)
 	if s == -1 {

--- a/backend/pkg/util/util_test.go
+++ b/backend/pkg/util/util_test.go
@@ -1,0 +1,155 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeWhitespace(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"only whitespace", " \t\n\r ", ""},
+		{"single spaces preserved", "TC Blau Weiss", "TC Blau Weiss"},
+		{"double space collapsed", "TC  Karlsruhe", "TC Karlsruhe"},
+		// Regression: the previous implementation only replaced double spaces
+		// once, so odd/long runs left residue behind.
+		{"triple space collapsed", "TC   Karlsruhe", "TC Karlsruhe"},
+		{"long run collapsed", "TC          Karlsruhe", "TC Karlsruhe"},
+		{"five spaces collapsed", "a     b", "a b"},
+		// Regression: newlines/tabs used to be deleted, which glued together
+		// words that were only separated by a line break.
+		{"newline becomes space", "Herren\nEinzel", "Herren Einzel"},
+		{"tab becomes space", "Herren\tEinzel", "Herren Einzel"},
+		{"crlf becomes single space", "Herren\r\nEinzel", "Herren Einzel"},
+		{"mixed indentation", "\n\t  Damen   \n\t Doppel \n", "Damen Doppel"},
+		{"leading and trailing trimmed", "   TC Karlsruhe   ", "TC Karlsruhe"},
+		{"non breaking space", "LK\u00a012,3", "LK 12,3"},
+		{"narrow non breaking space", "LK\u202f12,3", "LK 12,3"},
+		{"figure space", "LK\u200712,3", "LK 12,3"},
+		{"byte order mark", "\ufeffTC Karlsruhe", "TC Karlsruhe"},
+		{"umlauts preserved", "  Tennisclub Grün-Weiß  Süd  ", "Tennisclub Grün-Weiß Süd"},
+		{"unicode text preserved", "Württembergischer  Tennisbund", "Württembergischer Tennisbund"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeWhitespace(tt.input); got != tt.want {
+				t.Errorf("NormalizeWhitespace(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeWhitespaceIsIdempotent(t *testing.T) {
+	inputs := []string{
+		"TC   Karlsruhe\n\tAbt. Tennis",
+		"  Damen\u00a0Doppel  ",
+		"plain",
+		"",
+	}
+
+	for _, in := range inputs {
+		once := NormalizeWhitespace(in)
+		twice := NormalizeWhitespace(once)
+		if once != twice {
+			t.Errorf("NormalizeWhitespace not idempotent for %q: %q vs %q", in, once, twice)
+		}
+	}
+}
+
+func TestRemoveFormatFromStringAliasesNormalizeWhitespace(t *testing.T) {
+	in := "TC   Karlsruhe\n\tTennis"
+	if got, want := RemoveFormatFromString(in), NormalizeWhitespace(in); got != want {
+		t.Errorf("RemoveFormatFromString(%q) = %q, want %q", in, got, want)
+	}
+}
+
+func TestGetStringInBetweenTwoString(t *testing.T) {
+	tests := []struct {
+		name      string
+		str       string
+		start     string
+		end       string
+		want      string
+		wantFound bool
+	}{
+		{
+			name:      "extracts organizer",
+			str:       "Veranstalter: TC Karlsruhe Austragungsort: Karlsruhe",
+			start:     "Veranstalter: ",
+			end:       " Austragungsort",
+			want:      "TC Karlsruhe",
+			wantFound: true,
+		},
+		{
+			name:      "missing start delimiter",
+			str:       "Austragungsort: Karlsruhe",
+			start:     "Veranstalter: ",
+			end:       " Austragungsort",
+			wantFound: false,
+		},
+		{
+			name:      "missing end delimiter",
+			str:       "Veranstalter: TC Karlsruhe",
+			start:     "Veranstalter: ",
+			end:       " Austragungsort",
+			wantFound: false,
+		},
+		{
+			name:      "empty match between delimiters",
+			str:       "Veranstalter:  Austragungsort",
+			start:     "Veranstalter: ",
+			end:       " Austragungsort",
+			want:      "",
+			wantFound: true,
+		},
+		{
+			name:      "uses first occurrence",
+			str:       "A:1 B: A:2 B:",
+			start:     "A:",
+			end:       " B:",
+			want:      "1",
+			wantFound: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, found := GetStringInBetweenTwoString(tt.str, tt.start, tt.end)
+			if found != tt.wantFound {
+				t.Fatalf("found = %v, want %v", found, tt.wantFound)
+			}
+			if found && got != tt.want {
+				t.Errorf("result = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeleteEmpty(t *testing.T) {
+	got := DeleteEmpty([]string{"a", "", "b", "", ""})
+	want := []string{"a", "b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("DeleteEmpty() = %#v, want %#v", got, want)
+	}
+
+	if got := DeleteEmpty([]string{"", ""}); len(got) != 0 {
+		t.Errorf("DeleteEmpty(all empty) = %#v, want empty", got)
+	}
+}
+
+func TestConcatMultipleSlices(t *testing.T) {
+	got := ConcatMultipleSlices([][]int{{1, 2}, nil, {3}, {}})
+	want := []int{1, 2, 3}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ConcatMultipleSlices() = %#v, want %#v", got, want)
+	}
+
+	if got := ConcatMultipleSlices[int](nil); len(got) != 0 {
+		t.Errorf("ConcatMultipleSlices(nil) = %#v, want empty", got)
+	}
+}


### PR DESCRIPTION
Fixes the six backend bugs identified in the code review and adds the test infrastructure that was missing to catch them.

## Bugs fixed

| Issue | Problem | Fix |
| --- | --- | --- |
| #29 | Concurrent `append` to a shared slice across federation goroutines | Per-goroutine result slots, merged in input order |
| #30 | No timeouts on any outbound request or either HTTP server | Shared bounded clients, request contexts, server timeouts |
| #31 | Nominatim called without `User-Agent` and without rate limiting | Identifying agent + process-wide 1 req/s limiter |
| #32 | Failures cached under tournament ID, lookups under location key | One canonical key set for lookup, success and failure |
| #33 | `maxResults=100` fetched once, larger result sets truncated | Pagination with dedup and a page ceiling |
| #34 | Whitespace collapsed in one pass; newlines deleted | `strings.Fields`-based normalization |

### The data race was real, not theoretical

The regression test runs 12 federations returning 25 tournaments each. Against the previous implementation it fails reproducibly under `-race`:

```
WARNING: DATA RACE  (x6)
--- FAIL: TestEndToEndConcurrentFederationsAreRaceFree
    e2e_test.go:466: got 275 tournaments, want 300
```

25 tournaments silently disappeared. With the fix it returns 300 every time.

### Additional issues found while fixing the above

* The in-memory geocoding caches were plain maps written from one goroutine per federation — a second data race that could abort the process with `concurrent map writes`. They are now mutex-guarded.
* Cache statistics and cleanup only ever looked at the tournament map, so location and organizer entries were never counted or pruned.
* The geocoding query replaced spaces with `+` manually, which mis-encoded umlauts. It now uses `url.Values`.
* The old API payload had the same problem with the `+` in competition types.
* A panic in one federation parser took down the whole request; it is now recovered and reported per federation.

## Tests

There were no Go tests before this PR. Now:

* **Parser fixtures** — `backend/pkg/tournament/testdata/` holds sanitized HTML for both API flavours, including the WTB `h2` and RLP `h3` title variants, continuation rows, `&nbsp;` LK placeholders and malformed input.
* **End-to-end tests** — federation sites *and* Nominatim are mocked with `httptest` servers. They cover pagination across three pages, partial federation failure, deterministic ordering regardless of response latency, context cancellation on a stalled upstream, and that cache hits never reach the network.
* **Geocoder tests** — assert the `User-Agent`, the enforced request spacing, error handling for 500/429/invalid-JSON/HTML responses, and that the backoff both suppresses retries and clears after a success.
* **No network access required.** Everything is mocked, so CI runs offline and deterministically.

Coverage in the touched packages: `tournament` 88.6%, `util` 92.6%, `ratelimit` 95.8%, `openstreetmap` 61.3%.

## CI

The workflow previously only compiled the binary. It now runs a test job before build/deploy that fails on gofmt violations, an untidy `go.mod`, `go vet` findings, test failures or data races. Deploy depends on it, so a red test blocks the release.

## Notes for review

* `RemoveFormatFromString` and `Delete_empty` are kept as deprecated aliases, so no call sites break.
* Behaviour is configurable via `TTF_USER_AGENT`, `TTF_NOMINATIM_URL`, `TTF_NOMINATIM_INTERVAL_MS` and the timeout variables — documented in the README. `TTF_NOMINATIM_URL` also makes pointing at a self-hosted Nominatim instance straightforward.
* The parsers are now split into fetch and parse halves, which is also the groundwork for the result cache in #35.

Closes #29, closes #30, closes #31, closes #32, closes #33, closes #34, closes #36
