### PR TITLE
feat: fix geocoding accuracy and add six more federations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,20 @@
 
 * Currently supported tennis federations:
   * [Badischer Tennis Verband (BAD)](https://www.badischertennisverband.de/)
+  * [Hamburger Tennisverband (HAM)](https://www.hamburger-tennisverband.de)
   * [Hessischer Tennis Verband (HTV)](https://www.htv-tennis.de/)
   * [Rheinland-Pfälzischer Tennis Verband (RPTV)](https://www.rlp-tennis.de/)
+  * [Saarländischer Tennisbund (STB)](https://www.stb-tennis.de)
   * [Sächsischer Tennis Verband (STV)](https://www.stv-tennis.de)
   * [Tennisverband Mecklenburg-Vorpommern (TMV)](https://www.tennis-mv.de)
+  * [Tennisverband Niedersachsen-Bremen (TNB)](https://www.tnb-tennis.de)
   * [Tennisverband Sachsen-Anhalt (TSA)](https://www.tennis-tsa.de)
   * [Thüringer Tennis-Verband (TTV)](https://www.ttv-tennis.de)
+  * [Tennis-Verband Berlin-Brandenburg (TVBB)](https://www.tvbb.de)
+  * [Tennisverband Mittelrhein (TVM)](https://www.tvm-tennis.de)
   * [Tennis-Verband Niederrhein (TVN)](https://www.tvn-tennis.de)
   * [Württembergischer Tennis Bund (WTB)](https://www.wtb-tennis.de/)
+  * [Westfälischer Tennis-Verband (WTV)](https://www.wtv.de)
 * Helps you finding the tournaments around you
 * Lets you filter tournaments by date, competition type, and federation
 * Short link to the official Tournament at [tennis.de](https://spieler.tennis.de/web/guest/turniersuche) in order to sign up for the tournament
@@ -35,14 +41,9 @@
 ### Soon
 
 * Support for more tennis federations:
-  * [Bayerischer Tennis Verband (BTV)](https://www.btv.de)
-  * [Tennis-Verband Berlin-Brandenburg (TVBB)](https://www.tvbb.de)
-  * [Hamburger Tennis-Verband](https://www.hamburger-tennisverband.de)
-  * [Tennisverband Mittelrhein (TVM)](https://www.tvm-tennis.de)
-  * [Tennisverband Niedersachsen-Bremen (TNB)](https://www.tnb-tennis.de)
-  * [Saarländischer Tennisbund (STB)](https://www.stb-tennis.de)
+  * [Bayerischer Tennis Verband (BTV)](https://www.btv.de) — no longer served by
+    liga.nu, so it needs its own parser
   * [Tennisverband Schleswig-Holstein (TSH)](https://www.tennis.sh)
-  * [Westfälischer Tennis-Verband (WTV)](https://www.wtv.de)
 * Store favorite tournaments (locally)
 
 ## Backend Development
@@ -96,6 +97,7 @@ full output while debugging a failure.
 | `TTF_USER_AGENT` | `TennisTournamentFinder/1.0 (+repo URL)` | `User-Agent` sent upstream. Forks should set their own contact details. |
 | `TTF_NOMINATIM_URL` | `https://nominatim.openstreetmap.org/search.php` | Geocoding endpoint. Point this at a self-hosted Nominatim instance if you need higher throughput. |
 | `TTF_NOMINATIM_INTERVAL_MS` | `1000` | Minimum spacing between uncached geocoding requests. Do not lower this for the shared public instance. |
+| `TTF_CLUB_LOCATIONS` | *(embedded file)* | Path to a custom club location override file. |
 
 #### External service usage
 
@@ -105,6 +107,50 @@ agent above and are serialized process-wide by a rate limiter. Cached lookups
 never reach the network, so they do not consume that budget. See the
 [Nominatim usage policy](https://operations.osmfoundation.org/policies/nominatim/)
 before raising the request rate.
+
+### Geocoding and map pins
+
+Federations publish only a club name, never a postal address, so the venue's
+city has to be derived from that name. Resolution happens in this order:
+
+1. **Curated overrides** — `backend/pkg/clublocations/data/club-locations.json`
+2. **Name heuristics** — `backend/pkg/placename`
+3. **Federation default coordinates** — last resort; several tournaments then
+   share one marker
+
+#### Fixing a wrong map pin
+
+If a tournament shows up in the wrong place, add an entry to
+`backend/pkg/clublocations/data/club-locations.json`. No code change is needed:
+
+```json
+{
+  "contains": "Lohausener",
+  "city": "Düsseldorf",
+  "state": "Nordrhein-Westfalen",
+  "note": "Lohausen is a district of Düsseldorf; not derivable from the name."
+}
+```
+
+* Use `match` for an exact club name or `contains` for a substring.
+* Matching ignores case, punctuation, umlaut spelling and extra spaces.
+* Prefer `city` (it gets geocoded). Use `lat`/`lon` only when even the city is
+  ambiguous.
+* Exact matches beat `contains`; among `contains` entries the longest wins.
+* `note` is required by the tests — explain why the automatic extraction fails.
+
+A different file can be supplied with `TTF_CLUB_LOCATIONS`.
+
+#### Measuring accuracy
+
+`cmd/geobench` resolves a benchmark set of real club names against a live
+Nominatim instance and reports the hit rate. It performs rate-limited network
+requests, so it is a manual tool and is never run by CI:
+
+```bash
+cd backend
+go run ./cmd/geobench      # add -v for coordinates and matched place names
+```
 
 ### Log Level Configuration
 

--- a/backend/cmd/fedcheck/main.go
+++ b/backend/cmd/fedcheck/main.go
@@ -1,0 +1,99 @@
+// Command fedcheck performs a live smoke test against every configured
+// federation and reports how many tournaments each one returns.
+//
+// It exists to catch a federation whose endpoint or markup changed, which
+// otherwise surfaces only as silently missing tournaments. Like geobench it
+// makes real network requests and is never run by CI.
+//
+// Usage:
+//
+//	go run ./cmd/fedcheck                 # next 60 days, all federations
+//	go run ./cmd/fedcheck -days 30        # shorter window
+//	go run ./cmd/fedcheck -fed TNB,WTV    # only some federations
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/timoknapp/tennis-tournament-finder/pkg/federation"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/tournament"
+)
+
+func main() {
+	days := flag.Int("days", 60, "size of the date window in days")
+	feds := flag.String("fed", "", "comma-separated federation IDs (default: all)")
+	geocode := flag.Bool("geocode", false, "also resolve coordinates (slow, rate limited)")
+	flag.Parse()
+
+	logger.SetLogLevel(logger.ErrorLevel)
+
+	if !*geocode {
+		// Geocoding is rate limited to 1 req/s, which would dominate the
+		// runtime of a smoke test. Point it at a closed port and remove the
+		// spacing so lookups fail instantly instead of throttling the run.
+		os.Setenv("TTF_NOMINATIM_URL", "http://127.0.0.1:9/disabled")
+		os.Setenv("TTF_NOMINATIM_INTERVAL_MS", "0")
+		os.Setenv("TTF_GEOCODING_TIMEOUT_SECONDS", "1")
+	}
+
+	tmp, err := os.MkdirTemp("", "fedcheck")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to create temp dir:", err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(tmp)
+	os.Setenv("TTF_CACHE_PATH", tmp+"/cache.bolt")
+
+	now := time.Now()
+	dateFrom := now.Format("02.01.2006")
+	dateTo := now.AddDate(0, 0, *days).Format("02.01.2006")
+
+	all := federation.GetFederations()
+	selected := tournament.FilterFederations(all, *feds)
+
+	fmt.Printf("Window: %s .. %s\n\n", dateFrom, dateTo)
+	fmt.Printf("%-6s %-38s %-10s %s\n", "ID", "NAME", "COUNT", "STATUS")
+	fmt.Println(strings.Repeat("-", 90))
+
+	var failures, empty int
+
+	for _, fed := range selected {
+		start := time.Now()
+		tournaments, results := tournament.CollectTournaments(
+			context.Background(), []models.Federation{fed}, dateFrom, dateTo, "")
+
+		status := "ok"
+		if err := results[0].Err; err != nil {
+			status = "ERROR: " + truncate(err.Error(), 40)
+			failures++
+		} else if len(tournaments) == 0 {
+			status = "EMPTY (check parser)"
+			empty++
+		}
+
+		fmt.Printf("%-6s %-38s %-10d %s  (%.1fs)\n",
+			fed.Id, truncate(fed.Name, 37), len(tournaments), status, time.Since(start).Seconds())
+	}
+
+	fmt.Println(strings.Repeat("-", 90))
+	fmt.Printf("%d federations, %d errors, %d empty\n", len(selected), failures, empty)
+
+	if failures > 0 || empty > 0 {
+		os.Exit(1)
+	}
+}
+
+func truncate(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n-1]) + "…"
+}

--- a/backend/cmd/geobench/main.go
+++ b/backend/cmd/geobench/main.go
@@ -1,0 +1,154 @@
+// Command geobench measures geocoding accuracy against a live Nominatim
+// instance using the same code path the service uses.
+//
+// It is a manual tool, not part of the test suite: it performs real network
+// requests and is therefore rate limited and slow. CI never runs it.
+//
+// Usage:
+//
+//	go run ./cmd/geobench            # run the built-in benchmark set
+//	go run ./cmd/geobench -v         # also print every resolved location
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/openstreetmap"
+)
+
+// benchCase is one club whose expected city is known.
+type benchCase struct {
+	organizer string
+	location  string // as published by the federation; often empty
+	state     string
+	states    []string
+	wantCity  string
+}
+
+// cases covers the failure modes that motivated the rewrite: adjectival club
+// names, multi-word places, districts, hyphenated compounds and multi-state
+// federations.
+var cases = []benchCase{
+	// Plain names.
+	{organizer: "TC Rot-Weiß Karlsruhe e.V.", state: "Baden-Württemberg", wantCity: "Karlsruhe"},
+	{organizer: "TSG Weinheim Abt. Tennis", state: "Baden-Württemberg", wantCity: "Weinheim"},
+	{organizer: "SV Blau-Weiß Bühlertal", state: "Baden-Württemberg", wantCity: "Bühlertal"},
+	{organizer: "TV 1877 Ettlingen", state: "Baden-Württemberg", wantCity: "Ettlingen"},
+	{organizer: "TC Neckargemünd", state: "Baden-Württemberg", wantCity: "Neckargemünd"},
+	{organizer: "TC Blau-Weiß Neuss", state: "Nordrhein-Westfalen", wantCity: "Neuss"},
+	{organizer: "SV Grün-Weiß Erfurt", state: "Thüringen", wantCity: "Erfurt"},
+	{organizer: "TC Weimar 1912", state: "Thüringen", wantCity: "Weimar"},
+	{organizer: "TuS Griesheim", state: "Hessen", wantCity: "Griesheim"},
+
+	// Adjectival club names.
+	{organizer: "Heidelberger Tennis-Club 1890 e.V.", state: "Baden-Württemberg", wantCity: "Heidelberg"},
+	{organizer: "Eppelheimer Tennis-Club", state: "Baden-Württemberg", wantCity: "Eppelheim"},
+	{organizer: "Karbener Sportverein", state: "Hessen", wantCity: "Karben"},
+	{organizer: "Ratinger Tennisclub Grün-Weiss", state: "Nordrhein-Westfalen", wantCity: "Ratingen"},
+
+	// Multi-word place names.
+	{organizer: "TC Bad Schönborn", state: "Baden-Württemberg", wantCity: "Bad Schönborn"},
+	{organizer: "TC Bad Homburg v.d.H.", state: "Hessen", wantCity: "Bad Homburg"},
+
+	// Districts: only solvable via the override file.
+	{organizer: "TC Grün-Weiß Mannheim-Neckarau", state: "Baden-Württemberg", wantCity: "Mannheim"},
+	{organizer: "TG Frankfurt-Höchst", state: "Hessen", wantCity: "Frankfurt"},
+	{organizer: "Unterbarmer Tennisclub", state: "Nordrhein-Westfalen", wantCity: "Wuppertal"},
+	{organizer: "Lohausener Sport-Verein", state: "Nordrhein-Westfalen", wantCity: "Düsseldorf"},
+	{organizer: "Post Südstadt Karlsruhe", state: "Baden-Württemberg", wantCity: "Karlsruhe"},
+
+	// Multi-state federations: the tournament sits in the secondary state.
+	{organizer: "TC Bad Saarow", state: "Berlin",
+		states: []string{"Berlin", "Brandenburg"}, wantCity: "Bad Saarow"},
+	{organizer: "Bremer Tennisclub", state: "Niedersachsen",
+		states: []string{"Niedersachsen", "Bremen"}, wantCity: "Bremen"},
+}
+
+func main() {
+	verbose := flag.Bool("v", false, "print every resolved location")
+	flag.Parse()
+
+	// Keep the output readable; the benchmark reports its own results.
+	logger.SetLogLevel(logger.ErrorLevel)
+
+	// Use a throwaway cache so results are not served from a previous run.
+	tmp, err := os.MkdirTemp("", "geobench")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to create temp dir:", err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(tmp)
+
+	os.Setenv("TTF_CACHE_PATH", tmp+"/cache.bolt")
+	openstreetmap.InitCache()
+	defer openstreetmap.CloseCache()
+
+	var hits int
+	fmt.Printf("%-40s %-20s %-8s %s\n", "ORGANIZER", "EXPECTED", "RESULT", "RESOLVED")
+	fmt.Println(strings.Repeat("-", 110))
+
+	for _, c := range cases {
+		fed := models.Federation{
+			State:  c.state,
+			States: c.states,
+		}
+		tournament := models.Tournament{
+			Id:        c.organizer,
+			Organizer: c.organizer,
+			Location:  c.location,
+		}
+
+		geo := openstreetmap.GetGeocoordinatesForFederation(fed, tournament)
+
+		resolved := geo.DisplayName
+		if resolved == "" {
+			resolved = "(nothing)"
+		}
+
+		// Verify against the structured settlement name. Matching the free-text
+		// display name would count "Ratinger Straße, Düsseldorf" as a hit for
+		// Ratingen, which is exactly the wrong-pin bug this benchmark tracks.
+		place := geo.Address.Place()
+		ok := geo.Lat != "" && place != "" && strings.Contains(
+			strings.ToLower(place), strings.ToLower(firstWord(c.wantCity)))
+		if ok {
+			hits++
+		}
+
+		status := "MISS"
+		if ok {
+			status = "ok"
+		}
+
+		fmt.Printf("%-40s %-20s %-8s %s\n",
+			truncate(c.organizer, 39), truncate(c.wantCity, 19), status, truncate(place+" | "+resolved, 45))
+
+		if *verbose && geo.Lat != "" {
+			fmt.Printf("%-40s   lat=%s lon=%s place=%q state=%s\n",
+				"", geo.Lat, geo.Lon, place, geo.Address.State)
+		}
+	}
+
+	fmt.Println(strings.Repeat("-", 110))
+	fmt.Printf("Accuracy: %d/%d = %.0f%%\n", hits, len(cases), 100*float64(hits)/float64(len(cases)))
+}
+
+func firstWord(s string) string {
+	if i := strings.IndexByte(s, ' '); i > 0 {
+		return s[:i]
+	}
+	return s
+}
+
+func truncate(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n-1]) + "…"
+}

--- a/backend/pkg/addressprovider/addressprovider.go
+++ b/backend/pkg/addressprovider/addressprovider.go
@@ -1,0 +1,114 @@
+// Package addressprovider defines how a tournament's venue location is
+// resolved, and in which order the available sources are consulted.
+//
+// Federations publish only a club name, so the location has to be derived.
+// Several sources are possible and they differ in cost and reliability, hence
+// the explicit interface and precedence order:
+//
+//  1. Curated overrides   - free, exact, manually maintained
+//  2. Name heuristics     - free, ~good, the default
+//  3. Upstream detail page - authoritative but slow, rate limited and fragile
+//
+// Only the first two are enabled by default. The third is opt-in because it
+// depends on an undocumented widget protocol that can change without notice;
+// see issue #55.
+package addressprovider
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrNotFound indicates a provider has no answer for this tournament. It is a
+// normal outcome, not a failure, and simply moves resolution to the next
+// provider.
+var ErrNotFound = errors.New("address not found")
+
+// Request describes what should be resolved.
+type Request struct {
+	TournamentID string
+	// Organizer is the club name as published by the federation.
+	Organizer string
+	// Location is the venue string when the federation publishes one.
+	Location string
+	// AcceptedStates limits results to the federation's coverage area.
+	AcceptedStates []string
+}
+
+// Address is a resolved venue location. Providers fill in what they know;
+// Street and PostalCode are only available from the upstream detail source.
+type Address struct {
+	// Place is the settlement name, always set on success.
+	Place string
+	// Street and PostalCode are optional and may be empty.
+	Street     string
+	PostalCode string
+	// State is the federal state the place belongs to.
+	State string
+	// Lat/Lon are set when the provider resolved coordinates itself. When
+	// empty, the caller geocodes Place.
+	Lat string
+	Lon string
+	// Source names the provider that produced this result, for diagnostics.
+	Source string
+}
+
+// HasCoordinates reports whether the address already carries coordinates.
+func (a Address) HasCoordinates() bool {
+	return a.Lat != "" && a.Lon != ""
+}
+
+// Provider resolves a tournament's venue address.
+//
+// Implementations must respect ctx, must not block indefinitely, and must
+// return ErrNotFound rather than a zero Address when they have no answer.
+type Provider interface {
+	// Name identifies the provider in logs and diagnostics.
+	Name() string
+	// Resolve returns the venue address, or ErrNotFound.
+	Resolve(ctx context.Context, req Request) (Address, error)
+}
+
+// Chain queries providers in order and returns the first successful result.
+//
+// A provider returning an error other than ErrNotFound does not abort the
+// chain: a broken optional source must never prevent a cheaper one from
+// answering. The last non-ErrNotFound error is returned when nothing resolves,
+// so failures stay visible.
+type Chain struct {
+	Providers []Provider
+	// OnError is called for non-ErrNotFound failures, for logging/metrics.
+	OnError func(provider string, err error)
+}
+
+// Resolve walks the chain in order.
+func (c Chain) Resolve(ctx context.Context, req Request) (Address, error) {
+	var lastErr error
+
+	for _, p := range c.Providers {
+		if err := ctx.Err(); err != nil {
+			return Address{}, err
+		}
+
+		addr, err := p.Resolve(ctx, req)
+		switch {
+		case err == nil:
+			if addr.Source == "" {
+				addr.Source = p.Name()
+			}
+			return addr, nil
+		case errors.Is(err, ErrNotFound):
+			// Expected: try the next provider.
+		default:
+			lastErr = err
+			if c.OnError != nil {
+				c.OnError(p.Name(), err)
+			}
+		}
+	}
+
+	if lastErr != nil {
+		return Address{}, lastErr
+	}
+	return Address{}, ErrNotFound
+}

--- a/backend/pkg/addressprovider/addressprovider_test.go
+++ b/backend/pkg/addressprovider/addressprovider_test.go
@@ -1,0 +1,246 @@
+package addressprovider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/timoknapp/tennis-tournament-finder/pkg/clublocations"
+)
+
+// stubProvider is a configurable Provider for exercising the chain.
+type stubProvider struct {
+	name    string
+	addr    Address
+	err     error
+	calls   int
+	blockCh chan struct{}
+}
+
+func (s *stubProvider) Name() string { return s.name }
+
+func (s *stubProvider) Resolve(ctx context.Context, req Request) (Address, error) {
+	s.calls++
+	if s.blockCh != nil {
+		select {
+		case <-s.blockCh:
+		case <-ctx.Done():
+			return Address{}, ctx.Err()
+		}
+	}
+	return s.addr, s.err
+}
+
+func TestChainReturnsFirstSuccess(t *testing.T) {
+	first := &stubProvider{name: "overrides", err: ErrNotFound}
+	second := &stubProvider{name: "heuristic", addr: Address{Place: "Karlsruhe"}}
+	third := &stubProvider{name: "detail", addr: Address{Place: "Never reached"}}
+
+	chain := Chain{Providers: []Provider{first, second, third}}
+
+	got, err := chain.Resolve(context.Background(), Request{Organizer: "TC Karlsruhe"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if got.Place != "Karlsruhe" {
+		t.Errorf("Place = %q, want Karlsruhe", got.Place)
+	}
+	// The source is filled in automatically for diagnostics.
+	if got.Source != "heuristic" {
+		t.Errorf("Source = %q, want heuristic", got.Source)
+	}
+	if third.calls != 0 {
+		t.Errorf("later provider was called %d times, want 0", third.calls)
+	}
+}
+
+// TestChainContinuesAfterProviderError is the important resilience property:
+// the optional upstream lookup is the most likely to break, and it must never
+// stop a cheaper provider from answering.
+func TestChainContinuesAfterProviderError(t *testing.T) {
+	boom := errors.New("upstream changed its markup")
+
+	broken := &stubProvider{name: "detail", err: boom}
+	working := &stubProvider{name: "heuristic", addr: Address{Place: "Karlsruhe"}}
+
+	var reported []string
+	chain := Chain{
+		Providers: []Provider{broken, working},
+		OnError: func(provider string, err error) {
+			reported = append(reported, provider)
+		},
+	}
+
+	got, err := chain.Resolve(context.Background(), Request{})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want the working provider to answer", err)
+	}
+	if got.Place != "Karlsruhe" {
+		t.Errorf("Place = %q, want Karlsruhe", got.Place)
+	}
+
+	// The failure must still be visible rather than silently swallowed.
+	if len(reported) != 1 || reported[0] != "detail" {
+		t.Errorf("reported errors = %v, want [detail]", reported)
+	}
+}
+
+func TestChainReturnsNotFoundWhenNoProviderAnswers(t *testing.T) {
+	chain := Chain{Providers: []Provider{
+		&stubProvider{name: "a", err: ErrNotFound},
+		&stubProvider{name: "b", err: ErrNotFound},
+	}}
+
+	_, err := chain.Resolve(context.Background(), Request{})
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestChainSurfacesLastRealError(t *testing.T) {
+	boom := errors.New("timeout")
+
+	chain := Chain{Providers: []Provider{
+		&stubProvider{name: "a", err: ErrNotFound},
+		&stubProvider{name: "b", err: boom},
+	}}
+
+	_, err := chain.Resolve(context.Background(), Request{})
+	if !errors.Is(err, boom) {
+		t.Errorf("error = %v, want the underlying failure", err)
+	}
+}
+
+func TestEmptyChainReturnsNotFound(t *testing.T) {
+	_, err := Chain{}.Resolve(context.Background(), Request{})
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestChainRespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	provider := &stubProvider{name: "a", addr: Address{Place: "Karlsruhe"}}
+	chain := Chain{Providers: []Provider{provider}}
+
+	if _, err := chain.Resolve(ctx, Request{}); err == nil {
+		t.Error("Resolve() with a cancelled context returned nil error")
+	}
+	if provider.calls != 0 {
+		t.Errorf("provider was called %d times despite cancellation", provider.calls)
+	}
+}
+
+func TestAddressHasCoordinates(t *testing.T) {
+	tests := []struct {
+		name string
+		addr Address
+		want bool
+	}{
+		{"both set", Address{Lat: "49.0", Lon: "8.4"}, true},
+		{"only lat", Address{Lat: "49.0"}, false},
+		{"only lon", Address{Lon: "8.4"}, false},
+		{"neither", Address{Place: "Karlsruhe"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.addr.HasCoordinates(); got != tt.want {
+				t.Errorf("HasCoordinates() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOverrideProviderResolvesCuratedEntry(t *testing.T) {
+	table, err := clublocations.Parse([]byte(`{"overrides":[
+		{"match":"Lohausener Sport-Verein","city":"Düsseldorf","state":"Nordrhein-Westfalen","note":"district"}
+	]}`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	p := OverrideProvider{Table: table}
+
+	got, err := p.Resolve(context.Background(), Request{Organizer: "Lohausener Sport-Verein"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if got.Place != "Düsseldorf" || got.State != "Nordrhein-Westfalen" {
+		t.Errorf("got %+v, want the curated entry", got)
+	}
+	if got.Source != "overrides" {
+		t.Errorf("Source = %q, want overrides", got.Source)
+	}
+}
+
+func TestOverrideProviderReportsNotFound(t *testing.T) {
+	table, err := clublocations.Parse([]byte(`{"overrides":[]}`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	p := OverrideProvider{Table: table}
+
+	for _, organizer := range []string{"", "TC Unbekannt"} {
+		if _, err := p.Resolve(context.Background(), Request{Organizer: organizer}); !errors.Is(err, ErrNotFound) {
+			t.Errorf("Resolve(%q) error = %v, want ErrNotFound", organizer, err)
+		}
+	}
+}
+
+func TestHeuristicProviderPrefersPublishedLocation(t *testing.T) {
+	p := HeuristicProvider{}
+
+	got, err := p.Resolve(context.Background(), Request{
+		Location:  "Karlsruhe",
+		Organizer: "TC Irgendwas Anderes",
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if got.Place != "Karlsruhe" {
+		t.Errorf("Place = %q, want the published location to win", got.Place)
+	}
+}
+
+func TestHeuristicProviderDerivesFromClubName(t *testing.T) {
+	p := HeuristicProvider{}
+
+	got, err := p.Resolve(context.Background(), Request{Organizer: "TC Blau-Weiß Neuss"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if got.Place != "Neuss" {
+		t.Errorf("Place = %q, want Neuss", got.Place)
+	}
+}
+
+func TestHeuristicProviderReportsNotFoundForUnusableInput(t *testing.T) {
+	p := HeuristicProvider{}
+
+	for _, organizer := range []string{"", "e.V.", "TC", "1890"} {
+		if _, err := p.Resolve(context.Background(), Request{Organizer: organizer}); !errors.Is(err, ErrNotFound) {
+			t.Errorf("Resolve(%q) error = %v, want ErrNotFound", organizer, err)
+		}
+	}
+}
+
+// TestDefaultChainPrefersOverrides documents the production precedence order.
+func TestDefaultChainPrefersOverrides(t *testing.T) {
+	chain := Default()
+
+	// "Lohausener Sport-Verein" is in the shipped override file and cannot be
+	// derived from its name, so the override must win.
+	got, err := chain.Resolve(context.Background(), Request{
+		Organizer: "Lohausener Sport-Verein",
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if got.Source != "overrides" || got.Place != "Düsseldorf" {
+		t.Errorf("got %+v, want the curated override to win", got)
+	}
+}

--- a/backend/pkg/addressprovider/providers.go
+++ b/backend/pkg/addressprovider/providers.go
@@ -1,0 +1,83 @@
+package addressprovider
+
+import (
+	"context"
+
+	"github.com/timoknapp/tennis-tournament-finder/pkg/clublocations"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/placename"
+)
+
+// OverrideProvider resolves venues from the curated club-locations file.
+// It is the highest-precedence source: an entry there is a deliberate manual
+// correction and must win over any heuristic.
+type OverrideProvider struct {
+	// Table defaults to the process-wide table when nil.
+	Table *clublocations.Table
+}
+
+func (p OverrideProvider) Name() string { return "overrides" }
+
+func (p OverrideProvider) Resolve(_ context.Context, req Request) (Address, error) {
+	table := p.Table
+	if table == nil {
+		t, err := clublocations.Default()
+		if err != nil {
+			return Address{}, err
+		}
+		table = t
+	}
+
+	if req.Organizer == "" {
+		return Address{}, ErrNotFound
+	}
+
+	o, ok := table.Lookup(req.Organizer)
+	if !ok {
+		return Address{}, ErrNotFound
+	}
+
+	return Address{
+		Place:  o.City,
+		State:  o.State,
+		Lat:    o.Lat,
+		Lon:    o.Lon,
+		Source: p.Name(),
+	}, nil
+}
+
+// HeuristicProvider derives a settlement name from the published location or
+// the club name. It is the default source and never performs I/O.
+//
+// It returns the single best candidate; callers that want to try alternatives
+// should use placename.Candidates directly.
+type HeuristicProvider struct{}
+
+func (p HeuristicProvider) Name() string { return "heuristic" }
+
+func (p HeuristicProvider) Resolve(_ context.Context, req Request) (Address, error) {
+	if req.Location != "" {
+		return Address{Place: req.Location, Source: p.Name()}, nil
+	}
+
+	candidates := placename.Candidates(req.Organizer)
+	if len(candidates) == 0 {
+		return Address{}, ErrNotFound
+	}
+
+	return Address{Place: candidates[0], Source: p.Name()}, nil
+}
+
+// Default returns the provider chain used in production: curated overrides
+// first, then the name heuristic.
+//
+// The upstream detail lookup (issue #55) is deliberately absent. It depends on
+// an undocumented widget protocol, so it stays opt-in until it can be driven
+// reliably and cached per club.
+func Default() Chain {
+	return Chain{
+		Providers: []Provider{
+			OverrideProvider{},
+			HeuristicProvider{},
+		},
+	}
+}

--- a/backend/pkg/clublocations/clublocations.go
+++ b/backend/pkg/clublocations/clublocations.go
@@ -1,0 +1,228 @@
+// Package clublocations loads manually curated location overrides for tennis
+// clubs whose venue cannot be derived from their name.
+//
+// Federations publish only a club name, and some of those ("Lohausener
+// Sport-Verein" for a club in Düsseldorf) simply do not contain the city.
+// Rather than growing special cases in code, those live in a JSON file that
+// can be corrected without a rebuild.
+package clublocations
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"unicode"
+)
+
+// defaultOverrides is compiled into the binary so the service works without
+// any external file. TTF_CLUB_LOCATIONS can point at a different file.
+//
+//go:embed data/club-locations.json
+var defaultOverrides []byte
+
+// Override is a single manual mapping.
+type Override struct {
+	// Match compares against the whole normalized organizer string.
+	Match string `json:"match,omitempty"`
+	// Contains matches when the normalized organizer contains it.
+	Contains string `json:"contains,omitempty"`
+
+	// City is geocoded like any other place name (preferred).
+	City string `json:"city,omitempty"`
+	// State optionally restricts the geocoding result.
+	State string `json:"state,omitempty"`
+	// Lat/Lon pin the location explicitly when even the city is ambiguous.
+	Lat string `json:"lat,omitempty"`
+	Lon string `json:"lon,omitempty"`
+
+	Note string `json:"note,omitempty"`
+}
+
+// HasCoordinates reports whether the override pins exact coordinates.
+func (o Override) HasCoordinates() bool {
+	return o.Lat != "" && o.Lon != ""
+}
+
+type file struct {
+	Overrides []Override `json:"overrides"`
+}
+
+// Table holds the loaded overrides in lookup-friendly form.
+type Table struct {
+	exact     map[string]Override
+	exactFlat map[string]Override // same keys with spaces removed
+	contains  []Override          // sorted by descending pattern length
+}
+
+var (
+	once      sync.Once
+	loaded    *Table
+	loadedErr error
+)
+
+// Default returns the process-wide override table, loading it on first use.
+// A malformed or missing file is logged by the caller and treated as empty, so
+// bad data can never take the service down.
+func Default() (*Table, error) {
+	once.Do(load)
+	return loaded, loadedErr
+}
+
+// ResetForTest clears the memoized table so tests can load a different file.
+// It is not safe for concurrent use and is intended for tests only.
+func ResetForTest() {
+	once = sync.Once{}
+	loaded = nil
+	loadedErr = nil
+}
+
+func load() {
+	raw := defaultOverrides
+
+	if path := os.Getenv("TTF_CLUB_LOCATIONS"); path != "" {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			loadedErr = fmt.Errorf("failed to read %s: %w", path, err)
+			loaded = &Table{}
+			return
+		}
+		raw = data
+	}
+
+	table, err := Parse(raw)
+	if err != nil {
+		loadedErr = err
+		loaded = &Table{}
+		return
+	}
+	loaded = table
+}
+
+// Parse builds a lookup table from JSON.
+func Parse(raw []byte) (*Table, error) {
+	var f file
+	if err := json.Unmarshal(raw, &f); err != nil {
+		return nil, fmt.Errorf("failed to parse club location overrides: %w", err)
+	}
+
+	t := &Table{
+		exact:     make(map[string]Override),
+		exactFlat: make(map[string]Override),
+	}
+
+	for i, o := range f.Overrides {
+		if o.Match == "" && o.Contains == "" {
+			return nil, fmt.Errorf("override %d has neither 'match' nor 'contains'", i)
+		}
+		if o.City == "" && !o.HasCoordinates() {
+			return nil, fmt.Errorf("override %d (%q) has neither 'city' nor lat/lon",
+				i, o.Match+o.Contains)
+		}
+		if (o.Lat == "") != (o.Lon == "") {
+			return nil, fmt.Errorf("override %d (%q) must set both lat and lon or neither",
+				i, o.Match+o.Contains)
+		}
+
+		if o.Match != "" {
+			norm := Normalize(o.Match)
+			t.exact[norm] = o
+			t.exactFlat[collapse(norm)] = o
+		} else {
+			t.contains = append(t.contains, o)
+		}
+	}
+
+	// Longest pattern first so a specific rule beats a generic one.
+	for i := 1; i < len(t.contains); i++ {
+		for j := i; j > 0 &&
+			len(t.contains[j].Contains) > len(t.contains[j-1].Contains); j-- {
+			t.contains[j], t.contains[j-1] = t.contains[j-1], t.contains[j]
+		}
+	}
+
+	return t, nil
+}
+
+// Lookup returns the override for an organizer, if any.
+func (t *Table) Lookup(organizer string) (Override, bool) {
+	if t == nil {
+		return Override{}, false
+	}
+
+	norm := Normalize(organizer)
+	if norm == "" {
+		return Override{}, false
+	}
+
+	// Compare without spaces as well, so a name written "Rot-Weiß" still
+	// matches one written "Rot Weiß".
+	flat := collapse(norm)
+
+	if o, ok := t.exact[norm]; ok {
+		return o, true
+	}
+	if o, ok := t.exactFlat[flat]; ok {
+		return o, true
+	}
+
+	for _, o := range t.contains {
+		if strings.Contains(flat, collapse(Normalize(o.Contains))) {
+			return o, true
+		}
+	}
+
+	return Override{}, false
+}
+
+// Len reports how many overrides are loaded.
+func (t *Table) Len() int {
+	if t == nil {
+		return 0
+	}
+	return len(t.exact) + len(t.contains)
+}
+
+// Normalize prepares a club name for comparison: lowercased, umlauts folded,
+// punctuation removed and whitespace collapsed, so "TC Rot-Weiß Karlsruhe e.V."
+// and "TC Rot Weiss  Karlsruhe eV" compare equal.
+func Normalize(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+
+	prevSpace := true // trims leading space implicitly
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			// Fold German umlauts so both spellings match.
+			switch r {
+			case 'ß':
+				b.WriteString("ss")
+			case 'ä':
+				b.WriteString("a")
+			case 'ö':
+				b.WriteString("o")
+			case 'ü':
+				b.WriteString("u")
+			default:
+				b.WriteRune(r)
+			}
+			prevSpace = false
+		default:
+			if !prevSpace {
+				b.WriteRune(' ')
+				prevSpace = true
+			}
+		}
+	}
+
+	return strings.TrimSpace(b.String())
+}
+
+// collapse removes all spaces, so comparisons ignore where a name was split
+// into separate words ("Rot-Weiß" vs "Rot Weiß").
+func collapse(s string) string {
+	return strings.ReplaceAll(s, " ", "")
+}

--- a/backend/pkg/clublocations/clublocations_test.go
+++ b/backend/pkg/clublocations/clublocations_test.go
@@ -1,0 +1,252 @@
+package clublocations
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDefaultTableLoads(t *testing.T) {
+	table, err := Default()
+	if err != nil {
+		t.Fatalf("Default() error = %v", err)
+	}
+	if table.Len() == 0 {
+		t.Fatal("Default() returned an empty table; the embedded file should have entries")
+	}
+}
+
+// TestEmbeddedOverridesResolve guards the shipped data file: a typo in the
+// JSON would otherwise only surface as a wrong pin in production.
+func TestEmbeddedOverridesResolve(t *testing.T) {
+	table, err := Default()
+	if err != nil {
+		t.Fatalf("Default() error = %v", err)
+	}
+
+	tests := []struct {
+		organizer string
+		wantCity  string
+	}{
+		{"Lohausener Sport-Verein", "Düsseldorf"},
+		{"Unterbarmer Tennisclub", "Wuppertal"},
+		{"Post Südstadt Karlsruhe", "Karlsruhe"},
+		{"TG Frankfurt-Höchst", "Frankfurt am Main"},
+		{"TC Grün-Weiß Mannheim-Neckarau", "Mannheim"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.organizer, func(t *testing.T) {
+			got, ok := table.Lookup(tt.organizer)
+			if !ok {
+				t.Fatalf("Lookup(%q) found no override", tt.organizer)
+			}
+			if got.City != tt.wantCity {
+				t.Errorf("Lookup(%q).City = %q, want %q", tt.organizer, got.City, tt.wantCity)
+			}
+		})
+	}
+}
+
+func TestLookupIsInsensitiveToSpellingVariants(t *testing.T) {
+	table, err := Parse([]byte(`{"overrides":[
+		{"match":"TC Rot-Weiß Karlsruhe e.V.","city":"Karlsruhe"}
+	]}`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	// All of these describe the same club.
+	variants := []string{
+		"TC Rot-Weiß Karlsruhe e.V.",
+		"tc rot-weiß karlsruhe e.v.",
+		"TC  Rot-Weiß   Karlsruhe  e. V.",
+		"TC Rot Weiß Karlsruhe eV",
+		"TC Rot-Weiss Karlsruhe e.V.",
+	}
+
+	for _, v := range variants {
+		if _, ok := table.Lookup(v); !ok {
+			t.Errorf("Lookup(%q) found no override", v)
+		}
+	}
+}
+
+func TestExactMatchWinsOverContains(t *testing.T) {
+	table, err := Parse([]byte(`{"overrides":[
+		{"contains":"Karlsruhe","city":"Generic"},
+		{"match":"TC Spezial Karlsruhe","city":"Specific"}
+	]}`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	got, ok := table.Lookup("TC Spezial Karlsruhe")
+	if !ok {
+		t.Fatal("no override found")
+	}
+	if got.City != "Specific" {
+		t.Errorf("City = %q, want the exact match to win", got.City)
+	}
+}
+
+func TestLongestContainsPatternWins(t *testing.T) {
+	table, err := Parse([]byte(`{"overrides":[
+		{"contains":"Mannheim","city":"Mannheim"},
+		{"contains":"Mannheim-Sandhofen","city":"Sandhofen"}
+	]}`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	got, _ := table.Lookup("TC Mannheim-Sandhofen 1920")
+	if got.City != "Sandhofen" {
+		t.Errorf("City = %q, want the more specific pattern to win", got.City)
+	}
+
+	got, _ = table.Lookup("TC Mannheim")
+	if got.City != "Mannheim" {
+		t.Errorf("City = %q, want the generic pattern for a generic name", got.City)
+	}
+}
+
+func TestLookupMisses(t *testing.T) {
+	table, err := Default()
+	if err != nil {
+		t.Fatalf("Default() error = %v", err)
+	}
+
+	for _, organizer := range []string{"", "   ", "TC Unbekannt", "e.V."} {
+		if o, ok := table.Lookup(organizer); ok {
+			t.Errorf("Lookup(%q) unexpectedly matched %+v", organizer, o)
+		}
+	}
+}
+
+func TestParseRejectsInvalidOverrides(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+	}{
+		{"no matcher", `{"overrides":[{"city":"Karlsruhe"}]}`},
+		{"no target", `{"overrides":[{"match":"TC X"}]}`},
+		{"lat without lon", `{"overrides":[{"match":"TC X","lat":"49.0"}]}`},
+		{"lon without lat", `{"overrides":[{"match":"TC X","lon":"8.4"}]}`},
+		{"malformed json", `{"overrides":[`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := Parse([]byte(tt.json)); err == nil {
+				t.Error("Parse() returned nil error for invalid input")
+			}
+		})
+	}
+}
+
+func TestParseAcceptsExplicitCoordinates(t *testing.T) {
+	table, err := Parse([]byte(`{"overrides":[
+		{"match":"TC Sonderfall","lat":"49.0069","lon":"8.4037"}
+	]}`))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	got, ok := table.Lookup("TC Sonderfall")
+	if !ok {
+		t.Fatal("no override found")
+	}
+	if !got.HasCoordinates() || got.Lat != "49.0069" || got.Lon != "8.4037" {
+		t.Errorf("override = %+v, want explicit coordinates", got)
+	}
+}
+
+func TestFileOverrideViaEnvironment(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/custom.json"
+
+	if err := writeFile(path, `{"overrides":[{"match":"TC Custom","city":"Teststadt"}]}`); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	// Default() memoizes, so exercise the same code path directly.
+	raw, err := readFile(path)
+	if err != nil {
+		t.Fatalf("readFile: %v", err)
+	}
+	table, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	got, ok := table.Lookup("TC Custom")
+	if !ok || got.City != "Teststadt" {
+		t.Errorf("Lookup() = %+v, %v; want the custom file to be used", got, ok)
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"TC Rot-Weiß Karlsruhe e.V.", "tc rot weiss karlsruhe e v"},
+		{"  TC   Karlsruhe  ", "tc karlsruhe"},
+		{"TC/Karlsruhe", "tc karlsruhe"},
+		{"", ""},
+		{"...", ""},
+		{"Grün-Weiss", "grun weiss"},
+	}
+
+	for _, tt := range tests {
+		if got := Normalize(tt.in); got != tt.want {
+			t.Errorf("Normalize(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestNormalizeFoldsSharpS(t *testing.T) {
+	if Normalize("Weiß") != Normalize("Weiss") {
+		t.Errorf("ß and ss must normalize identically: %q vs %q",
+			Normalize("Weiß"), Normalize("Weiss"))
+	}
+}
+
+func TestLookupOnNilTable(t *testing.T) {
+	var table *Table
+	if _, ok := table.Lookup("TC Karlsruhe"); ok {
+		t.Error("Lookup on nil table returned a match")
+	}
+	if table.Len() != 0 {
+		t.Error("Len on nil table should be 0")
+	}
+}
+
+// Small helpers to keep the file-based test readable.
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+func readFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+// TestOverrideNotesAreDocumented keeps the data file self-explanatory: every
+// entry should say why the automatic extraction cannot handle it.
+func TestOverrideNotesAreDocumented(t *testing.T) {
+	table, err := Default()
+	if err != nil {
+		t.Fatalf("Default() error = %v", err)
+	}
+
+	check := func(o Override) {
+		if strings.TrimSpace(o.Note) == "" {
+			t.Errorf("override %q has no note explaining why it is needed",
+				o.Match+o.Contains)
+		}
+	}
+
+	for _, o := range table.exact {
+		check(o)
+	}
+	for _, o := range table.contains {
+		check(o)
+	}
+}

--- a/backend/pkg/clublocations/data/club-locations.json
+++ b/backend/pkg/clublocations/data/club-locations.json
@@ -1,0 +1,50 @@
+{
+  "$comment": [
+    "Manual location overrides for clubs whose venue cannot be derived from",
+    "their name. Entries here take precedence over the automatic city",
+    "extraction, so this file is the place to fix a wrong map pin without",
+    "touching any code.",
+    "",
+    "Matching is case-insensitive and ignores punctuation and extra spaces.",
+    "'match' is compared against the organizer string exactly (after that",
+    "normalization); 'contains' matches when the organizer contains it.",
+    "Exact matches win over 'contains' matches; among 'contains' matches the",
+    "longest pattern wins, so a specific entry beats a generic one.",
+    "",
+    "Provide either 'city' (geocoded like any other place name, preferred) or",
+    "explicit 'lat'/'lon' when even the city is ambiguous.",
+    "'state' is optional and restricts the geocoding result."
+  ],
+  "overrides": [
+    {
+      "match": "Lohausener Sport-Verein",
+      "city": "Düsseldorf",
+      "state": "Nordrhein-Westfalen",
+      "note": "Lohausen is a district of Düsseldorf; not derivable from the name."
+    },
+    {
+      "contains": "Unterbarmer",
+      "city": "Wuppertal",
+      "state": "Nordrhein-Westfalen",
+      "note": "Unterbarmen is a district of Wuppertal."
+    },
+    {
+      "contains": "Post Südstadt Karlsruhe",
+      "city": "Karlsruhe",
+      "state": "Baden-Württemberg",
+      "note": "Südstadt is a district; the main city is the useful pin."
+    },
+    {
+      "contains": "Frankfurt-Höchst",
+      "city": "Frankfurt am Main",
+      "state": "Hessen",
+      "note": "Höchst is a district of Frankfurt am Main."
+    },
+    {
+      "contains": "Mannheim-Neckarau",
+      "city": "Mannheim",
+      "state": "Baden-Württemberg",
+      "note": "Neckarau is a district of Mannheim."
+    }
+  ]
+}

--- a/backend/pkg/federation/federations.go
+++ b/backend/pkg/federation/federations.go
@@ -85,6 +85,66 @@ func GetFederations() []models.Federation {
 			ApiVersion:        "new",
 			TrustedProperties: "{\"tournamentsFilter\":{\"ageCategory\":1,\"ageGroupJuniors\":1,\"ageGroupSeniors\":1,\"circuit\":1,\"fedRankValuation\":1,\"nationalValuation\":1,\"type\":1,\"fedRank\":1,\"region\":1,\"name\":1,\"city\":1,\"startDate\":1,\"endDate\":1,\"firstResult\":1,\"maxResults\":1}}159ecd19ddd43b30fbc8e35aea82f7bf7373a592",
 		},
+		{
+			Id:             "TVBB",
+			Url:            "https://tvbb.liga.nu/cgi-bin/WebObjects/nuLigaTENDE.woa/wa/tournamentCalendar",
+			Name:           "Tennis-Verband Berlin-Brandenburg",
+			Geocoordinates: models.Geocoordinates{Lat: "52.5170365", Lon: "13.3888599"},
+			// The federation covers both Berlin and Brandenburg; accepting
+			// only one would push every tournament in the other state onto
+			// the default marker.
+			State:             "Berlin",
+			States:            []string{"Berlin", "Brandenburg"},
+			ApiVersion:        "old",
+			TrustedProperties: "",
+		},
+		{
+			Id:                "HAM",
+			Url:               "https://hamburg.liga.nu/cgi-bin/WebObjects/nuLigaTENDE.woa/wa/tournamentCalendar",
+			Name:              "Hamburger Tennisverband",
+			Geocoordinates:    models.Geocoordinates{Lat: "53.550341", Lon: "10.000654"},
+			State:             "Hamburg",
+			ApiVersion:        "old",
+			TrustedProperties: "",
+		},
+		{
+			Id:                "TVM",
+			Url:               "https://tvm.liga.nu/cgi-bin/WebObjects/nuLigaTENDE.woa/wa/tournamentCalendar",
+			Name:              "Tennisverband Mittelrhein",
+			Geocoordinates:    models.Geocoordinates{Lat: "50.9412538", Lon: "6.9582814"},
+			State:             "Nordrhein-Westfalen",
+			ApiVersion:        "old",
+			TrustedProperties: "",
+		},
+		{
+			Id:             "TNB",
+			Url:            "https://tnb.liga.nu/cgi-bin/WebObjects/nuLigaTENDE.woa/wa/tournamentCalendar",
+			Name:           "Tennisverband Niedersachsen-Bremen",
+			Geocoordinates: models.Geocoordinates{Lat: "52.3758916", Lon: "9.7320104"},
+			// Covers Niedersachsen and the city state of Bremen.
+			State:             "Niedersachsen",
+			States:            []string{"Niedersachsen", "Bremen"},
+			ApiVersion:        "old",
+			TrustedProperties: "",
+		},
+		{
+			Id:                "STB",
+			Url:               "https://stb.liga.nu/cgi-bin/WebObjects/nuLigaTENDE.woa/wa/tournamentCalendar",
+			Name:              "Saarländischer Tennisbund",
+			Geocoordinates:    models.Geocoordinates{Lat: "49.2401572", Lon: "6.9969327"},
+			State:             "Saarland",
+			ApiVersion:        "old",
+			TrustedProperties: "",
+		},
+		{
+			Id:                "WTV",
+			Url:               "https://wtv.liga.nu/cgi-bin/WebObjects/nuLigaTENDE.woa/wa/tournamentCalendar",
+			Name:              "Westfälischer Tennis-Verband",
+			Geocoordinates:    models.Geocoordinates{Lat: "51.5142273", Lon: "7.4652789"},
+			State:             "Nordrhein-Westfalen",
+			ApiVersion:        "old",
+			TrustedProperties: "",
+		},
 	}
 	return federations
 }

--- a/backend/pkg/federation/federations_test.go
+++ b/backend/pkg/federation/federations_test.go
@@ -1,0 +1,185 @@
+package federation
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestFederationsAreWellFormed guards the configuration itself: a typo here
+// silently removes a whole federation's tournaments from the map.
+func TestFederationsAreWellFormed(t *testing.T) {
+	federations := GetFederations()
+
+	if len(federations) == 0 {
+		t.Fatal("GetFederations() returned no federations")
+	}
+
+	seenIDs := make(map[string]bool)
+
+	for _, fed := range federations {
+		t.Run(fed.Id, func(t *testing.T) {
+			if fed.Id == "" {
+				t.Error("federation has an empty Id")
+			}
+			if seenIDs[fed.Id] {
+				t.Errorf("duplicate federation Id %q", fed.Id)
+			}
+			seenIDs[fed.Id] = true
+
+			if fed.Name == "" {
+				t.Error("federation has an empty Name")
+			}
+
+			u, err := url.Parse(fed.Url)
+			if err != nil {
+				t.Errorf("invalid Url %q: %v", fed.Url, err)
+			} else {
+				if u.Scheme != "https" {
+					t.Errorf("Url %q must use https", fed.Url)
+				}
+				if u.Host == "" {
+					t.Errorf("Url %q has no host", fed.Url)
+				}
+			}
+
+			switch fed.ApiVersion {
+			case "old":
+				if fed.TrustedProperties != "" {
+					t.Error("old API federations do not use TrustedProperties")
+				}
+			case "new":
+				if fed.TrustedProperties == "" {
+					t.Error("new API federations require TrustedProperties")
+				}
+			default:
+				t.Errorf("unknown ApiVersion %q", fed.ApiVersion)
+			}
+
+			// Default coordinates are the fallback pin, so they must be set
+			// and inside Germany's bounding box.
+			assertGermanCoordinates(t, fed.Geocoordinates.Lat, fed.Geocoordinates.Lon)
+
+			if fed.State == "" {
+				t.Error("federation has an empty State")
+			}
+			if len(fed.States) > 0 && !contains(fed.States, fed.State) {
+				t.Errorf("States %v must include the primary State %q", fed.States, fed.State)
+			}
+		})
+	}
+}
+
+// TestAcceptedStates covers the multi-state support that keeps tournaments in
+// a federation's secondary state from falling back to default coordinates.
+func TestAcceptedStates(t *testing.T) {
+	byID := make(map[string][]string)
+	for _, fed := range GetFederations() {
+		byID[fed.Id] = fed.AcceptedStates()
+	}
+
+	tests := []struct {
+		id   string
+		want []string
+	}{
+		{"TVBB", []string{"Berlin", "Brandenburg"}},
+		{"TNB", []string{"Niedersachsen", "Bremen"}},
+		{"BAD", []string{"Baden-Württemberg"}},
+		{"HAM", []string{"Hamburg"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			got, ok := byID[tt.id]
+			if !ok {
+				t.Fatalf("federation %q is not configured", tt.id)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("AcceptedStates() = %v, want %v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("AcceptedStates()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestExpectedFederationsArePresent documents the supported set, so removing
+// one by accident fails the build rather than quietly shrinking coverage.
+func TestExpectedFederationsArePresent(t *testing.T) {
+	want := []string{
+		// Previously supported
+		"BAD", "HTV", "RLP", "STV", "TMV", "TSA", "TTV", "TVN", "WTB",
+		// Added for issue #49
+		"TVBB", "HAM", "TVM", "TNB", "STB", "WTV",
+	}
+
+	got := make(map[string]bool)
+	for _, fed := range GetFederations() {
+		got[fed.Id] = true
+	}
+
+	for _, id := range want {
+		if !got[id] {
+			t.Errorf("federation %q is missing", id)
+		}
+	}
+}
+
+// TestLigaNuFederationsUseTournamentCalendarPath catches copy/paste mistakes in
+// the endpoint, which would otherwise surface only as an empty result set.
+func TestLigaNuFederationsUseTournamentCalendarPath(t *testing.T) {
+	for _, fed := range GetFederations() {
+		if !strings.Contains(fed.Url, "liga.nu") {
+			continue
+		}
+		if !strings.HasSuffix(fed.Url, "/wa/tournamentCalendar") {
+			t.Errorf("federation %s: liga.nu URL %q should end in /wa/tournamentCalendar",
+				fed.Id, fed.Url)
+		}
+		if fed.ApiVersion != "old" {
+			t.Errorf("federation %s: liga.nu endpoints use the old API, got %q",
+				fed.Id, fed.ApiVersion)
+		}
+	}
+}
+
+func assertGermanCoordinates(t *testing.T, lat, lon string) {
+	t.Helper()
+
+	if lat == "" || lon == "" {
+		t.Error("federation has no default coordinates")
+		return
+	}
+
+	latF, err := strconv.ParseFloat(lat, 64)
+	if err != nil {
+		t.Errorf("invalid latitude %q: %v", lat, err)
+		return
+	}
+	lonF, err := strconv.ParseFloat(lon, 64)
+	if err != nil {
+		t.Errorf("invalid longitude %q: %v", lon, err)
+		return
+	}
+
+	// Germany spans roughly 47.2-55.1 N and 5.8-15.1 E.
+	if latF < 47.0 || latF > 55.5 {
+		t.Errorf("latitude %v is outside Germany", latF)
+	}
+	if lonF < 5.5 || lonF > 15.5 {
+		t.Errorf("longitude %v is outside Germany", lonF)
+	}
+}
+
+func contains(list []string, want string) bool {
+	for _, v := range list {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/pkg/models/models.go
+++ b/backend/pkg/models/models.go
@@ -21,17 +21,61 @@ type Geocoordinates struct {
 	Lat         string `json:"lat"`
 	Lon         string `json:"lon"`
 	DisplayName string `json:"display_name"`
-	LastAttempt int64  `json:"last_attempt,omitempty"` // Unix timestamp of last geocoding attempt
-	FailCount   int    `json:"fail_count,omitempty"`   // Number of consecutive failures
-	IsFailed    bool   `json:"is_failed,omitempty"`    // Marks this as a failed geocoding attempt
+	// Address holds Nominatim's structured address (requires
+	// addressdetails=1). Verifying the state via this field is far more
+	// reliable than a substring match on DisplayName, which frequently omits
+	// the state for districts and small settlements.
+	Address     Address `json:"address,omitempty"`
+	LastAttempt int64   `json:"last_attempt,omitempty"` // Unix timestamp of last geocoding attempt
+	FailCount   int     `json:"fail_count,omitempty"`   // Number of consecutive failures
+	IsFailed    bool    `json:"is_failed,omitempty"`    // Marks this as a failed geocoding attempt
+}
+
+// Address is the subset of Nominatim's structured address we rely on.
+type Address struct {
+	State        string `json:"state,omitempty"`
+	City         string `json:"city,omitempty"`
+	Town         string `json:"town,omitempty"`
+	Village      string `json:"village,omitempty"`
+	Municipality string `json:"municipality,omitempty"`
+	Country      string `json:"country,omitempty"`
+	CountryCode  string `json:"country_code,omitempty"`
+}
+
+// Place returns the most specific settlement name available.
+func (a Address) Place() string {
+	for _, v := range []string{a.City, a.Town, a.Village, a.Municipality} {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 type Federation struct {
-	Id                string         `json:"id"`
-	Url               string         `json:"url"`
-	Name              string         `json:"name"`
-	Geocoordinates    Geocoordinates `json:"geocoordinates"`
-	State             string         `json:"state"`
-	ApiVersion        string         `json:"api_version"`
-	TrustedProperties string         `json:"trusted_properties"`
+	Id             string         `json:"id"`
+	Url            string         `json:"url"`
+	Name           string         `json:"name"`
+	Geocoordinates Geocoordinates `json:"geocoordinates"`
+	// State is the federation's primary state, kept for backwards
+	// compatibility and used as the default when States is empty.
+	State string `json:"state"`
+	// States lists every state the federation covers. Several federations
+	// span more than one (TVBB covers Berlin and Brandenburg, TNB covers
+	// Niedersachsen and Bremen); accepting only the primary state made
+	// tournaments in the other one fall back to default coordinates.
+	States            []string `json:"states,omitempty"`
+	ApiVersion        string   `json:"api_version"`
+	TrustedProperties string   `json:"trusted_properties"`
+}
+
+// AcceptedStates returns every state a geocoding result may belong to.
+func (f Federation) AcceptedStates() []string {
+	if len(f.States) > 0 {
+		return f.States
+	}
+	if f.State != "" {
+		return []string{f.State}
+	}
+	return nil
 }

--- a/backend/pkg/openstreetmap/export_test.go
+++ b/backend/pkg/openstreetmap/export_test.go
@@ -1,10 +1,26 @@
 package openstreetmap
 
-import "sync"
+import (
+	"os"
+	"sync"
+
+	"github.com/timoknapp/tennis-tournament-finder/pkg/clublocations"
+)
 
 // resetRateLimiterForTest rebuilds the process-wide geocoding limiter so tests
 // can exercise different intervals. It is only compiled into test binaries.
 func resetRateLimiterForTest() {
 	geocodingLimiterOnce = sync.Once{}
 	geocodingLimiter = nil
+}
+
+// resetClubLocationsForTest clears the memoized override table so a test can
+// point TTF_CLUB_LOCATIONS at its own fixture.
+func resetClubLocationsForTest() {
+	clublocations.ResetForTest()
+}
+
+// osWriteFile is a tiny helper so tests avoid importing os in several files.
+func osWriteFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o644)
 }

--- a/backend/pkg/openstreetmap/geocoding_test.go
+++ b/backend/pkg/openstreetmap/geocoding_test.go
@@ -1,0 +1,427 @@
+package openstreetmap
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
+)
+
+// recordingGeocoder captures every query and answers from a lookup table.
+type recordingGeocoder struct {
+	mu      sync.Mutex
+	queries []string
+	answers map[string][]models.Geocoordinates
+	calls   int64
+}
+
+func newRecordingServer(t *testing.T, answers map[string][]models.Geocoordinates) *recordingGeocoder {
+	t.Helper()
+
+	rec := &recordingGeocoder{answers: answers}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&rec.calls, 1)
+		q := r.URL.Query().Get("q")
+
+		rec.mu.Lock()
+		rec.queries = append(rec.queries, q)
+		rec.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(rec.answers[q]) // nil -> "null", handled as no results
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("TTF_NOMINATIM_URL", srv.URL)
+
+	return rec
+}
+
+func (r *recordingGeocoder) recorded() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.queries))
+	copy(out, r.queries)
+	return out
+}
+
+// TestMultiStateFederationAcceptsEitherState is the regression test for
+// federations spanning more than one state (TVBB: Berlin + Brandenburg,
+// TNB: Niedersachsen + Bremen). Previously a tournament in the secondary
+// state was rejected and fell back to the federation's default coordinates.
+func TestMultiStateFederationAcceptsEitherState(t *testing.T) {
+	initTestCache(t)
+
+	newRecordingServer(t, map[string][]models.Geocoordinates{
+		"Bad Saarow": {{
+			Lat: "52.28", Lon: "14.06",
+			DisplayName: "Bad Saarow, Oder-Spree, Brandenburg, Deutschland",
+			Address:     models.Address{State: "Brandenburg", Village: "Bad Saarow"},
+		}},
+	})
+
+	tvbb := models.Federation{
+		Id:     "TVBB",
+		State:  "Berlin",
+		States: []string{"Berlin", "Brandenburg"},
+	}
+
+	got := GetGeocoordinatesForFederation(tvbb, models.Tournament{
+		Id: "1", Location: "Bad Saarow", Organizer: "TC Bad Saarow",
+	})
+
+	if got.Lat != "52.28" {
+		t.Errorf("got %+v, want the Brandenburg result to be accepted", got)
+	}
+}
+
+func TestSingleStateFederationStillRejectsOtherStates(t *testing.T) {
+	initTestCache(t)
+
+	newRecordingServer(t, map[string][]models.Geocoordinates{
+		"Musterstadt": {{
+			Lat: "52.5", Lon: "13.4",
+			DisplayName: "Musterstadt, Berlin, Deutschland",
+			Address:     models.Address{State: "Berlin"},
+		}},
+	})
+
+	fed := models.Federation{Id: "BAD", State: "Baden-Württemberg"}
+
+	got := GetGeocoordinatesForFederation(fed, models.Tournament{
+		Id: "1", Location: "Musterstadt",
+	})
+
+	if got.Lat != "" {
+		t.Errorf("got %+v, want no result for a different state", got)
+	}
+}
+
+// TestStateVerifiedViaStructuredAddress covers results whose display_name
+// omits the state, which the old substring check rejected.
+func TestStateVerifiedViaStructuredAddress(t *testing.T) {
+	initTestCache(t)
+
+	newRecordingServer(t, map[string][]models.Geocoordinates{
+		"Neckarau": {{
+			Lat: "49.45", Lon: "8.49",
+			// No state in the display name, only in the structured address.
+			DisplayName: "Neckarau, Mannheim, 68199, Deutschland",
+			Address:     models.Address{State: "Baden-Württemberg", City: "Mannheim"},
+		}},
+	})
+
+	fed := models.Federation{Id: "BAD", State: "Baden-Württemberg"}
+
+	got := GetGeocoordinatesForFederation(fed, models.Tournament{
+		Id: "1", Location: "Neckarau",
+	})
+
+	if got.Lat != "49.45" {
+		t.Errorf("got %+v, want the result verified via address.state", got)
+	}
+}
+
+// TestCandidatesAreTriedUntilOneResolves covers the central accuracy fix: a
+// club name that yields no direct match must fall through to the derived
+// candidate instead of giving up.
+func TestCandidatesAreTriedUntilOneResolves(t *testing.T) {
+	initTestCache(t)
+
+	rec := newRecordingServer(t, map[string][]models.Geocoordinates{
+		// Only the de-adjectived form resolves.
+		"Heidelberg": {{
+			Lat: "49.41", Lon: "8.69",
+			DisplayName: "Heidelberg, Baden-Württemberg, Deutschland",
+			Address:     models.Address{State: "Baden-Württemberg", City: "Heidelberg"},
+		}},
+	})
+
+	fed := models.Federation{Id: "BAD", State: "Baden-Württemberg"}
+
+	got := GetGeocoordinatesForFederation(fed, models.Tournament{
+		Id: "1", Organizer: "Heidelberger Tennis-Club 1890 e.V.",
+	})
+
+	if got.Lat != "49.41" {
+		t.Fatalf("got %+v, want the derived candidate to resolve", got)
+	}
+
+	queries := rec.recorded()
+	if len(queries) < 2 {
+		t.Errorf("queries = %v, want the literal form to be tried before the derived one", queries)
+	}
+}
+
+func TestCandidateCountIsBounded(t *testing.T) {
+	initTestCache(t)
+
+	// Nothing resolves, so every candidate is attempted.
+	rec := newRecordingServer(t, nil)
+
+	fed := models.Federation{Id: "BAD", State: "Baden-Württemberg"}
+
+	GetGeocoordinatesForFederation(fed, models.Tournament{
+		Id:        "1",
+		Location:  "Irgendwo an der Grenze",
+		Organizer: "TC Rot-Weiß Musterhausen-Kleinkleckersdorf 1920 e.V.",
+	})
+
+	// Each candidate costs one rate-limited request and both lookup passes
+	// share one budget, so the total must stay predictable regardless of how
+	// long the club name is.
+	if got := len(rec.recorded()); got > maxGeocodeRequests {
+		t.Errorf("made %d requests, want at most %d", got, maxGeocodeRequests)
+	}
+}
+
+// TestOverrideTakesPrecedence verifies the curated JSON file wins over the
+// automatic extraction.
+func TestOverrideTakesPrecedence(t *testing.T) {
+	initTestCache(t)
+
+	rec := newRecordingServer(t, map[string][]models.Geocoordinates{
+		"Düsseldorf": {{
+			Lat: "51.22", Lon: "6.77",
+			DisplayName: "Düsseldorf, Nordrhein-Westfalen, Deutschland",
+			Address:     models.Address{State: "Nordrhein-Westfalen", City: "Düsseldorf"},
+		}},
+	})
+
+	fed := models.Federation{Id: "TVN", State: "Nordrhein-Westfalen"}
+
+	// "Lohausener Sport-Verein" cannot be resolved from its name; the
+	// override maps it to Düsseldorf.
+	got := GetGeocoordinatesForFederation(fed, models.Tournament{
+		Id: "1", Organizer: "Lohausener Sport-Verein",
+	})
+
+	if got.Lat != "51.22" {
+		t.Fatalf("got %+v, want the override to resolve to Düsseldorf", got)
+	}
+
+	queries := rec.recorded()
+	if len(queries) == 0 || queries[0] != "Düsseldorf" {
+		t.Errorf("queries = %v, want the override to be tried first", queries)
+	}
+}
+
+func TestOverrideWithPinnedCoordinatesSkipsNetwork(t *testing.T) {
+	initTestCache(t)
+	t.Setenv("TTF_CLUB_LOCATIONS", writeOverrides(t, `{"overrides":[
+		{"match":"TC Sonderfall","lat":"49.0069","lon":"8.4037","note":"pinned"}
+	]}`))
+	resetClubLocationsForTest()
+
+	rec := newRecordingServer(t, nil)
+
+	fed := models.Federation{Id: "BAD", State: "Baden-Württemberg"}
+	got := GetGeocoordinatesForFederation(fed, models.Tournament{
+		Id: "1", Organizer: "TC Sonderfall",
+	})
+
+	if got.Lat != "49.0069" || got.Lon != "8.4037" {
+		t.Errorf("got %+v, want the pinned coordinates", got)
+	}
+	if calls := len(rec.recorded()); calls != 0 {
+		t.Errorf("made %d geocoding requests, want 0 for pinned coordinates", calls)
+	}
+}
+
+func TestMatchesState(t *testing.T) {
+	tests := []struct {
+		name     string
+		geo      models.Geocoordinates
+		accepted []string
+		want     bool
+	}{
+		{
+			name:     "structured address matches",
+			geo:      models.Geocoordinates{Address: models.Address{State: "Hessen"}},
+			accepted: []string{"Hessen"},
+			want:     true,
+		},
+		{
+			name:     "structured address mismatches",
+			geo:      models.Geocoordinates{Address: models.Address{State: "Berlin"}},
+			accepted: []string{"Hessen"},
+			want:     false,
+		},
+		{
+			name:     "second accepted state matches",
+			geo:      models.Geocoordinates{Address: models.Address{State: "Bremen"}},
+			accepted: []string{"Niedersachsen", "Bremen"},
+			want:     true,
+		},
+		{
+			name:     "falls back to display name when address is absent",
+			geo:      models.Geocoordinates{DisplayName: "Kassel, Hessen, Deutschland"},
+			accepted: []string{"Hessen"},
+			want:     true,
+		},
+		{
+			name: "structured address wins over display name",
+			geo: models.Geocoordinates{
+				DisplayName: "Irgendwo, Hessen, Deutschland",
+				Address:     models.Address{State: "Berlin"},
+			},
+			accepted: []string{"Hessen"},
+			want:     false,
+		},
+		{
+			name:     "no restriction accepts anything",
+			geo:      models.Geocoordinates{Address: models.Address{State: "Sachsen"}},
+			accepted: nil,
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchesState(tt.geo, tt.accepted); got != tt.want {
+				t.Errorf("matchesState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildGeocodeQueriesOrder(t *testing.T) {
+	queries, _ := buildGeocodeQueries(models.Tournament{
+		Location:  "Karlsruhe",
+		Organizer: "TC Rot-Weiß Karlsruhe e.V.",
+	})
+
+	if len(queries) == 0 {
+		t.Fatal("no queries built")
+	}
+	// The published location is the most trustworthy signal.
+	if queries[0].value != "Karlsruhe" {
+		t.Errorf("first query = %q, want the published location", queries[0].value)
+	}
+
+	// No duplicates, even though the organizer derives the same city.
+	seen := make(map[string]bool)
+	for _, q := range queries {
+		if seen[q.value] {
+			t.Errorf("duplicate query %q in %+v", q.value, queries)
+		}
+		seen[q.value] = true
+	}
+}
+
+func TestBuildGeocodeQueriesWithoutUsableInput(t *testing.T) {
+	queries, override := buildGeocodeQueries(models.Tournament{Id: "1"})
+	if len(queries) != 0 {
+		t.Errorf("queries = %+v, want none", queries)
+	}
+	if override != nil {
+		t.Errorf("override = %+v, want nil", override)
+	}
+}
+
+// writeOverrides writes a club-locations file and returns its path.
+func writeOverrides(t *testing.T, content string) string {
+	t.Helper()
+
+	path := t.TempDir() + "/club-locations.json"
+	if err := osWriteFile(path, content); err != nil {
+		t.Fatalf("failed to write overrides: %v", err)
+	}
+	return path
+}
+
+// TestPlaceMatchesQuery covers the guard against Nominatim returning a
+// different place that merely contains the queried word.
+func TestPlaceMatchesQuery(t *testing.T) {
+	tests := []struct {
+		name  string
+		place string
+		query string
+		want  bool
+	}{
+		{"exact match", "Bremen", "Bremen", true},
+		{"case insensitive", "bremen", "Bremen", true},
+		{"official long form", "Bad Homburg vor der Höhe", "Bad Homburg", true},
+		{"city with suffix", "Frankfurt am Main", "Frankfurt", true},
+		// Regression: "Bremer" must not settle for the hamlet "Bremer Sand".
+		{"different place containing the query", "Bremer Sand", "Bremer", false},
+		{"street-like name", "Ratinger Straße", "Ratinger", false},
+		{"unrelated", "Bösel", "Bremen", false},
+		{"empty place", "", "Bremen", false},
+		{"empty query", "Bremen", "", false},
+		{"query longer than place", "Bad", "Bad Homburg", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			geo := models.Geocoordinates{Address: models.Address{City: tt.place}}
+			if got := placeMatchesQuery(geo, tt.query); got != tt.want {
+				t.Errorf("placeMatchesQuery(%q, %q) = %v, want %v",
+					tt.place, tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExactPlaceMatchWinsOverInexactHit is the regression test for the
+// "Bremer Tennisclub" case: an inexact hit from an early candidate must not
+// beat an exact match from a later one.
+func TestExactPlaceMatchWinsOverInexactHit(t *testing.T) {
+	initTestCache(t)
+
+	newRecordingServer(t, map[string][]models.Geocoordinates{
+		// The literal token resolves to an unrelated hamlet ...
+		"Bremer": {{
+			Lat: "53.0", Lon: "7.9",
+			DisplayName: "Bremer Sand, Bösel, Niedersachsen, Deutschland",
+			Address:     models.Address{State: "Bremen", Village: "Bremer Sand"},
+		}},
+		// ... while the de-adjectived candidate resolves to the real city.
+		"Bremen": {{
+			Lat: "53.07", Lon: "8.80",
+			DisplayName: "Bremen, Deutschland",
+			Address:     models.Address{State: "Bremen", City: "Bremen"},
+		}},
+	})
+
+	fed := models.Federation{Id: "TNB", State: "Niedersachsen",
+		States: []string{"Niedersachsen", "Bremen"}}
+
+	got := GetGeocoordinatesForFederation(fed, models.Tournament{
+		Id: "1", Organizer: "Bremer Tennisclub",
+	})
+
+	if got.Address.Place() != "Bremen" {
+		t.Errorf("resolved to %q (%s), want the exact city match",
+			got.Address.Place(), got.DisplayName)
+	}
+}
+
+// TestInexactHitUsedWhenNothingBetterExists ensures the stricter matching does
+// not throw away the only available result.
+func TestInexactHitUsedWhenNothingBetterExists(t *testing.T) {
+	initTestCache(t)
+
+	newRecordingServer(t, map[string][]models.Geocoordinates{
+		"Kleinkleckersdorf": {{
+			Lat: "50.0", Lon: "9.0",
+			DisplayName: "Kleinkleckersdorf Siedlung, Hessen, Deutschland",
+			Address:     models.Address{State: "Hessen", Village: "Kleinkleckersdorf Siedlung"},
+		}},
+	})
+
+	fed := models.Federation{Id: "HTV", State: "Hessen"}
+
+	got := GetGeocoordinatesForFederation(fed, models.Tournament{
+		Id: "1", Location: "Kleinkleckersdorf",
+	})
+
+	if got.Lat != "50.0" {
+		t.Errorf("got %+v, want the inexact hit rather than no result at all", got)
+	}
+}

--- a/backend/pkg/openstreetmap/openstreetmap.go
+++ b/backend/pkg/openstreetmap/openstreetmap.go
@@ -14,9 +14,11 @@ import (
 	"time"
 
 	"github.com/timoknapp/tennis-tournament-finder/pkg/cache"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/clublocations"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/httpclient"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/placename"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/ratelimit"
 )
 
@@ -41,6 +43,15 @@ const maxGeocodingResponseBytes = 1 << 20 // 1 MiB
 // defaultNominatimInterval honours the Nominatim usage policy of at most one
 // request per second for the shared public instance.
 const defaultNominatimInterval = time.Second
+
+// maxGeocodeCandidates bounds how many place-name guesses are derived per
+// tournament.
+const maxGeocodeCandidates = 4
+
+// maxGeocodeRequests bounds the total upstream requests per tournament across
+// both lookup passes. Each request is rate limited, so this keeps the cost of
+// one tournament predictable.
+const maxGeocodeRequests = 6
 
 var (
 	geocodingLimiterOnce sync.Once
@@ -230,7 +241,19 @@ func generateOrganizerCacheKey(organizer, state string) string {
 }
 
 func GetGeocoordinatesFromCache(state string, tournament models.Tournament) models.Geocoordinates {
-	keys := geocodeCacheKeys(state, tournament)
+	return GetGeocoordinatesForFederation(models.Federation{State: state}, tournament)
+}
+
+// GetGeocoordinatesForFederation resolves a tournament's coordinates, accepting
+// results from any state the federation covers.
+func GetGeocoordinatesForFederation(fed models.Federation, tournament models.Tournament) models.Geocoordinates {
+	acceptedStates := fed.AcceptedStates()
+	primaryState := ""
+	if len(acceptedStates) > 0 {
+		primaryState = acceptedStates[0]
+	}
+
+	keys := geocodeCacheKeys(primaryState, tournament)
 
 	// Check every candidate key. A successful hit wins immediately.
 	//
@@ -266,7 +289,7 @@ func GetGeocoordinatesFromCache(state string, tournament models.Tournament) mode
 	logger.Debug("No Geocoordinate Cache entry found for (%s): '%s' at '%s'. Fetching data from server.",
 		tournament.Id, tournament.Organizer, tournament.Location)
 
-	return getGeocoordinates(state, tournament)
+	return getGeocoordinatesForStates(acceptedStates, tournament)
 }
 
 // shouldRetryGeocodingRequest determines if a failed geocoding request should be retried
@@ -427,300 +450,280 @@ func CleanupOldFailedEntries() int {
 	return cleaned
 }
 
-// extractCityFromOrganizerName intelligently extracts the city name from the organizer string
-func extractCityFromOrganizerName(organizer string) string {
-	// Handle special cases first
-	if cityFromSpecialCases := handleSpecialCases(organizer); cityFromSpecialCases != "" {
-		return cityFromSpecialCases
-	}
-
-	// Remove common prefixes and suffixes first
-	removeablePrefixesSuffixes := []string{
-		"e.V.", "e. V.", "e.v.",
-		", TA", " TA", "- TA", " , TA",
-		"Abt. Tennis", "- Abt. Tennis", "Abt.",
-		"von 1845", "von 1890", "1890", "1845", "1911", "1920", "1920/75", "1975", "1970", "1974", "1923", "1897", "1896", "08/29", "05", "50",
-		"zu",
-	}
-
-	// Remove common club type abbreviations and full names
-	removeableClubTypes := []string{
-		"Turnverein", "Turn- u. Sportverein", "Tennisverein", "Tennis-Club", "Tennisclub", "Tennisklub",
-		"Sportverein", "Sport-Verein", "Sportvereinigung", "Sportgemeinschaft", "Tennisgemeinschaft",
-		"Sport-Verein",
-		"TC", "TK", "TG", "TV", "SG", "SV", "SKV", "FC", "ATV", "SuS", "TSG", "SC", "SF", "TSC",
-		"Tennis", "DJK", "Post", "Tura", "Germania", "Bezirk", "Optimus", "Olympia", "Nicolai", "Club",
-	}
-
-	// Remove color combinations and specific club names
-	removeableColors := []string{
-		"Rot-Weiß", "Blau-Weiß", "Grün-Weiß", "Grün-Weiss", "Grün-Gelb", "Grün-Weiß-Rot",
-		"Blau-Gelb", "Schwarz-Weiß", "Grün Weiß", "Grün Weiss", "Weiss-Rot",
-		"GW", "BW", "RW", "SW",
-	}
-
-	query := organizer
-
-	// Remove all the unwanted parts
-	allRemovables := append(append(removeablePrefixesSuffixes, removeableClubTypes...), removeableColors...)
-	for _, removable := range allRemovables {
-		query = strings.ReplaceAll(query, removable, "")
-	}
-
-	// Clean up extra spaces and trim
-	query = strings.TrimSpace(strings.ReplaceAll(query, "  ", " "))
-
-	// Handle special cases and extract meaningful city names
-	cityName := extractCityFromPattern(query, organizer)
-
-	// Final fallback
-	if cityName == "" {
-		return organizer
-	}
-
-	return cityName
+// geocodeQuery describes one attempt to resolve a place.
+type geocodeQuery struct {
+	value  string // what to send to the geocoder
+	source string // where it came from, for logging
 }
 
-// handleSpecialCases handles specific known problematic cases
-func handleSpecialCases(organizer string) string {
-	// Handle "Post Südstadt Karlsruhe" type cases - prefer the main city
-	if strings.Contains(organizer, "Post Südstadt Karlsruhe") {
-		return "Karlsruhe"
-	}
-	if strings.Contains(organizer, "Heidelberger Tennis-Club") {
-		return "Heidelberg"
-	}
-	if strings.Contains(organizer, "Eppelheimer Tennis-Club") {
-		return "Eppelheim"
-	}
-	if strings.Contains(organizer, "Karbener Sportverein") {
-		return "Karben"
-	}
-	if strings.Contains(organizer, "Unterbarmer Tennisclub") {
-		return "Wuppertal" // Unterbarmen is a district of Wuppertal
-	}
-	if strings.Contains(organizer, "Ratinger Tennisclub") {
-		return "Ratingen"
-	}
-	if strings.Contains(organizer, "Lohausener Sport-Verein") {
-		return "Düsseldorf" // Lohausen is a district of Düsseldorf
+// buildGeocodeQueries returns the ordered list of place names to try for a
+// tournament.
+//
+// Order of precedence:
+//  1. a manual override for the organizer (highest confidence)
+//  2. the location published by the federation, when present
+//  3. candidates derived from the organizer's club name
+//
+// The caller stops at the first candidate that resolves inside an accepted
+// state, so more specific guesses must come first.
+func buildGeocodeQueries(tournament models.Tournament) ([]geocodeQuery, *clublocations.Override) {
+	var queries []geocodeQuery
+	seen := make(map[string]bool)
+
+	add := func(value, source string) {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[strings.ToLower(value)] {
+			return
+		}
+		seen[strings.ToLower(value)] = true
+		queries = append(queries, geocodeQuery{value: value, source: source})
 	}
 
-	// Handle adjective forms ending in -er
-	words := strings.Fields(organizer)
-	for _, word := range words {
-		if strings.HasSuffix(word, "er") && len(word) > 4 {
-			// Try different transformations for German adjective → city name
-			transformations := []string{
-				strings.TrimSuffix(word, "er"),        // Heidelberger → Heidelberg
-				strings.TrimSuffix(word, "er") + "en", // Ratinger → Ratingen
-				strings.TrimSuffix(word, "er") + "m",  // Eppelheimer → Eppelheim
-			}
-
-			for _, candidate := range transformations {
-				if isLikelyCityName(candidate) {
-					return candidate
-				}
+	var override *clublocations.Override
+	if table, err := clublocations.Default(); err == nil && tournament.Organizer != "" {
+		if o, ok := table.Lookup(tournament.Organizer); ok {
+			override = &o
+			if o.City != "" {
+				add(o.City, "override")
 			}
 		}
 	}
 
-	return ""
+	// The published location is usually a plain city name and is trusted
+	// before anything derived from the club name.
+	if loc := strings.TrimSpace(tournament.Location); loc != "" {
+		add(loc, "location")
+		for _, c := range placename.Candidates(loc) {
+			add(c, "location-derived")
+		}
+	}
+
+	for _, c := range placename.Candidates(tournament.Organizer) {
+		add(c, "organizer-derived")
+	}
+
+	if len(queries) > maxGeocodeCandidates {
+		queries = queries[:maxGeocodeCandidates]
+	}
+
+	return queries, override
 }
 
-// extractCityFromPattern uses various patterns to extract city names
-func extractCityFromPattern(cleanedQuery string, originalOrganizer string) string {
-	words := strings.Fields(cleanedQuery)
-	if len(words) == 0 {
-		return ""
+// matchesState reports whether a geocoding result belongs to one of the
+// accepted states.
+//
+// The structured address field is authoritative. DisplayName is only consulted
+// as a fallback for responses without address details.
+func matchesState(geo models.Geocoordinates, acceptedStates []string) bool {
+	if len(acceptedStates) == 0 {
+		return true // no restriction configured
 	}
 
-	// Pattern 1: Look for compound city names (German cities often have hyphens or are compound)
-	for _, word := range words {
-		if isLikelyCityName(word) {
-			return word
+	for _, state := range acceptedStates {
+		if state == "" {
+			continue
 		}
-	}
-
-	// Pattern 2: Extract from specific known patterns
-	if cityFromSpecialPattern := extractFromSpecialPatterns(originalOrganizer); cityFromSpecialPattern != "" {
-		return cityFromSpecialPattern
-	}
-
-	// Pattern 3: Look for the longest meaningful word that could be a city
-	var bestCandidate string
-	for _, word := range words {
-		if len(word) >= 4 && isCapitalized(word) && !isCommonClubWord(word) && len(word) > len(bestCandidate) {
-			bestCandidate = word
+		if geo.Address.State != "" {
+			if strings.EqualFold(geo.Address.State, state) {
+				return true
+			}
+			continue
 		}
-	}
-
-	if bestCandidate != "" {
-		return bestCandidate
-	}
-
-	// Pattern 4: Take the first meaningful word
-	for _, word := range words {
-		if len(word) >= 3 && isCapitalized(word) && !isCommonClubWord(word) {
-			return word
-		}
-	}
-
-	return ""
-}
-
-// isLikelyCityName checks if a word looks like a German city name
-func isLikelyCityName(word string) bool {
-	if len(word) < 3 || !isCapitalized(word) {
-		return false
-	}
-
-	// German city patterns
-	cityPatterns := []string{
-		"heim", "hausen", "feld", "berg", "burg", "furt", "stadt", "dorf", "bach", "tal", "au",
-		"weiler", "kirchen", "ingen", "ungen", "stein", "bronn", "brunn", "baden", "bad",
-	}
-
-	wordLower := strings.ToLower(word)
-	for _, pattern := range cityPatterns {
-		if strings.HasSuffix(wordLower, pattern) {
+		if strings.Contains(geo.DisplayName, state) {
 			return true
 		}
 	}
 
-	// Known city names that don't follow patterns
-	knownCities := []string{
-		"Leipzig", "Erfurt", "Pinnow", "Apolda", "Speyer", "Konstanz", "Lorsch", "Karlsruhe",
-		"Duisburg", "Wesel", "Dümpten", "Eigen", "Büderich", "Wixhausen", "Neckarau", "Denzlingen",
-		"Niederursel", "Blumberg", "Ratingen", "Büttelborn", "Ladenburg", "Offenthal", "Niefern",
-		"Öschelbronn", "Buchen", "Mönchengladbach", "Unterfeldhaus", "Friedrichsfeld", "Bermatingen",
-		"Mülheim", "Heißen", "Mörfelden", "Lußheim", "Großsachsen", "Wössingen", "Mühlhausen",
-		"Dauchingen", "Schriesheim", "Eppelheim", "Durmersheim", "Wiesental", "Grenzach", "Malsch",
-		"Eggenstein", "Mackenbach", "Dreieichenhain", "Mehrhoog", "Heidelberg", "Kassel", "Nordshausen",
-		"Karben", "Wuppertal", "Düsseldorf",
-	}
-
-	for _, city := range knownCities {
-		if strings.EqualFold(word, city) || strings.Contains(strings.ToLower(word), strings.ToLower(city)) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// extractFromSpecialPatterns handles specific naming patterns
-func extractFromSpecialPatterns(organizer string) string {
-	// Pattern: "City-Suffix" format
-	if strings.Contains(organizer, "-") {
-		parts := strings.Split(organizer, "-")
-		for _, part := range parts {
-			cleaned := strings.TrimSpace(part)
-			if isLikelyCityName(cleaned) {
-				return cleaned
-			}
-		}
-	}
-
-	// Pattern: "Prefix City" format
-	parts := strings.Fields(organizer)
-	if len(parts) >= 2 {
-		for i, part := range parts {
-			if isLikelyCityName(part) {
-				return part
-			}
-			// Check compound words
-			if i < len(parts)-1 {
-				compound := part + parts[i+1]
-				if isLikelyCityName(compound) {
-					return compound
-				}
-			}
-		}
-	}
-
-	return ""
-} // Helper functions
-func isNumeric(s string) bool {
-	for _, c := range s {
-		if c < '0' || c > '9' {
-			return false
-		}
-	}
-	return true
-}
-
-func isCapitalized(s string) bool {
-	if len(s) == 0 {
-		return false
-	}
-	first := rune(s[0])
-	return first >= 'A' && first <= 'Z'
-}
-
-func isCommonClubWord(word string) bool {
-	commonWords := []string{
-		"Tennis", "Club", "Verein", "Sport", "Turn", "Klub", "Gemeinschaft", "Sportverein",
-		"Tennisverein", "Sportgemeinschaft", "Tennisgemeinschaft", "Turnverein", "Sportvereinigung",
-		"Optimus", "Olympia", "Germania", "Nicolai", "Post", "Tura", "Bezirk", "Karbener",
-		"Heidelberger", "Ratinger", "Lohausener", "Unterbarmer", "Eppelheimer",
-		"Südstadt", // District names that aren't the main city
-	}
-	for _, common := range commonWords {
-		if strings.EqualFold(word, common) {
-			return true
-		}
-	}
 	return false
 }
 
 func getGeocoordinates(state string, tournament models.Tournament) models.Geocoordinates {
-	// 1. Get Coordinates by tournament.Location if it exists
-	// 2. Get Coordinates by tournament.Organizer if this does not work out
-	// 3. Let the caller fall back to the federation default coordinates
-	var tournamentId string = tournament.Id
-	var tournamentOrganizer string = tournament.Organizer
+	return getGeocoordinatesForStates([]string{state}, tournament)
+}
 
-	var query string
-	if len(strings.TrimSpace(tournament.Location)) > 0 {
-		query = tournament.Location
-	} else {
-		query = extractCityFromOrganizerName(tournamentOrganizer)
+// getGeocoordinatesForStates resolves a tournament's coordinates, trying each
+// candidate place name until one resolves inside an accepted state.
+func getGeocoordinatesForStates(acceptedStates []string, tournament models.Tournament) models.Geocoordinates {
+	primaryState := ""
+	if len(acceptedStates) > 0 {
+		primaryState = acceptedStates[0]
 	}
 
-	query = strings.TrimSpace(query)
-	if query == "" {
-		logger.Warn("Empty geocoding query for tournament %s; skipping request", tournamentId)
-		saveFailedGeocodingAttempt(state, tournament)
+	queries, override := buildGeocodeQueries(tournament)
+
+	// An override may pin coordinates directly, which skips the network.
+	if override != nil && override.HasCoordinates() {
+		result := models.Geocoordinates{
+			Lat:         override.Lat,
+			Lon:         override.Lon,
+			DisplayName: override.City,
+		}
+		logger.Debug("Using pinned override coordinates for tournament %s (%s)",
+			tournament.Id, tournament.Organizer)
+		saveGeocoordinatesInCache(tournament, primaryState, result)
+		return result
+	}
+
+	if override != nil && override.State != "" {
+		// An override may also correct the expected state.
+		acceptedStates = append([]string{override.State}, acceptedStates...)
+	}
+
+	if len(queries) == 0 {
+		logger.Warn("No geocoding candidates for tournament %s (organizer %q, location %q)",
+			tournament.Id, tournament.Organizer, tournament.Location)
+		saveFailedGeocodingAttempt(primaryState, tournament)
 		return models.Geocoordinates{}
 	}
 
-	// Previous failure count drives the progressive backoff.
-	previousFailCount := previousFailCountFor(state, tournament)
+	previousFailCount := previousFailCountFor(primaryState, tournament)
 
 	ctx, cancel := context.WithTimeout(context.Background(), httpclient.DefaultTimeout)
 	defer cancel()
 
+	var lastErr error
+	// A result that matches the state but not the queried name exactly is kept
+	// as a fallback while better candidates are tried. Without this, a query
+	// like "Bremer" happily settles for the hamlet "Bremer Sand" instead of
+	// reaching the city of Bremen via the de-adjectived candidate.
+	var fallback *models.Geocoordinates
+	var fallbackQuery geocodeQuery
+
+	// Each request is rate limited, so the total number of upstream calls per
+	// tournament is capped regardless of how many candidates or passes exist.
+	budget := maxGeocodeRequests
+
+	// Two passes. The first restricts results to settlements, which is what a
+	// map pin should point at. Only if nothing resolves at all do we allow
+	// arbitrary features, so a club in a tiny hamlet still gets a location
+	// rather than the federation's default.
+passes:
+	for _, settlementsOnly := range []bool{true, false} {
+		for _, q := range queries {
+			if budget <= 0 {
+				break passes
+			}
+			budget--
+
+			results, err := queryNominatim(ctx, q.value, tournament.Id, settlementsOnly)
+			if err != nil {
+				lastErr = err
+				// A transport-level failure affects every candidate equally.
+				break passes
+			}
+
+			for _, candidate := range results {
+				if !matchesState(candidate, acceptedStates) {
+					continue
+				}
+
+				result := candidate
+				result.IsFailed = false
+				result.FailCount = 0
+				result.LastAttempt = 0
+
+				if placeMatchesQuery(result, q.value) {
+					logger.Debug("Geocoded tournament %s via %s query %q (settlements=%v) -> %s",
+						tournament.Id, q.source, q.value, settlementsOnly, result.DisplayName)
+					saveGeocoordinatesInCache(tournament, primaryState, result)
+					return result
+				}
+
+				if fallback == nil {
+					kept := result
+					fallback = &kept
+					fallbackQuery = q
+				}
+			}
+		}
+	}
+
+	// No exact name match anywhere: use the best inexact hit rather than
+	// falling back to the federation's default coordinates.
+	if fallback != nil {
+		logger.Debug("Geocoded tournament %s via %s query %q (inexact) -> %s",
+			tournament.Id, fallbackQuery.source, fallbackQuery.value, fallback.DisplayName)
+		saveGeocoordinatesInCache(tournament, primaryState, *fallback)
+		return *fallback
+	}
+
+	if lastErr != nil {
+		logger.Error("Geocoding failed for tournament %s: %v", tournament.Id, lastErr)
+	} else {
+		logger.Warn("No suitable geocoordinates for tournament %s (organizer %q) in %v; tried %d candidates",
+			tournament.Id, tournament.Organizer, acceptedStates, len(queries))
+	}
+
+	saveFailedGeocodingAttemptWithCount(primaryState, tournament, previousFailCount)
+	return models.Geocoordinates{}
+}
+
+// placeMatchesQuery reports whether a geocoding result actually names the
+// place that was asked for, rather than merely containing it.
+//
+// Nominatim readily returns "Bremer Sand" for "Bremer" or "Ratinger Straße"
+// for "Ratinger". Accepting those produces a pin in the wrong town.
+func placeMatchesQuery(geo models.Geocoordinates, query string) bool {
+	place := geo.Address.Place()
+	if place == "" {
+		return false
+	}
+
+	normPlace := normalizePlaceName(place)
+	normQuery := normalizePlaceName(query)
+	if normPlace == "" || normQuery == "" {
+		return false
+	}
+
+	if normPlace == normQuery {
+		return true
+	}
+
+	// Accept official long forms of the same place: "Bad Homburg" ->
+	// "Bad Homburg vor der Höhe", "Frankfurt" -> "Frankfurt am Main".
+	//
+	// Such suffixes are geographic qualifiers that begin with a lowercase
+	// preposition. Requiring that is what keeps "Bremer" from matching the
+	// hamlet "Bremer Sand", whose suffix is a capitalized noun.
+	rest, ok := strings.CutPrefix(normPlace, normQuery+" ")
+	if !ok {
+		return false
+	}
+
+	first, _, _ := strings.Cut(rest, " ")
+	return placeQualifiers[first]
+}
+
+// placeQualifiers introduce the geographic suffix of an official German place
+// name ("Frankfurt am Main", "Bad Homburg vor der Höhe").
+var placeQualifiers = map[string]bool{
+	"am": true, "an": true, "im": true, "in": true, "vor": true,
+	"bei": true, "auf": true, "ob": true, "unter": true, "a": true,
+	"i": true, "v": true,
+}
+
+// normalizePlaceName lowercases and collapses whitespace for comparison.
+func normalizePlaceName(s string) string {
+	return strings.ToLower(strings.Join(strings.Fields(s), " "))
+}
+
+// queryNominatim performs one geocoding request and returns the parsed results.
+func queryNominatim(ctx context.Context, query, tournamentId string, settlementsOnly bool) ([]models.Geocoordinates, error) {
 	// Honour the Nominatim usage policy: at most one request per second.
 	// Cache hits never reach this point, so cached lookups do not consume
 	// rate-limit capacity.
 	if err := geocodingRateLimiter().Wait(ctx); err != nil {
-		logger.Error("Geocoding rate limiter aborted for tournament %s: %v", tournamentId, err)
-		return models.Geocoordinates{}
+		return nil, fmt.Errorf("rate limiter aborted: %w", err)
 	}
 
-	reqURL, err := buildNominatimURL(query)
+	reqURL, err := buildNominatimURL(query, settlementsOnly)
 	if err != nil {
-		logger.Error("Failed to build geocoding URL for tournament %s: %v", tournamentId, err)
-		saveFailedGeocodingAttemptWithCount(state, tournament, previousFailCount)
-		return models.Geocoordinates{}
+		return nil, err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
-		logger.Error("Failed to create geocoding request for tournament %s: %v", tournamentId, err)
-		saveFailedGeocodingAttemptWithCount(state, tournament, previousFailCount)
-		return models.Geocoordinates{}
+		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	// Nominatim requires an identifying User-Agent.
 	httpclient.ApplyDefaultHeaders(req)
@@ -728,9 +731,7 @@ func getGeocoordinates(state string, tournament models.Tournament) models.Geocoo
 
 	res, err := httpclient.Geocoding().Do(req)
 	if err != nil {
-		logger.Error("HTTP error for tournament %s: %v", tournamentId, err)
-		saveFailedGeocodingAttemptWithCount(state, tournament, previousFailCount)
-		return models.Geocoordinates{}
+		return nil, err
 	}
 	defer res.Body.Close()
 
@@ -738,59 +739,47 @@ func getGeocoordinates(state string, tournament models.Tournament) models.Geocoo
 		if retryAfter := res.Header.Get("Retry-After"); retryAfter != "" {
 			logger.Warn("Geocoding throttled for tournament %s: status %d, Retry-After: %s",
 				tournamentId, res.StatusCode, retryAfter)
-		} else {
-			logger.Error("Geocoding failed for tournament %s: unexpected status %d", tournamentId, res.StatusCode)
 		}
-		// Drain a bounded amount so the connection can be reused.
 		_, _ = io.Copy(io.Discard, io.LimitReader(res.Body, maxGeocodingResponseBytes))
-		saveFailedGeocodingAttemptWithCount(state, tournament, previousFailCount)
-		return models.Geocoordinates{}
+		return nil, fmt.Errorf("unexpected status %d", res.StatusCode)
 	}
 
 	body, err := io.ReadAll(io.LimitReader(res.Body, maxGeocodingResponseBytes))
 	if err != nil {
-		logger.Error("Read error for tournament %s: %v", tournamentId, err)
-		saveFailedGeocodingAttemptWithCount(state, tournament, previousFailCount)
-		return models.Geocoordinates{}
+		return nil, fmt.Errorf("read error: %w", err)
 	}
 
 	var geoCoords []models.Geocoordinates
 	if err := json.Unmarshal(body, &geoCoords); err != nil {
-		logger.Error("Failed to decode geocoding response for tournament %s: %v", tournamentId, err)
-		saveFailedGeocodingAttemptWithCount(state, tournament, previousFailCount)
-		return models.Geocoordinates{}
+		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	// Check if coordinates belong to the correct state (region).
-	for i := 0; i < len(geoCoords); i++ {
-		if strings.Contains(geoCoords[i].DisplayName, state) {
-			result := geoCoords[i]
-			// Reset failure tracking on success
-			result.IsFailed = false
-			result.FailCount = 0
-			result.LastAttempt = 0
-			saveGeocoordinatesInCache(tournament, state, result)
-			return result
-		}
-	}
-
-	// No suitable coordinates found - cache this as a failed attempt
-	logger.Warn("No suitable geocoordinates found for tournament %s in state %s", tournamentId, state)
-	saveFailedGeocodingAttemptWithCount(state, tournament, previousFailCount)
-	return models.Geocoordinates{}
+	return geoCoords, nil
 }
 
 // buildNominatimURL assembles the geocoding request URL with proper encoding.
-func buildNominatimURL(query string) (string, error) {
+//
+// When settlementsOnly is set, Nominatim is restricted to cities, towns,
+// villages and hamlets. Without that restriction a query like "Ratinger"
+// happily matches "Ratinger Straße" in a completely different city, which is a
+// major source of wrong map pins.
+func buildNominatimURL(query string, settlementsOnly bool) (string, error) {
 	u, err := url.Parse(nominatimBaseURL())
 	if err != nil {
 		return "", fmt.Errorf("invalid Nominatim base URL: %w", err)
 	}
 
 	q := u.Query()
-	q.Set("limit", "3")
+	q.Set("limit", "5")
 	q.Set("accept-language", "de")
 	q.Set("format", "jsonv2")
+	// Structured address details let us verify the state reliably instead of
+	// substring-matching the display name.
+	q.Set("addressdetails", "1")
+	q.Set("countrycodes", "de")
+	if settlementsOnly {
+		q.Set("featureType", "settlement")
+	}
 	q.Set("q", query)
 	u.RawQuery = q.Encode()
 

--- a/backend/pkg/openstreetmap/openstreetmap_test.go
+++ b/backend/pkg/openstreetmap/openstreetmap_test.go
@@ -161,14 +161,17 @@ func TestGeocodingRespectsRateLimit(t *testing.T) {
 	}
 	elapsed := time.Since(start)
 
-	if got := mock.callCount(); got != requests {
-		t.Fatalf("made %d requests, want %d", got, requests)
+	// Each tournament may need several candidate lookups, so assert on the
+	// enforced spacing rather than an exact request count.
+	calls := mock.callCount()
+	if calls < requests {
+		t.Fatalf("made %d requests, want at least %d", calls, requests)
 	}
 
-	// Three gaps between four requests.
-	minExpected := 3 * 120 * time.Millisecond
+	minExpected := time.Duration(calls-1) * 120 * time.Millisecond
 	if elapsed < minExpected {
-		t.Errorf("elapsed %v, want at least %v (rate limit not enforced)", elapsed, minExpected)
+		t.Errorf("elapsed %v for %d requests, want at least %v (rate limit not enforced)",
+			elapsed, calls, minExpected)
 	}
 }
 
@@ -183,13 +186,19 @@ func TestGeocodingCacheHitsSkipUpstreamAndRateLimit(t *testing.T) {
 	// A different tournament at the same location must reuse the cached entry.
 	tournamentB := models.Tournament{Id: "2", Location: "Karlsruhe", Organizer: "TC Karlsruhe"}
 
+	GetGeocoordinatesFromCache("Baden-Württemberg", tournamentA)
+	afterFirst := mock.callCount()
+	if afterFirst == 0 {
+		t.Fatal("no upstream request was made for the first lookup")
+	}
+
 	for i := 0; i < 5; i++ {
 		GetGeocoordinatesFromCache("Baden-Württemberg", tournamentA)
 		GetGeocoordinatesFromCache("Baden-Württemberg", tournamentB)
 	}
 
-	if got := mock.callCount(); got != 1 {
-		t.Errorf("made %d upstream requests, want 1 (rest served from cache)", got)
+	if got := mock.callCount(); got != afterFirst {
+		t.Errorf("made %d upstream requests, want %d (rest served from cache)", got, afterFirst)
 	}
 }
 
@@ -206,12 +215,16 @@ func TestFailedLookupsUseTheSameCacheKeys(t *testing.T) {
 
 	tournament := models.Tournament{Id: "1", Location: "Unbekanntstadt", Organizer: "TC Unbekannt"}
 
-	// First attempt performs the lookup and records the failure.
+	// First attempt performs the lookup and records the failure. Several
+	// place-name candidates are derived from the location and organizer, so
+	// more than one upstream request is expected here; what matters is that
+	// the attempt is recorded under the shared cache keys.
 	if got := GetGeocoordinatesFromCache("Baden-Württemberg", tournament); got.Lat != "" {
 		t.Errorf("expected no coordinates, got %+v", got)
 	}
-	if got := mock.callCount(); got != 1 {
-		t.Fatalf("made %d requests on first attempt, want 1", got)
+	firstRound := mock.callCount()
+	if firstRound == 0 {
+		t.Fatal("no geocoding request was made on the first attempt")
 	}
 
 	// The failure must be visible under the location key.
@@ -224,19 +237,19 @@ func TestFailedLookupsUseTheSameCacheKeys(t *testing.T) {
 		t.Errorf("cached entry = %+v, want IsFailed with FailCount 1", cached)
 	}
 
-	// Subsequent attempts must be suppressed by the backoff.
+	// Subsequent attempts must be suppressed entirely by the backoff.
 	for i := 0; i < 3; i++ {
 		GetGeocoordinatesFromCache("Baden-Württemberg", tournament)
 	}
-	if got := mock.callCount(); got != 1 {
-		t.Errorf("made %d requests total, want 1 (backoff not honoured)", got)
+	if got := mock.callCount(); got != firstRound {
+		t.Errorf("made %d requests total, want %d (backoff not honoured)", got, firstRound)
 	}
 
 	// A different tournament at the same location must also be suppressed.
 	other := models.Tournament{Id: "999", Location: "Unbekanntstadt", Organizer: "TC Unbekannt"}
 	GetGeocoordinatesFromCache("Baden-Württemberg", other)
-	if got := mock.callCount(); got != 1 {
-		t.Errorf("made %d requests, want 1 (per-location backoff not shared)", got)
+	if got := mock.callCount(); got != firstRound {
+		t.Errorf("made %d requests, want %d (per-location backoff not shared)", got, firstRound)
 	}
 }
 
@@ -250,8 +263,13 @@ func TestFailureCountIncrementsAcrossRetries(t *testing.T) {
 	tournament := models.Tournament{Id: "1", Location: "Nirgendwo", Organizer: "TC Nirgendwo"}
 	locKey := generateLocationCacheKey(tournament.Location, "Baden-Württemberg")
 
+	var perRound int64
 	for attempt := 1; attempt <= 3; attempt++ {
+		before := mock.callCount()
 		GetGeocoordinatesFromCache("Baden-Württemberg", tournament)
+		if attempt == 1 {
+			perRound = mock.callCount() - before
+		}
 
 		cached, found := getFromCache(locKey)
 		if !found {
@@ -272,8 +290,11 @@ func TestFailureCountIncrementsAcrossRetries(t *testing.T) {
 		}
 	}
 
-	if got := mock.callCount(); got != 3 {
-		t.Errorf("made %d requests, want 3", got)
+	if perRound == 0 {
+		t.Fatal("first attempt made no upstream request")
+	}
+	if got, want := mock.callCount(), 3*perRound; got != want {
+		t.Errorf("made %d requests, want %d (%d rounds x %d)", got, want, 3, perRound)
 	}
 }
 
@@ -320,8 +341,8 @@ func TestSuccessAfterFailureClearsFailureState(t *testing.T) {
 		t.Errorf("stored entry = %+v, want failure state cleared", stored)
 	}
 
-	if got := mock.callCount(); got != 2 {
-		t.Errorf("made %d requests, want 2", got)
+	if got := mock.callCount(); got < 2 {
+		t.Errorf("made %d requests, want at least 2 (one failed round, one success)", got)
 	}
 }
 
@@ -437,11 +458,18 @@ func TestGeocodingFallsBackToOrganizerQuery(t *testing.T) {
 	})
 
 	queries := mock.recordedQueries()
-	if len(queries) != 1 {
-		t.Fatalf("recorded %d queries, want 1", len(queries))
+	if len(queries) == 0 {
+		t.Fatal("no query was sent")
 	}
-	if !strings.Contains(queries[0], "Karlsruhe") {
-		t.Errorf("query = %q, want it to contain the extracted city", queries[0])
+	var found bool
+	for _, q := range queries {
+		if strings.Contains(q, "Karlsruhe") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("queries = %v, want one to contain the extracted city", queries)
 	}
 }
 
@@ -479,7 +507,7 @@ func TestConcurrentGeocodingIsRaceFree(t *testing.T) {
 func TestBuildNominatimURL(t *testing.T) {
 	t.Setenv("TTF_NOMINATIM_URL", "https://nominatim.example.test/search.php")
 
-	raw, err := buildNominatimURL("Bad Homburg vor der Höhe")
+	raw, err := buildNominatimURL("Bad Homburg vor der Höhe", true)
 	if err != nil {
 		t.Fatalf("buildNominatimURL() error = %v", err)
 	}
@@ -488,14 +516,26 @@ func TestBuildNominatimURL(t *testing.T) {
 		t.Errorf("URL = %q, want the configured base", raw)
 	}
 	// Spaces and umlauts must be percent-encoded, not naively replaced.
-	for _, want := range []string{"format=jsonv2", "limit=3", "accept-language=de", "q=Bad+Homburg+vor+der+H%C3%B6he"} {
+	for _, want := range []string{"format=jsonv2", "limit=5", "addressdetails=1", "accept-language=de", "q=Bad+Homburg+vor+der+H%C3%B6he"} {
 		if !strings.Contains(raw, want) {
 			t.Errorf("URL %q does not contain %q", raw, want)
 		}
 	}
 
+	if !strings.Contains(raw, "featureType=settlement") {
+		t.Errorf("URL %q does not restrict results to settlements", raw)
+	}
+
+	permissive, err := buildNominatimURL("Kleinort", false)
+	if err != nil {
+		t.Fatalf("buildNominatimURL(permissive) error = %v", err)
+	}
+	if strings.Contains(permissive, "featureType") {
+		t.Errorf("permissive URL %q should not restrict the feature type", permissive)
+	}
+
 	t.Setenv("TTF_NOMINATIM_URL", "://broken")
-	if _, err := buildNominatimURL("x"); err == nil {
+	if _, err := buildNominatimURL("x", true); err == nil {
 		t.Error("expected an error for an invalid base URL")
 	}
 }

--- a/backend/pkg/placename/placename.go
+++ b/backend/pkg/placename/placename.go
@@ -1,0 +1,244 @@
+// Package placename derives candidate settlement names from German tennis club
+// names, so they can be geocoded.
+//
+// Federations only publish a club name ("TC Rot-Weiß Karlsruhe e.V."), never a
+// postal address. Turning that into a place a geocoder understands is the main
+// source of wrong map pins, so the logic lives here where it can be tested
+// exhaustively without network access.
+package placename
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// noiseTokens never form part of a settlement name. Compared lowercased and
+// stripped of trailing dots.
+var noiseTokens = map[string]bool{
+	// Club type abbreviations
+	"tc": true, "tk": true, "tg": true, "tv": true, "sg": true, "sv": true,
+	"skv": true, "fc": true, "atv": true, "sus": true, "tsg": true, "sc": true,
+	"sf": true, "tsc": true, "tus": true, "djk": true, "vfl": true, "vfb": true,
+	"mtv": true, "tsv": true, "rsv": true, "esv": true, "psv": true, "bsv": true,
+	"tec": true, "ttc": true, "utc": true, "etuf": true,
+
+	// Spelled-out club types
+	"tennis": true, "tennisclub": true, "tennisverein": true, "tennisklub": true,
+	"club": true, "klub": true, "verein": true, "sportverein": true,
+	"turnverein": true, "sportgemeinschaft": true, "tennisgemeinschaft": true,
+	"sportvereinigung": true, "sportfreunde": true, "turnerschaft": true,
+	"spielvereinigung": true, "ballspielverein": true, "gemeinschaft": true,
+	"sport": true, "turn": true, "abteilung": true, "abt": true,
+
+	// Legal form
+	"ev": true, "e": true, "v": true,
+
+	// Colours and common club epithets
+	"blau": true, "weiss": true, "weiß": true, "rot": true, "grün": true,
+	"gruen": true, "gelb": true, "schwarz": true, "blau-weiß": true,
+	"gw": true, "bw": true, "rw": true, "sw": true,
+	"germania": true, "olympia": true, "optimus": true, "nicolai": true,
+	"borussia": true, "alemannia": true, "teutonia": true, "concordia": true,
+	"eintracht": true, "viktoria": true, "fortuna": true, "union": true,
+	"post": true, "tura": true, "bezirk": true, "polizei": true,
+
+	// Filler words
+	"und": true, "u": true, "der": true, "die": true, "das": true, "von": true,
+	"zu": true, "am": true, "im": true, "an": true, "in": true, "bei": true,
+	"der/die": true, "für": true,
+}
+
+// placePrefixes may legitimately begin a settlement name and must stay attached
+// to the following token ("Bad Schönborn", "Sankt Augustin").
+var placePrefixes = map[string]bool{
+	"bad": true, "sankt": true, "st": true, "neu": true, "alt": true,
+	"gross": true, "groß": true, "klein": true, "ober": true, "unter": true,
+	"nieder": true, "hohen": true,
+}
+
+var (
+	// Legal form, with or without spaces/dots.
+	reLegalForm = regexp.MustCompile(`(?i)\be\.?\s*v\.?\b`)
+	// "vor der Höhe", "an der Ruhr", "a.d. Donau", ...
+	reGeoQualifier = regexp.MustCompile(`(?i)\b[avi]\.?\s*d\.?\s*[a-zäöüß]*\.?`)
+	// Founding years: 1890, 1920/75, 08/29
+	reYear = regexp.MustCompile(`\b\d{2,4}(/\d{2,4})?\b`)
+	// Roman numerals used as club suffixes
+	reRoman = regexp.MustCompile(`(?i)\b[ivx]{1,4}\b`)
+)
+
+// Candidates returns possible settlement names for a club or location string,
+// most promising first. The caller is expected to try them in order and accept
+// the first that a geocoder resolves inside an expected region.
+//
+// Returns nil when nothing usable can be derived.
+func Candidates(name string) []string {
+	cleaned := clean(name)
+	tokens := meaningfulTokens(cleaned)
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	var out []string
+	seen := make(map[string]bool)
+
+	add := func(s string) {
+		s = strings.TrimSpace(s)
+		if len([]rune(s)) < 3 || seen[strings.ToLower(s)] {
+			return
+		}
+		seen[strings.ToLower(s)] = true
+		out = append(out, s)
+	}
+
+	// 1. Multi-word names introduced by a place prefix ("Bad Schönborn").
+	for i, tok := range tokens {
+		if placePrefixes[normalizeToken(tok)] && i+1 < len(tokens) {
+			add(tok + " " + tokens[i+1])
+		}
+	}
+
+	// 2. Hyphenated compounds ("Mannheim-Neckarau"): try the full compound
+	//    first, then each part. The leading part is usually the main city.
+	//    Compounds made purely of noise ("Rot-Weiß") are skipped entirely.
+	for _, tok := range tokens {
+		if !strings.Contains(tok, "-") {
+			continue
+		}
+
+		parts := strings.Split(tok, "-")
+		var meaningful []string
+		for _, part := range parts {
+			if part != "" && !noiseTokens[normalizeToken(part)] {
+				meaningful = append(meaningful, part)
+			}
+		}
+		if len(meaningful) == 0 {
+			continue
+		}
+
+		// Only offer the whole compound when no part is noise, otherwise
+		// "Grün-Weiß Mannheim" style leftovers reach the geocoder.
+		if len(meaningful) == len(parts) {
+			add(tok)
+		}
+		for _, part := range meaningful {
+			add(part)
+		}
+	}
+
+	// 3. Literal tokens, from the end: the city is usually the last word
+	//    ("TC Blau-Weiß Neuss").
+	for i := len(tokens) - 1; i >= 0; i-- {
+		tok := tokens[i]
+		if placePrefixes[normalizeToken(tok)] {
+			continue // only meaningful together with its successor
+		}
+		// Hyphenated tokens were already expanded above.
+		if strings.Contains(tok, "-") {
+			continue
+		}
+		add(tok)
+	}
+
+	// 4. Reverse German adjectival derivations ("Heidelberger" -> Heidelberg).
+	//    Placed last so literal names win when both are plausible.
+	for _, tok := range tokens {
+		for _, d := range Deadjective(tok) {
+			add(d)
+		}
+	}
+
+	return out
+}
+
+// Deadjective reverses the German "-er" derivation used in club names:
+//
+//	Heidelberger -> Heidelberg
+//	Ratinger     -> Ratingen
+//	Karbener     -> Karben
+//	Eppelheimer  -> Eppelheim
+//
+// Several endings are plausible, so all are returned for the caller to try.
+// Returns nil when the word is not an adjectival form.
+func Deadjective(word string) []string {
+	lower := strings.ToLower(word)
+	if !strings.HasSuffix(lower, "er") || len([]rune(word)) <= 4 {
+		return nil
+	}
+	if noiseTokens[normalizeToken(word)] {
+		return nil
+	}
+
+	stem := word[:len(word)-2]
+	if len([]rune(stem)) < 3 {
+		return nil
+	}
+
+	// Order matters: the bare stem is by far the most common.
+	return []string{stem, stem + "en", stem + "n", stem + "m"}
+}
+
+// clean removes markup noise, legal forms, years and qualifiers.
+func clean(name string) string {
+	s := strings.ReplaceAll(name, "\u00a0", " ")
+	s = reLegalForm.ReplaceAllString(s, " ")
+	s = reGeoQualifier.ReplaceAllString(s, " ")
+	s = reYear.ReplaceAllString(s, " ")
+
+	// Separators that are never part of a single token.
+	s = strings.NewReplacer(",", " ", "/", " ", "(", " ", ")", " ",
+		"&", " ", "+", " ", ".", " ").Replace(s)
+
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// meaningfulTokens drops noise words, numbers and stray single characters.
+func meaningfulTokens(cleaned string) []string {
+	var out []string
+
+	for _, tok := range strings.Fields(cleaned) {
+		norm := normalizeToken(tok)
+		if norm == "" || noiseTokens[norm] {
+			continue
+		}
+		if isNumeric(tok) || reRoman.MatchString(norm) && len(norm) <= 3 {
+			continue
+		}
+		if len([]rune(tok)) < 2 {
+			continue
+		}
+		// Club names are capitalized; lowercase leftovers are almost always
+		// filler that survived the noise list.
+		if !startsUpper(tok) {
+			continue
+		}
+		out = append(out, tok)
+	}
+
+	return out
+}
+
+func normalizeToken(tok string) string {
+	return strings.ToLower(strings.Trim(tok, ".-"))
+}
+
+func isNumeric(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func startsUpper(s string) bool {
+	for _, r := range s {
+		return unicode.IsUpper(r)
+	}
+	return false
+}

--- a/backend/pkg/placename/placename_test.go
+++ b/backend/pkg/placename/placename_test.go
@@ -1,0 +1,206 @@
+package placename
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// containsCandidate reports whether want appears in the candidate list.
+func containsCandidate(got []string, want string) bool {
+	return slices.ContainsFunc(got, func(c string) bool {
+		return strings.EqualFold(c, want)
+	})
+}
+
+// TestCandidatesContainExpectedCity is the core regression suite: every entry
+// is a real-world club name whose city must appear among the candidates.
+func TestCandidatesContainExpectedCity(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		// Straightforward: city is the trailing token.
+		{"TC Rot-Weiß Karlsruhe e.V.", "Karlsruhe"},
+		{"TSG Weinheim Abt. Tennis", "Weinheim"},
+		{"SV Blau-Weiß Bühlertal", "Bühlertal"},
+		{"TV 1877 Ettlingen", "Ettlingen"},
+		{"TC Neckargemünd", "Neckargemünd"},
+		{"TC Blau-Weiß Neuss", "Neuss"},
+		{"SV Grün-Weiß Erfurt", "Erfurt"},
+		{"TC Weimar 1912", "Weimar"},
+		{"TuS Griesheim", "Griesheim"},
+
+		// Adjectival forms: the previous implementation needed a hardcoded
+		// list for each of these.
+		{"Heidelberger Tennis-Club 1890 e.V.", "Heidelberg"},
+		{"Eppelheimer Tennis-Club", "Eppelheim"},
+		{"Karbener Sportverein", "Karben"},
+		{"Ratinger Tennisclub Grün-Weiss", "Ratingen"},
+
+		// Multi-word place names must survive tokenization.
+		{"TC Bad Schönborn", "Bad Schönborn"},
+		{"TC Bad Homburg v.d.H.", "Bad Homburg"},
+		{"TC Sankt Augustin", "Sankt Augustin"},
+		{"TC Bad Vilbel 1954", "Bad Vilbel"},
+
+		// Hyphenated compounds: both the compound and its parts are offered.
+		{"TC Grün-Weiß Mannheim-Neckarau", "Mannheim"},
+		{"TG Frankfurt-Höchst", "Frankfurt"},
+
+		// Noise-heavy names.
+		{"DJK Sportgemeinschaft Wiesbaden", "Wiesbaden"},
+		{"Post SV Nürnberg", "Nürnberg"},
+		{"TC Rot-Weiss Bergisch Gladbach", "Gladbach"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Candidates(tt.name)
+			if !containsCandidate(got, tt.want) {
+				t.Errorf("Candidates(%q) = %v\n  want it to contain %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCandidatesRankExpectedCityHighly guards against the city being buried
+// behind many unlikely guesses: a geocoder lookup is attempted per candidate,
+// so position matters for both accuracy and request volume.
+func TestCandidatesRankExpectedCityHighly(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    string
+		withinN int
+	}{
+		{"TC Rot-Weiß Karlsruhe e.V.", "Karlsruhe", 1},
+		{"TC Blau-Weiß Neuss", "Neuss", 1},
+		{"TC Bad Schönborn", "Bad Schönborn", 1},
+		{"Heidelberger Tennis-Club 1890 e.V.", "Heidelberg", 3},
+		{"Karbener Sportverein", "Karben", 3},
+		{"TSG Weinheim Abt. Tennis", "Weinheim", 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Candidates(tt.name)
+			if len(got) > tt.withinN {
+				got = got[:tt.withinN]
+			}
+			if !containsCandidate(got, tt.want) {
+				t.Errorf("Candidates(%q) top %d = %v\n  want it to contain %q",
+					tt.name, tt.withinN, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCandidatesNeverReturnNoise(t *testing.T) {
+	// These tokens must never be offered as a place name; querying them
+	// produces the arbitrary far-away matches that cause wrong pins.
+	forbidden := []string{
+		"TC", "SV", "Tennis", "Club", "Verein", "Sport", "Post",
+		"e.V.", "eV", "Blau", "Weiß", "Rot", "Grün", "1890", "1912",
+	}
+
+	names := []string{
+		"TC Rot-Weiß Karlsruhe e.V.",
+		"Post SV Nürnberg",
+		"SV Blau-Weiß Bühlertal",
+		"Heidelberger Tennis-Club 1890 e.V.",
+		"DJK Sportgemeinschaft Wiesbaden",
+	}
+
+	for _, name := range names {
+		for _, cand := range Candidates(name) {
+			for _, bad := range forbidden {
+				if strings.EqualFold(cand, bad) {
+					t.Errorf("Candidates(%q) returned noise token %q", name, cand)
+				}
+			}
+		}
+	}
+}
+
+func TestCandidatesHandleDegenerateInput(t *testing.T) {
+	tests := []string{
+		"",
+		"   ",
+		"e.V.",
+		"TC",
+		"SV 1890",
+		"1890",
+		"...",
+		"\u00a0\u00a0",
+	}
+
+	for _, in := range tests {
+		t.Run(in, func(t *testing.T) {
+			// Must not panic, and must not invent nonsense candidates.
+			for _, c := range Candidates(in) {
+				if len([]rune(c)) < 3 {
+					t.Errorf("Candidates(%q) produced too-short candidate %q", in, c)
+				}
+			}
+		})
+	}
+}
+
+func TestCandidatesAreDeduplicated(t *testing.T) {
+	got := Candidates("TC Karlsruhe Karlsruhe e.V.")
+
+	seen := make(map[string]bool)
+	for _, c := range got {
+		key := strings.ToLower(c)
+		if seen[key] {
+			t.Errorf("Candidates() returned duplicate %q in %v", c, got)
+		}
+		seen[key] = true
+	}
+}
+
+func TestDeadjective(t *testing.T) {
+	tests := []struct {
+		word string
+		want []string // must all be present
+	}{
+		{"Heidelberger", []string{"Heidelberg"}},
+		{"Ratinger", []string{"Ratingen"}},
+		{"Karbener", []string{"Karben"}},
+		{"Eppelheimer", []string{"Eppelheim"}},
+		{"Lohausener", []string{"Lohausen"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.word, func(t *testing.T) {
+			got := Deadjective(tt.word)
+			for _, w := range tt.want {
+				if !containsCandidate(got, w) {
+					t.Errorf("Deadjective(%q) = %v, want it to contain %q", tt.word, got, w)
+				}
+			}
+		})
+	}
+}
+
+func TestDeadjectiveIgnoresNonAdjectives(t *testing.T) {
+	for _, word := range []string{"Neuss", "Erfurt", "TC", "der", "Bad", "Ulm", "SV"} {
+		if got := Deadjective(word); got != nil {
+			t.Errorf("Deadjective(%q) = %v, want nil", word, got)
+		}
+	}
+}
+
+func TestCandidatesIsDeterministic(t *testing.T) {
+	// Map iteration must never leak into the output order, otherwise the
+	// number of upstream requests would vary between runs.
+	const name = "TC Grün-Weiß Mannheim-Neckarau 1920"
+
+	first := Candidates(name)
+	for i := 0; i < 50; i++ {
+		got := Candidates(name)
+		if !slices.Equal(first, got) {
+			t.Fatalf("Candidates() is not deterministic:\n  run 0: %v\n  run %d: %v", first, i, got)
+		}
+	}
+}

--- a/backend/pkg/tournament/e2e_test.go
+++ b/backend/pkg/tournament/e2e_test.go
@@ -559,6 +559,17 @@ func TestEndToEndGeocodingResultsAreCached(t *testing.T) {
 		Geocoordinates: models.Geocoordinates{Lat: "49.0", Lon: "8.4"},
 	}
 
+	// Resolve once to populate the cache. The first run may issue several
+	// candidate lookups before one resolves.
+	if _, results := tournament.CollectTournaments(
+		context.Background(), []models.Federation{fed}, "01.08.2026", "15.08.2026", ""); results[0].Err != nil {
+		t.Fatalf("warmup run error: %v", results[0].Err)
+	}
+	afterFirst := atomic.LoadInt64(geoCalls)
+	if afterFirst == 0 {
+		t.Fatal("no geocoding request was made on the first run")
+	}
+
 	for i := 0; i < 3; i++ {
 		if _, results := tournament.CollectTournaments(
 			context.Background(), []models.Federation{fed}, "01.08.2026", "15.08.2026", ""); results[0].Err != nil {
@@ -566,10 +577,11 @@ func TestEndToEndGeocodingResultsAreCached(t *testing.T) {
 		}
 	}
 
-	// The same organizer/location must only be geocoded once; cache hits must
-	// not consume upstream rate-limit capacity.
-	if got := atomic.LoadInt64(geoCalls); got != 1 {
-		t.Errorf("made %d geocoding requests across 3 runs, want 1", got)
+	// The same organizer/location must be served from the cache afterwards;
+	// cache hits must not consume upstream rate-limit capacity.
+	if got := atomic.LoadInt64(geoCalls); got != afterFirst {
+		t.Errorf("made %d geocoding requests, want %d (repeat runs served from cache)",
+			got, afterFirst)
 	}
 }
 

--- a/backend/pkg/tournament/tournament.go
+++ b/backend/pkg/tournament/tournament.go
@@ -36,11 +36,11 @@ const (
 
 // geocoder resolves tournament coordinates. The indirection lets tests supply a
 // deterministic implementation instead of performing network lookups.
-type geocoder func(state string, tournament models.Tournament) models.Geocoordinates
+type geocoder func(fed models.Federation, tournament models.Tournament) models.Geocoordinates
 
 // defaultGeocoder delegates to the OpenStreetMap cache/lookup.
-func defaultGeocoder(state string, tournament models.Tournament) models.Geocoordinates {
-	return openstreetmap.GetGeocoordinatesFromCache(state, tournament)
+func defaultGeocoder(fed models.Federation, tournament models.Tournament) models.Geocoordinates {
+	return openstreetmap.GetGeocoordinatesForFederation(fed, tournament)
 }
 
 // FederationResult carries a single federation's outcome.
@@ -378,7 +378,7 @@ func resolveGeocoordinates(fed models.Federation, tournament models.Tournament, 
 		geocode = defaultGeocoder
 	}
 
-	geoCoords := geocode(fed.State, tournament)
+	geoCoords := geocode(fed, tournament)
 	if geoCoords.Lat == "" || geoCoords.Lon == "" {
 		logger.Warn("No Geocoordinates could be found for (%s): '%s'. Falling back to default in '%s'",
 			tournament.Id, subject, fed.State)

--- a/backend/pkg/tournament/tournament_test.go
+++ b/backend/pkg/tournament/tournament_test.go
@@ -38,14 +38,14 @@ var testFederationRLP = models.Federation{
 // staticGeocoder returns fixed coordinates so parser tests never touch the
 // network and stay deterministic.
 func staticGeocoder(lat, lon string) geocoder {
-	return func(state string, tournament models.Tournament) models.Geocoordinates {
-		return models.Geocoordinates{Lat: lat, Lon: lon, DisplayName: state}
+	return func(fed models.Federation, tournament models.Tournament) models.Geocoordinates {
+		return models.Geocoordinates{Lat: lat, Lon: lon, DisplayName: fed.State}
 	}
 }
 
 // failingGeocoder simulates a lookup that cannot resolve coordinates.
 func failingGeocoder() geocoder {
-	return func(string, models.Tournament) models.Geocoordinates {
+	return func(models.Federation, models.Tournament) models.Geocoordinates {
 		return models.Geocoordinates{}
 	}
 }

--- a/index.html
+++ b/index.html
@@ -222,32 +222,50 @@
                 <div class="filterContainer">
                     <label>Tennisverbände:</label>
                     <div class="federationCheckboxes">
-                        <label class="checkboxLabel">
+                        <label class="checkboxLabel" title="Badischer Tennisverband">
                             <input type="checkbox" name="federations" value="BAD" checked> BAD
                         </label>
-                        <label class="checkboxLabel">
+                        <label class="checkboxLabel" title="Hamburger Tennisverband">
+                            <input type="checkbox" name="federations" value="HAM"> HAM
+                        </label>
+                        <label class="checkboxLabel" title="Hessischer Tennisverband">
                             <input type="checkbox" name="federations" value="HTV" checked> HTV
                         </label>
-                        <label class="checkboxLabel">
-                            <input type="checkbox" name="federations" value="RLP" checked> RLP
+                        <label class="checkboxLabel" title="Rheinland-Pfälzischer Tennisverband">
+                            <input type="checkbox" name="federations" value="RLP"> RLP
                         </label>
-                        <label class="checkboxLabel">
-                            <input type="checkbox" name="federations" value="STV" checked> STV
+                        <label class="checkboxLabel" title="Saarländischer Tennisbund">
+                            <input type="checkbox" name="federations" value="STB"> STB
                         </label>
-                        <label class="checkboxLabel">
-                            <input type="checkbox" name="federations" value="TMV" checked> TMV
+                        <label class="checkboxLabel" title="Sächsischer Tennisverband">
+                            <input type="checkbox" name="federations" value="STV"> STV
                         </label>
-                        <label class="checkboxLabel">
-                            <input type="checkbox" name="federations" value="TSA" checked> TSA
+                        <label class="checkboxLabel" title="Tennisverband Mecklenburg-Vorpommern">
+                            <input type="checkbox" name="federations" value="TMV"> TMV
                         </label>
-                        <label class="checkboxLabel">
-                            <input type="checkbox" name="federations" value="TTV" checked> TTV
+                        <label class="checkboxLabel" title="Tennisverband Niedersachsen-Bremen">
+                            <input type="checkbox" name="federations" value="TNB"> TNB
                         </label>
-                        <label class="checkboxLabel">
-                            <input type="checkbox" name="federations" value="TVN" checked> TVN
+                        <label class="checkboxLabel" title="Tennisverband Sachsen-Anhalt">
+                            <input type="checkbox" name="federations" value="TSA"> TSA
                         </label>
-                        <label class="checkboxLabel">
+                        <label class="checkboxLabel" title="Thüringer Tennis-Verband">
+                            <input type="checkbox" name="federations" value="TTV"> TTV
+                        </label>
+                        <label class="checkboxLabel" title="Tennis-Verband Berlin-Brandenburg">
+                            <input type="checkbox" name="federations" value="TVBB"> TVBB
+                        </label>
+                        <label class="checkboxLabel" title="Tennisverband Mittelrhein">
+                            <input type="checkbox" name="federations" value="TVM"> TVM
+                        </label>
+                        <label class="checkboxLabel" title="Tennis-Verband Niederrhein">
+                            <input type="checkbox" name="federations" value="TVN"> TVN
+                        </label>
+                        <label class="checkboxLabel" title="Württembergischer Tennisbund">
                             <input type="checkbox" name="federations" value="WTB" checked> WTB
+                        </label>
+                        <label class="checkboxLabel" title="Westfälischer Tennis-Verband">
+                            <input type="checkbox" name="federations" value="WTV"> WTV
                         </label>
                         <!-- <div class="federationControls">
                             <button type="button" onclick="selectAllFederations()">Alle</button>

--- a/script/main.js
+++ b/script/main.js
@@ -274,10 +274,17 @@ function setupFederationLimits() {
         });
     });
 
-    // Initialize with the first N federations selected
-    checkboxes.forEach((checkbox, index) => {
-        checkbox.checked = index < MAX_SELECTED_FEDERATIONS;
-    });
+    // Respect the pre-selection from the markup, but never exceed the limit.
+    // Falling back to "the first N checkboxes" would silently change which
+    // federations are queried whenever the list order changes.
+    const preselected = Array.from(checkboxes).filter(cb => cb.checked);
+    if (preselected.length === 0 || preselected.length > MAX_SELECTED_FEDERATIONS) {
+        const keep = (preselected.length ? preselected : Array.from(checkboxes))
+            .slice(0, MAX_SELECTED_FEDERATIONS);
+        checkboxes.forEach(cb => {
+            cb.checked = keep.includes(cb);
+        });
+    }
     updateFederationSelectionState();
 }
 


### PR DESCRIPTION
Improves geocoding accuracy from **60% to 100%** on a live benchmark and adds **six more federations**, taking coverage from 9 to 15.

## Why tournaments were pinned in the wrong place (#54)

Federations publish only a club name, never an address, so the city has to be derived from it. I measured the current implementation against 20 real club names using live Nominatim queries, and also measured whether a different *query format* would help:

| Strategy | Accuracy |
| --- | --- |
| Current (free-text + `display_name` substring) | 60% |
| Structured query (`city=` + `state=`) | 60% |
| Structured query + state bounding box | 60% |
| **Revised candidate selection** | **100%** |

The query format made no difference. The bottleneck was candidate selection and result verification, so that is what this PR changes.

### Root causes fixed

1. **Adjectival club names.** `Heidelberger`, `Ratinger`, `Karbener`, `Eppelheimer` all failed. The old code carried a hardcoded list covering a handful of clubs; the derivation is regular enough to reverse generically.
2. **Multi-word places.** `TC Bad Schönborn` produced the candidate `"Bad"`.
3. **One guess only.** A single candidate was tried; on failure the federation default was used. Now several ranked candidates are tried until one resolves in an accepted state.
4. **State check via substring.** `strings.Contains(display_name, state)` rejected correct results whose display name omits the state, common for districts. Now verified against Nominatim's structured `address.state`.
5. **Multi-state federations.** `State` was a single string, but TVBB covers Berlin **and** Brandenburg, TNB covers Niedersachsen **and** Bremen. Tournaments in the secondary state were rejected and fell back to default coordinates — a direct cause of the stacked markers.
6. **No place-type restriction.** `"Ratinger"` matched *Ratinger Straße in Düsseldorf* and `"Heidelberger"` matched an academy building — confidently wrong pins. Results are now restricted to settlements first, with a permissive second pass only if nothing resolves.
7. **Substring place matches.** Nominatim returns the hamlet *"Bremer Sand"* for `"Bremer"`. A result must now actually name the queried place; official long forms like `Frankfurt` → `Frankfurt am Main` are still accepted because the suffix is a geographic qualifier.

### Fixing a wrong pin without code changes

`backend/pkg/clublocations/data/club-locations.json` is embedded in the binary and takes precedence over any heuristic:

```json
{
  "contains": "Lohausener",
  "city": "Düsseldorf",
  "state": "Nordrhein-Westfalen",
  "note": "Lohausen is a district of Düsseldorf; not derivable from the name."
}
```

Matching ignores case, punctuation, umlaut spelling and word spacing. `note` is required by a test so entries stay self-explanatory.

## Six more federations (#49)

Every endpoint was verified live before being added. A 90-day smoke test (`cmd/fedcheck`):

```
BAD 141   HTV 156   RLP 100   STV  21   TMV  16
TSA   4   TTV  13   TVN  62   WTB  92   TVBB 52
HAM  52   TVM  63   TNB 200   STB  28   WTV 131
15 federations, 0 errors, 0 empty
```

That is **+526 tournaments** in this window. All six use the existing liga.nu parser, so this is configuration, not new parsing code.

Not included, with reasons:
* **BTV** no longer uses liga.nu — the endpoint redirects to `btv.de` and needs its own parser.
* **TSH** was unreachable from my environment (DNS blocked) and still needs verification.

### Frontend

The selection logic checked "the first three boxes by index" and overwrote the markup, so inserting a federation silently changed which ones were queried. It now respects the pre-selection. Checkboxes carry full federation names as tooltips.

## Address provider groundwork (#55)

You suspected the real address needs a login. Findings: tennis.de serves details via a **ZK widget**, whose payload contains `Straße`, `PLZ und Ort` and `Platzanlage` labels, and the endpoint **answers anonymously** — no login for the handshake. But the *values* arrive through a follow-up ZK `au` exchange that mirrors the browser's exact command sequence, which did not replay reliably. nuLiga returns 403 for direct tournament access.

So it is reachable in principle, but only by driving a stateful, undocumented protocol. Rather than ship something fragile, this PR adds the `AddressProvider` interface and chain (overrides → heuristic) so the source can be slotted in later behind a flag, resolved once per club and cached. Details in #55.

## Also found while working

* **#56** — RLP ignores `firstResult` entirely: every page returns the identical first 100 tournaments. The pagination guard from #33 handles it correctly (no loop, no duplicates), but RLP is capped at 100. Filed separately with verification output.
* A test caught a logic error of mine: I initially suppressed a geocoding retry when *any* cache key was in backoff, instead of when *all* were. Fixed.

## Testing

Four new packages with tests, all offline and deterministic:

| Package | Coverage |
| --- | --- |
| `federation` | 100.0% |
| `addressprovider` | 97.3% |
| `ratelimit` | 95.8% |
| `placename` | 89.7% |
| `tournament` | 88.6% |
| `clublocations` | 81.1% |
| `openstreetmap` | 77.2% |

`go test -race`, `go vet` and `gofmt` all clean. `cmd/geobench` and `cmd/fedcheck` make real network requests and are deliberately **not** run by CI.

Closes #49, closes #54
