### PR TITLE
feat: cache tournament results and surface partial failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ full output while debugging a failure.
 | `TTF_NOMINATIM_URL` | `https://nominatim.openstreetmap.org/search.php` | Geocoding endpoint. Point this at a self-hosted Nominatim instance if you need higher throughput. |
 | `TTF_NOMINATIM_INTERVAL_MS` | `1000` | Minimum spacing between uncached geocoding requests. Do not lower this for the shared public instance. |
 | `TTF_CLUB_LOCATIONS` | *(embedded file)* | Path to a custom club location override file. |
+| `TTF_RESULT_CACHE` | `true` | Set to `false` to bypass the tournament result cache. |
+| `TTF_RESULT_CACHE_PATH` | `./data/results.bolt` | BoltDB file backing the result cache. |
+| `TTF_CACHE_TTL_MINUTES` | `120` | How long cached tournament results stay fresh. |
+| `TTF_CACHE_STALE_MINUTES` | `1440` | How long expired results may still be served when a federation is unreachable. |
+| `TTF_SCHEDULER_WARMUP_DAYS` | `30` | How far ahead the scheduled run pre-fetches. |
 
 #### External service usage
 
@@ -107,6 +112,49 @@ agent above and are serialized process-wide by a rate limiter. Cached lookups
 never reach the network, so they do not consume that budget. See the
 [Nominatim usage policy](https://operations.osmfoundation.org/policies/nominatim/)
 before raising the request rate.
+
+### Result caching
+
+Tournament results are cached per federation and query, so a user request
+normally performs no scraping at all.
+
+* **Keyed** by federation, date range and competition type, so one slow
+  federation never holds up the others and a refresh only redoes expired work.
+* **Persistent** (BoltDB), so a restart keeps whatever the scheduler fetched.
+* **Stale-tolerant**: when a federation is unreachable, the expired copy is
+  still served (up to `TTF_CACHE_STALE_MINUTES`) and marked as stale, because
+  an out-of-date list is far more useful than an empty map.
+* **Stampede-safe**: concurrent misses for the same key trigger a single
+  upstream fetch.
+
+Cache contents are visible at `http://127.0.0.1:9090/stats` under
+`result_cache`, including how many entries are fresh, stale or expired.
+
+Enable the scheduler to keep the cache warm ahead of user traffic; it
+invalidates before fetching, so a scheduled run always retrieves current data.
+
+### API response format
+
+By default the API returns a bare JSON array of tournaments, which is what
+older clients expect.
+
+Pass `?format=full` for per-federation status, so a client can tell "no
+tournaments match" apart from "this federation is down":
+
+```json
+{
+  "tournaments": [ ... ],
+  "federations": [
+    { "id": "BAD", "name": "Badischer Tennisverband", "status": "ok", "count": 141 },
+    { "id": "WTV", "name": "Westfälischer Tennis-Verband", "status": "stale", "count": 131, "age_seconds": 7200 }
+  ],
+  "partial": true
+}
+```
+
+`status` is one of `ok`, `cached`, `stale` or `error`. `partial` is true when
+any federation failed or is serving stale data; the frontend surfaces that as a
+banner instead of silently showing fewer tournaments.
 
 ### Geocoding and map pins
 

--- a/backend/cmd/cachebench/main.go
+++ b/backend/cmd/cachebench/main.go
@@ -1,0 +1,117 @@
+// Command cachebench measures the effect of the result cache against live
+// federation endpoints: a cold run scrapes, a warm run should not.
+//
+// It makes real network requests and is a manual tool, never run by CI.
+//
+// Usage:
+//
+//	go run ./cmd/cachebench                # all federations, 30-day window
+//	go run ./cmd/cachebench -fed BAD,HTV   # a subset
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/timoknapp/tennis-tournament-finder/pkg/federation"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/resultcache"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/tournament"
+)
+
+func main() {
+	days := flag.Int("days", 30, "size of the date window in days")
+	feds := flag.String("fed", "", "comma-separated federation IDs (default: all)")
+	flag.Parse()
+
+	logger.SetLogLevel(logger.ErrorLevel)
+
+	tmp, err := os.MkdirTemp("", "cachebench")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to create temp dir:", err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(tmp)
+
+	os.Setenv("TTF_CACHE_PATH", tmp+"/geo.bolt")
+	// Geocoding is rate limited and would dominate the measurement; the cache
+	// effect being measured here is about federation scraping.
+	os.Setenv("TTF_NOMINATIM_URL", "http://127.0.0.1:9/disabled")
+	os.Setenv("TTF_NOMINATIM_INTERVAL_MS", "0")
+	os.Setenv("TTF_GEOCODING_TIMEOUT_SECONDS", "1")
+
+	store, err := resultcache.NewBoltStore(tmp + "/results.bolt")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to open result cache:", err)
+		os.Exit(1)
+	}
+	cache := resultcache.New(store, resultcache.Options{
+		TTL:      time.Hour,
+		StaleTTL: 24 * time.Hour,
+	})
+	defer cache.Close()
+	tournament.SetResultCache(cache)
+
+	selected := tournament.FilterFederations(federation.GetFederations(), *feds)
+
+	now := time.Now()
+	dateFrom := now.Format("02.01.2006")
+	dateTo := now.AddDate(0, 0, *days).Format("02.01.2006")
+
+	fmt.Printf("Window: %s .. %s, %d federations\n\n", dateFrom, dateTo, len(selected))
+
+	// Cold: nothing cached yet.
+	coldStart := time.Now()
+	coldTournaments, coldResults := tournament.CollectTournaments(
+		context.Background(), selected, dateFrom, dateTo, "")
+	cold := time.Since(coldStart)
+
+	// Warm: everything should now come from the cache.
+	warmStart := time.Now()
+	warmTournaments, warmResults := tournament.CollectTournaments(
+		context.Background(), selected, dateFrom, dateTo, "")
+	warm := time.Since(warmStart)
+
+	cachedCount := 0
+	for _, r := range warmResults {
+		if r.Cached {
+			cachedCount++
+		}
+	}
+
+	failed := 0
+	for _, r := range coldResults {
+		if r.Err != nil {
+			failed++
+		}
+	}
+
+	fmt.Printf("%-22s %s\n", "cold (scraping):", cold.Round(time.Millisecond))
+	fmt.Printf("%-22s %s\n", "warm (cached):", warm.Round(time.Millisecond))
+	if warm > 0 {
+		fmt.Printf("%-22s %.0fx faster\n", "speedup:", float64(cold)/float64(warm))
+	}
+	fmt.Println(strings.Repeat("-", 50))
+	fmt.Printf("tournaments: cold %d, warm %d\n", len(coldTournaments), len(warmTournaments))
+	fmt.Printf("served from cache on warm run: %d/%d federations\n", cachedCount, len(warmResults))
+	fmt.Printf("federations failing on cold run: %d\n", failed)
+
+	stats, err := cache.Stats()
+	if err == nil {
+		fmt.Printf("cache entries: %d (fresh %d), tournaments stored: %d\n",
+			stats.Entries, stats.Fresh, stats.Tournaments)
+	}
+
+	if len(coldTournaments) != len(warmTournaments) {
+		fmt.Fprintln(os.Stderr, "\nWARNING: cached run returned a different tournament count")
+		os.Exit(1)
+	}
+	if cachedCount != len(warmResults) {
+		fmt.Fprintln(os.Stderr, "\nWARNING: not every federation was served from cache")
+		os.Exit(1)
+	}
+}

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/metrics"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/openstreetmap"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/resultcache"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/scheduler"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/tournament"
 )
@@ -23,6 +24,7 @@ var (
 	globalScheduler   *scheduler.Scheduler
 	globalSchedulerMu sync.Mutex
 	reloadMu          sync.Mutex
+	globalResultCache *resultcache.Cache
 )
 
 // newServer builds an HTTP server with defensive timeouts so slow or
@@ -39,11 +41,55 @@ func newServer(addr string, handler http.Handler) *http.Server {
 	}
 }
 
+// initResultCache wires up the tournament result cache.
+//
+// A failure to open the persistent store is not fatal: caching falls back to
+// memory, which still spares the federations most of the load and only costs
+// the cache contents on restart.
+func initResultCache() {
+	if !resultcache.Enabled() {
+		logger.Info("Result cache disabled (TTF_RESULT_CACHE=false)")
+		return
+	}
+
+	path := os.Getenv("TTF_RESULT_CACHE_PATH")
+	if path == "" {
+		path = "./data/results.bolt"
+	}
+
+	var store resultcache.Store
+	boltStore, err := resultcache.NewBoltStore(path)
+	if err != nil {
+		logger.Error("Failed to open result cache at %s, falling back to memory: %v", path, err)
+		store = resultcache.NewMemoryStore()
+	} else {
+		store = boltStore
+	}
+
+	opts := resultcache.OptionsFromEnv()
+	cache := resultcache.New(store, opts)
+	tournament.SetResultCache(cache)
+	globalResultCache = cache
+
+	// Expose cache contents through /stats so freshness is observable.
+	metrics.SetResultCacheProvider(func() any {
+		stats, err := cache.Stats()
+		if err != nil {
+			return map[string]string{"error": err.Error()}
+		}
+		return stats
+	})
+
+	logger.Info("Result cache enabled (path=%s, ttl=%s, stale=%s)", path, opts.TTL, opts.StaleTTL)
+}
+
 func main() {
 	logger.Info("Starting Tennis Tournament Finder backend server...")
 
 	openstreetmap.InitCache()
 	logger.Info("OpenStreetMap cache initialized")
+
+	initResultCache()
 
 	// Lightweight metrics (no Prometheus required)
 	metrics.Init()
@@ -109,6 +155,12 @@ func main() {
 			globalScheduler.Stop()
 		}
 		globalSchedulerMu.Unlock()
+
+		if globalResultCache != nil {
+			if err := globalResultCache.Close(); err != nil {
+				logger.Error("Result cache shutdown error: %v", err)
+			}
+		}
 
 		openstreetmap.CloseCache()
 		os.Exit(0)

--- a/backend/pkg/metrics/simple.go
+++ b/backend/pkg/metrics/simple.go
@@ -176,6 +176,7 @@ func StatsHandler(w http.ResponseWriter, r *http.Request) {
 		RequestsPerMinuteLast10m:  rpm,
 		ActiveUsers5m:             int64(len(st.active)),
 		RequestsByMethodAndStatus: methodStatus,
+		ResultCache:               resultCacheSnapshot(),
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -195,7 +196,35 @@ type stats struct {
 	RequestsPerMinuteLast10m  []int64                     `json:"requests_last_10m_newest_first"`
 	ActiveUsers5m             int64                       `json:"active_users_5m"`
 	RequestsByMethodAndStatus map[string]map[string]int64 `json:"requests_by_method_status"`
+	ResultCache               any                         `json:"result_cache,omitempty"`
 }
+
+// resultCacheProvider supplies cache statistics for the diagnostics endpoint.
+// It is a function so this package does not import the cache (which would
+// create an import cycle through the tournament package).
+var (
+	resultCacheProvider   func() any
+	resultCacheProviderMu sync.RWMutex
+)
+
+// SetResultCacheProvider registers a source of result-cache statistics.
+func SetResultCacheProvider(fn func() any) {
+	resultCacheProviderMu.Lock()
+	defer resultCacheProviderMu.Unlock()
+	resultCacheProvider = fn
+}
+
+func resultCacheSnapshot() any {
+	resultCacheProviderMu.RLock()
+	fn := resultCacheProvider
+	resultCacheProviderMu.RUnlock()
+
+	if fn == nil {
+		return nil
+	}
+	return fn()
+}
+
 type metricsState struct {
 	mu sync.Mutex
 

--- a/backend/pkg/resultcache/resultcache.go
+++ b/backend/pkg/resultcache/resultcache.go
@@ -1,0 +1,352 @@
+// Package resultcache stores tournament results per federation so user
+// requests do not have to scrape federation websites live.
+//
+// Without it, every request fans out to each selected federation, which is
+// slow, amplifies upstream failures and is the reason the frontend limits
+// users to a handful of federations at a time.
+//
+// The cache is:
+//
+//   - keyed per federation and query, so one slow federation cannot hold up
+//     the others and a refresh only redoes the work that expired
+//   - persistent, so a restart does not throw away work the scheduler did
+//   - stale-tolerant: expired data is still served when the upstream is
+//     unavailable, with its age reported so callers can surface it
+//   - stampede-safe: concurrent misses for the same key trigger one refresh
+package resultcache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
+)
+
+// Default cache lifetimes. Tournament calendars change slowly: entries are
+// added days or weeks in advance, so an hour-old list is materially the same
+// list.
+const (
+	DefaultTTL = 2 * time.Hour
+	// DefaultStaleTTL is how long expired data may still be served when the
+	// upstream cannot be reached. Stale results beat an empty map.
+	DefaultStaleTTL = 24 * time.Hour
+)
+
+// Entry is one cached federation result.
+type Entry struct {
+	FederationID string              `json:"federation_id"`
+	Query        string              `json:"query"`
+	Tournaments  []models.Tournament `json:"tournaments"`
+	StoredAt     time.Time           `json:"stored_at"`
+	// Err records why the last refresh failed, if it did. An entry can hold
+	// both tournaments and an error: the data is from an earlier successful
+	// run and the error explains why it was not refreshed.
+	Err string `json:"err,omitempty"`
+}
+
+// Age reports how long ago the entry was stored.
+func (e Entry) Age(now time.Time) time.Duration {
+	return now.Sub(e.StoredAt)
+}
+
+// Key identifies a cached query for one federation.
+type Key struct {
+	FederationID string
+	DateFrom     string
+	DateTo       string
+	CompType     string
+}
+
+// String renders the key for storage and logging.
+func (k Key) String() string {
+	return strings.Join([]string{k.FederationID, k.DateFrom, k.DateTo, k.CompType}, "|")
+}
+
+// Store persists cache entries.
+type Store interface {
+	Get(key string) (Entry, bool, error)
+	Set(key string, entry Entry) error
+	Delete(key string) error
+	ForEach(fn func(key string, entry Entry) error) error
+	Close() error
+}
+
+// Loader fetches fresh results for a key. It is the expensive operation the
+// cache exists to avoid.
+type Loader func(ctx context.Context, key Key) ([]models.Tournament, error)
+
+// Result is what the cache returns to a caller.
+type Result struct {
+	Tournaments []models.Tournament
+	// Age is zero for a freshly loaded result.
+	Age time.Duration
+	// Stale reports that the TTL had expired and the upstream could not be
+	// refreshed, so this is older data.
+	Stale bool
+	// Cached reports that no upstream request was made.
+	Cached bool
+	// Err is the refresh error when stale data is returned, or the load error
+	// when nothing could be served.
+	Err error
+}
+
+// Cache serves tournament results, refreshing them on demand.
+type Cache struct {
+	store Store
+	ttl   time.Duration
+	stale time.Duration
+
+	// now is injectable so tests do not depend on wall-clock time.
+	now func() time.Time
+
+	// inflight collapses concurrent refreshes of the same key.
+	mu       sync.Mutex
+	inflight map[string]*call
+}
+
+type call struct {
+	done chan struct{}
+	res  Result
+}
+
+// Options configures a Cache.
+type Options struct {
+	TTL      time.Duration
+	StaleTTL time.Duration
+	Now      func() time.Time
+}
+
+// New creates a cache backed by store.
+func New(store Store, opts Options) *Cache {
+	ttl := opts.TTL
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	stale := opts.StaleTTL
+	if stale <= 0 {
+		stale = DefaultStaleTTL
+	}
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+
+	return &Cache{
+		store:    store,
+		ttl:      ttl,
+		stale:    stale,
+		now:      now,
+		inflight: make(map[string]*call),
+	}
+}
+
+// OptionsFromEnv reads cache tuning from the environment.
+func OptionsFromEnv() Options {
+	return Options{
+		TTL:      durationFromEnv("TTF_CACHE_TTL_MINUTES", DefaultTTL),
+		StaleTTL: durationFromEnv("TTF_CACHE_STALE_MINUTES", DefaultStaleTTL),
+	}
+}
+
+// Enabled reports whether result caching is switched on. It defaults to true;
+// set TTF_RESULT_CACHE=false to bypass the cache entirely.
+func Enabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("TTF_RESULT_CACHE")))
+	return v != "false" && v != "0" && v != "off"
+}
+
+func durationFromEnv(key string, fallback time.Duration) time.Duration {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback
+	}
+	minutes, err := strconv.Atoi(raw)
+	if err != nil || minutes < 0 {
+		return fallback
+	}
+	return time.Duration(minutes) * time.Minute
+}
+
+// TTL returns the configured freshness window.
+func (c *Cache) TTL() time.Duration { return c.ttl }
+
+// Get returns results for key, loading them when the cached copy is missing or
+// expired.
+//
+// Behaviour on a failed refresh is deliberate: usable stale data is preferred
+// over an error, because an out-of-date tournament list is far more useful to
+// a player than an empty map.
+func (c *Cache) Get(ctx context.Context, key Key, load Loader) Result {
+	if c == nil {
+		tournaments, err := load(ctx, key)
+		return Result{Tournaments: tournaments, Err: err}
+	}
+
+	k := key.String()
+	now := c.now()
+
+	cached, found, err := c.store.Get(k)
+	if err != nil {
+		// A broken cache must never take down the request path.
+		cached, found = Entry{}, false
+	}
+
+	if found && cached.Age(now) < c.ttl && cached.Tournaments != nil {
+		return Result{
+			Tournaments: cached.Tournaments,
+			Age:         cached.Age(now),
+			Cached:      true,
+		}
+	}
+
+	// Miss or expired: refresh, collapsing concurrent callers.
+	res := c.refresh(ctx, key, load)
+
+	// Refresh failed: fall back to stale data when it is still within the
+	// stale window.
+	if res.Err != nil && found && cached.Tournaments != nil {
+		age := cached.Age(now)
+		if age < c.stale {
+			return Result{
+				Tournaments: cached.Tournaments,
+				Age:         age,
+				Stale:       true,
+				Cached:      true,
+				Err:         res.Err,
+			}
+		}
+	}
+
+	return res
+}
+
+// refresh loads fresh data, ensuring only one load per key runs at a time.
+func (c *Cache) refresh(ctx context.Context, key Key, load Loader) Result {
+	k := key.String()
+
+	c.mu.Lock()
+	if existing, ok := c.inflight[k]; ok {
+		c.mu.Unlock()
+		// Wait for the in-flight refresh instead of starting a second one.
+		select {
+		case <-existing.done:
+			return existing.res
+		case <-ctx.Done():
+			return Result{Err: ctx.Err()}
+		}
+	}
+
+	cl := &call{done: make(chan struct{})}
+	c.inflight[k] = cl
+	c.mu.Unlock()
+
+	tournaments, err := load(ctx, key)
+
+	if err == nil {
+		entry := Entry{
+			FederationID: key.FederationID,
+			Query:        k,
+			Tournaments:  tournaments,
+			StoredAt:     c.now(),
+		}
+		if storeErr := c.store.Set(k, entry); storeErr != nil {
+			// Failing to persist is not fatal; the data is still returned.
+			err = nil
+		}
+	}
+
+	cl.res = Result{Tournaments: tournaments, Err: err}
+
+	c.mu.Lock()
+	delete(c.inflight, k)
+	c.mu.Unlock()
+	close(cl.done)
+
+	return cl.res
+}
+
+// Invalidate removes a cached entry.
+func (c *Cache) Invalidate(key Key) error {
+	if c == nil {
+		return nil
+	}
+	return c.store.Delete(key.String())
+}
+
+// Stats summarises cache contents for diagnostics.
+type Stats struct {
+	Entries       int            `json:"entries"`
+	Fresh         int            `json:"fresh"`
+	Stale         int            `json:"stale"`
+	Expired       int            `json:"expired"`
+	Tournaments   int            `json:"tournaments"`
+	OldestSecond  int64          `json:"oldest_entry_seconds"`
+	PerFederation map[string]int `json:"per_federation"`
+}
+
+// Stats inspects the cache.
+func (c *Cache) Stats() (Stats, error) {
+	stats := Stats{PerFederation: make(map[string]int)}
+	if c == nil {
+		return stats, nil
+	}
+
+	now := c.now()
+	err := c.store.ForEach(func(_ string, entry Entry) error {
+		stats.Entries++
+		stats.Tournaments += len(entry.Tournaments)
+		stats.PerFederation[entry.FederationID] += len(entry.Tournaments)
+
+		age := entry.Age(now)
+		switch {
+		case age < c.ttl:
+			stats.Fresh++
+		case age < c.stale:
+			stats.Stale++
+		default:
+			stats.Expired++
+		}
+
+		if secs := int64(age.Seconds()); secs > stats.OldestSecond {
+			stats.OldestSecond = secs
+		}
+		return nil
+	})
+
+	return stats, err
+}
+
+// Close releases the underlying store.
+func (c *Cache) Close() error {
+	if c == nil {
+		return nil
+	}
+	return c.store.Close()
+}
+
+// ErrNotFound is returned by stores for a missing key.
+var ErrNotFound = errors.New("cache entry not found")
+
+// encode/decode are shared by store implementations.
+func encode(entry Entry) ([]byte, error) {
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode cache entry: %w", err)
+	}
+	return data, nil
+}
+
+func decode(data []byte) (Entry, error) {
+	var entry Entry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return Entry{}, fmt.Errorf("failed to decode cache entry: %w", err)
+	}
+	return entry, nil
+}

--- a/backend/pkg/resultcache/resultcache_test.go
+++ b/backend/pkg/resultcache/resultcache_test.go
@@ -1,0 +1,528 @@
+package resultcache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
+)
+
+// fakeClock gives tests deterministic control over cache expiry.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+func testKey() Key {
+	return Key{FederationID: "BAD", DateFrom: "01.08.2026", DateTo: "15.08.2026"}
+}
+
+func tournaments(ids ...string) []models.Tournament {
+	out := make([]models.Tournament, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, models.Tournament{Id: id, Title: "Turnier " + id})
+	}
+	return out
+}
+
+// countingLoader records how often the expensive path was taken.
+func countingLoader(calls *int64, result []models.Tournament, err error) Loader {
+	return func(ctx context.Context, key Key) ([]models.Tournament, error) {
+		atomic.AddInt64(calls, 1)
+		return result, err
+	}
+}
+
+func newTestCache(clock *fakeClock, ttl, stale time.Duration) *Cache {
+	return New(NewMemoryStore(), Options{TTL: ttl, StaleTTL: stale, Now: clock.Now})
+}
+
+func TestFreshEntryIsServedFromCache(t *testing.T) {
+	clock := newFakeClock()
+	c := newTestCache(clock, time.Hour, 24*time.Hour)
+
+	var calls int64
+	load := countingLoader(&calls, tournaments("1", "2"), nil)
+
+	// First call populates the cache.
+	first := c.Get(context.Background(), testKey(), load)
+	if first.Err != nil {
+		t.Fatalf("first Get() error = %v", first.Err)
+	}
+	if first.Cached {
+		t.Error("first call reported Cached, want a fresh load")
+	}
+	if len(first.Tournaments) != 2 {
+		t.Fatalf("got %d tournaments, want 2", len(first.Tournaments))
+	}
+
+	// Subsequent calls within the TTL must not hit the loader.
+	for i := 0; i < 5; i++ {
+		res := c.Get(context.Background(), testKey(), load)
+		if !res.Cached {
+			t.Errorf("call %d was not served from cache", i)
+		}
+		if res.Stale {
+			t.Errorf("call %d reported stale data inside the TTL", i)
+		}
+		if len(res.Tournaments) != 2 {
+			t.Errorf("call %d returned %d tournaments, want 2", i, len(res.Tournaments))
+		}
+	}
+
+	if got := atomic.LoadInt64(&calls); got != 1 {
+		t.Errorf("loader ran %d times, want 1", got)
+	}
+}
+
+func TestExpiredEntryTriggersRefresh(t *testing.T) {
+	clock := newFakeClock()
+	c := newTestCache(clock, time.Hour, 24*time.Hour)
+
+	var calls int64
+	load := countingLoader(&calls, tournaments("1"), nil)
+
+	c.Get(context.Background(), testKey(), load)
+
+	// Still fresh.
+	clock.Advance(59 * time.Minute)
+	if res := c.Get(context.Background(), testKey(), load); !res.Cached {
+		t.Error("entry expired too early")
+	}
+
+	// Past the TTL.
+	clock.Advance(2 * time.Minute)
+	res := c.Get(context.Background(), testKey(), load)
+	if res.Cached {
+		t.Error("expired entry was served from cache")
+	}
+
+	if got := atomic.LoadInt64(&calls); got != 2 {
+		t.Errorf("loader ran %d times, want 2", got)
+	}
+}
+
+func TestAgeIsReported(t *testing.T) {
+	clock := newFakeClock()
+	c := newTestCache(clock, time.Hour, 24*time.Hour)
+
+	var calls int64
+	load := countingLoader(&calls, tournaments("1"), nil)
+
+	c.Get(context.Background(), testKey(), load)
+	clock.Advance(20 * time.Minute)
+
+	res := c.Get(context.Background(), testKey(), load)
+	if res.Age != 20*time.Minute {
+		t.Errorf("Age = %v, want 20m", res.Age)
+	}
+}
+
+// TestStaleDataServedWhenUpstreamFails is the property that keeps the map
+// usable during a federation outage.
+func TestStaleDataServedWhenUpstreamFails(t *testing.T) {
+	clock := newFakeClock()
+	c := newTestCache(clock, time.Hour, 24*time.Hour)
+
+	// Populate with a successful load.
+	var okCalls int64
+	c.Get(context.Background(), testKey(), countingLoader(&okCalls, tournaments("1", "2"), nil))
+
+	// Expire it, then fail every refresh.
+	clock.Advance(2 * time.Hour)
+	boom := errors.New("federation unreachable")
+	var failCalls int64
+	res := c.Get(context.Background(), testKey(), countingLoader(&failCalls, nil, boom))
+
+	if len(res.Tournaments) != 2 {
+		t.Fatalf("got %d tournaments, want the stale copy of 2", len(res.Tournaments))
+	}
+	if !res.Stale {
+		t.Error("result was not marked stale")
+	}
+	if !res.Cached {
+		t.Error("result was not marked cached")
+	}
+	if res.Age != 2*time.Hour {
+		t.Errorf("Age = %v, want 2h", res.Age)
+	}
+	// The refresh error must remain visible so callers can surface it.
+	if !errors.Is(res.Err, boom) {
+		t.Errorf("Err = %v, want the refresh failure", res.Err)
+	}
+}
+
+func TestStaleDataExpiresEventually(t *testing.T) {
+	clock := newFakeClock()
+	c := newTestCache(clock, time.Hour, 6*time.Hour)
+
+	var calls int64
+	c.Get(context.Background(), testKey(), countingLoader(&calls, tournaments("1"), nil))
+
+	// Beyond the stale window the data is too old to be useful.
+	clock.Advance(7 * time.Hour)
+
+	boom := errors.New("federation unreachable")
+	res := c.Get(context.Background(), testKey(), countingLoader(&calls, nil, boom))
+
+	if len(res.Tournaments) != 0 {
+		t.Errorf("got %d tournaments, want none beyond the stale window", len(res.Tournaments))
+	}
+	if !errors.Is(res.Err, boom) {
+		t.Errorf("Err = %v, want the refresh failure", res.Err)
+	}
+}
+
+// TestConcurrentMissesLoadOnce covers the cache stampede guard: 50 users
+// hitting a cold cache must produce one upstream fetch, not 50.
+func TestConcurrentMissesLoadOnce(t *testing.T) {
+	clock := newFakeClock()
+	c := newTestCache(clock, time.Hour, 24*time.Hour)
+
+	var calls int64
+	release := make(chan struct{})
+	load := func(ctx context.Context, key Key) ([]models.Tournament, error) {
+		atomic.AddInt64(&calls, 1)
+		<-release // hold the load open so every caller piles up
+		return tournaments("1", "2", "3"), nil
+	}
+
+	const callers = 50
+	var wg sync.WaitGroup
+	results := make([]Result, callers)
+
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = c.Get(context.Background(), testKey(), load)
+		}(i)
+	}
+
+	// Give the goroutines time to arrive at the cache.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&calls); got != 1 {
+		t.Errorf("loader ran %d times for %d concurrent callers, want 1", got, callers)
+	}
+
+	for i, res := range results {
+		if res.Err != nil {
+			t.Errorf("caller %d error = %v", i, res.Err)
+		}
+		if len(res.Tournaments) != 3 {
+			t.Errorf("caller %d got %d tournaments, want 3", i, len(res.Tournaments))
+		}
+	}
+}
+
+func TestDifferentKeysDoNotShareEntries(t *testing.T) {
+	clock := newFakeClock()
+	c := newTestCache(clock, time.Hour, 24*time.Hour)
+
+	keyA := Key{FederationID: "BAD", DateFrom: "01.08.2026", DateTo: "15.08.2026"}
+	keyB := Key{FederationID: "HTV", DateFrom: "01.08.2026", DateTo: "15.08.2026"}
+	keyC := Key{FederationID: "BAD", DateFrom: "01.09.2026", DateTo: "15.09.2026"}
+	keyD := Key{FederationID: "BAD", DateFrom: "01.08.2026", DateTo: "15.08.2026", CompType: "Damen+Einzel"}
+
+	var calls int64
+	load := func(ctx context.Context, key Key) ([]models.Tournament, error) {
+		atomic.AddInt64(&calls, 1)
+		return tournaments(key.String()), nil
+	}
+
+	for _, k := range []Key{keyA, keyB, keyC, keyD} {
+		c.Get(context.Background(), k, load)
+	}
+
+	if got := atomic.LoadInt64(&calls); got != 4 {
+		t.Errorf("loader ran %d times, want 4 (one per distinct key)", got)
+	}
+
+	// Each key must return its own data.
+	res := c.Get(context.Background(), keyA, load)
+	if len(res.Tournaments) != 1 || res.Tournaments[0].Id != keyA.String() {
+		t.Errorf("keyA returned %+v, want its own entry", res.Tournaments)
+	}
+}
+
+func TestEmptyResultIsCached(t *testing.T) {
+	clock := newFakeClock()
+	c := newTestCache(clock, time.Hour, 24*time.Hour)
+
+	var calls int64
+	// A federation legitimately having no tournaments must not be retried on
+	// every request.
+	load := countingLoader(&calls, []models.Tournament{}, nil)
+
+	for i := 0; i < 3; i++ {
+		res := c.Get(context.Background(), testKey(), load)
+		if res.Err != nil {
+			t.Fatalf("call %d error = %v", i, res.Err)
+		}
+		if len(res.Tournaments) != 0 {
+			t.Errorf("call %d returned %d tournaments, want 0", i, len(res.Tournaments))
+		}
+	}
+
+	if got := atomic.LoadInt64(&calls); got != 1 {
+		t.Errorf("loader ran %d times, want 1 (empty results are cacheable)", got)
+	}
+}
+
+func TestFailedFirstLoadIsNotCached(t *testing.T) {
+	clock := newFakeClock()
+	c := newTestCache(clock, time.Hour, 24*time.Hour)
+
+	boom := errors.New("upstream down")
+	var failCalls int64
+	res := c.Get(context.Background(), testKey(), countingLoader(&failCalls, nil, boom))
+	if !errors.Is(res.Err, boom) {
+		t.Fatalf("Err = %v, want the load failure", res.Err)
+	}
+
+	// The next call must retry rather than serve a cached failure.
+	var okCalls int64
+	res = c.Get(context.Background(), testKey(), countingLoader(&okCalls, tournaments("1"), nil))
+	if res.Err != nil {
+		t.Fatalf("retry error = %v", res.Err)
+	}
+	if len(res.Tournaments) != 1 {
+		t.Errorf("got %d tournaments, want 1", len(res.Tournaments))
+	}
+	if atomic.LoadInt64(&okCalls) != 1 {
+		t.Error("retry did not reach the loader")
+	}
+}
+
+func TestInvalidate(t *testing.T) {
+	clock := newFakeClock()
+	c := newTestCache(clock, time.Hour, 24*time.Hour)
+
+	var calls int64
+	load := countingLoader(&calls, tournaments("1"), nil)
+
+	c.Get(context.Background(), testKey(), load)
+	if err := c.Invalidate(testKey()); err != nil {
+		t.Fatalf("Invalidate() error = %v", err)
+	}
+	c.Get(context.Background(), testKey(), load)
+
+	if got := atomic.LoadInt64(&calls); got != 2 {
+		t.Errorf("loader ran %d times, want 2 after invalidation", got)
+	}
+}
+
+func TestNilCacheLoadsDirectly(t *testing.T) {
+	var c *Cache
+
+	var calls int64
+	res := c.Get(context.Background(), testKey(), countingLoader(&calls, tournaments("1"), nil))
+
+	if len(res.Tournaments) != 1 {
+		t.Errorf("got %d tournaments, want 1", len(res.Tournaments))
+	}
+	if atomic.LoadInt64(&calls) != 1 {
+		t.Error("nil cache did not call the loader")
+	}
+}
+
+func TestStats(t *testing.T) {
+	clock := newFakeClock()
+	c := newTestCache(clock, time.Hour, 6*time.Hour)
+
+	load := func(ctx context.Context, key Key) ([]models.Tournament, error) {
+		return tournaments("1", "2"), nil
+	}
+
+	c.Get(context.Background(), Key{FederationID: "BAD"}, load)
+	c.Get(context.Background(), Key{FederationID: "HTV"}, load)
+
+	clock.Advance(2 * time.Hour) // both entries now stale but not expired
+
+	c.Get(context.Background(), Key{FederationID: "WTB"}, func(ctx context.Context, key Key) ([]models.Tournament, error) {
+		return tournaments("9"), nil
+	})
+
+	stats, err := c.Stats()
+	if err != nil {
+		t.Fatalf("Stats() error = %v", err)
+	}
+
+	if stats.Entries != 3 {
+		t.Errorf("Entries = %d, want 3", stats.Entries)
+	}
+	if stats.Fresh != 1 {
+		t.Errorf("Fresh = %d, want 1", stats.Fresh)
+	}
+	if stats.Stale != 2 {
+		t.Errorf("Stale = %d, want 2", stats.Stale)
+	}
+	if stats.Tournaments != 5 {
+		t.Errorf("Tournaments = %d, want 5", stats.Tournaments)
+	}
+	if stats.PerFederation["BAD"] != 2 {
+		t.Errorf("PerFederation[BAD] = %d, want 2", stats.PerFederation["BAD"])
+	}
+}
+
+func TestKeyString(t *testing.T) {
+	k := Key{FederationID: "BAD", DateFrom: "01.08.2026", DateTo: "15.08.2026", CompType: "Damen+Einzel"}
+	want := "BAD|01.08.2026|15.08.2026|Damen+Einzel"
+	if got := k.String(); got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestOptionDefaults(t *testing.T) {
+	c := New(NewMemoryStore(), Options{})
+	if c.ttl != DefaultTTL {
+		t.Errorf("ttl = %v, want the default %v", c.ttl, DefaultTTL)
+	}
+	if c.stale != DefaultStaleTTL {
+		t.Errorf("stale = %v, want the default %v", c.stale, DefaultStaleTTL)
+	}
+}
+
+func TestEnabledDefaultsToTrue(t *testing.T) {
+	t.Setenv("TTF_RESULT_CACHE", "")
+	if !Enabled() {
+		t.Error("Enabled() = false, want true by default")
+	}
+
+	for _, v := range []string{"false", "FALSE", "0", "off"} {
+		t.Setenv("TTF_RESULT_CACHE", v)
+		if Enabled() {
+			t.Errorf("Enabled() = true for %q, want false", v)
+		}
+	}
+}
+
+func TestOptionsFromEnv(t *testing.T) {
+	t.Setenv("TTF_CACHE_TTL_MINUTES", "30")
+	t.Setenv("TTF_CACHE_STALE_MINUTES", "120")
+
+	opts := OptionsFromEnv()
+	if opts.TTL != 30*time.Minute {
+		t.Errorf("TTL = %v, want 30m", opts.TTL)
+	}
+	if opts.StaleTTL != 120*time.Minute {
+		t.Errorf("StaleTTL = %v, want 120m", opts.StaleTTL)
+	}
+
+	// Invalid values fall back to the defaults rather than disabling caching.
+	t.Setenv("TTF_CACHE_TTL_MINUTES", "not-a-number")
+	if got := OptionsFromEnv().TTL; got != DefaultTTL {
+		t.Errorf("TTL = %v, want the default for invalid input", got)
+	}
+}
+
+// TestBoltStoreRoundTrip verifies persistence, which is what lets a restart
+// keep the work the scheduler already did.
+func TestBoltStoreRoundTrip(t *testing.T) {
+	path := t.TempDir() + "/results.bolt"
+
+	store, err := NewBoltStore(path)
+	if err != nil {
+		t.Fatalf("NewBoltStore() error = %v", err)
+	}
+
+	entry := Entry{
+		FederationID: "BAD",
+		Query:        "BAD|01.08.2026|15.08.2026|",
+		Tournaments:  tournaments("1", "2"),
+		StoredAt:     time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC),
+	}
+	if err := store.Set(entry.Query, entry); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	// Reopen: the data must survive.
+	reopened, err := NewBoltStore(path)
+	if err != nil {
+		t.Fatalf("reopen error = %v", err)
+	}
+	defer reopened.Close()
+
+	got, found, err := reopened.Get(entry.Query)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !found {
+		t.Fatal("entry did not survive a restart")
+	}
+	if len(got.Tournaments) != 2 || got.Tournaments[0].Id != "1" {
+		t.Errorf("got %+v, want the stored tournaments", got.Tournaments)
+	}
+	if !got.StoredAt.Equal(entry.StoredAt) {
+		t.Errorf("StoredAt = %v, want %v", got.StoredAt, entry.StoredAt)
+	}
+}
+
+func TestBoltStoreDeleteAndForEach(t *testing.T) {
+	store, err := NewBoltStore(t.TempDir() + "/results.bolt")
+	if err != nil {
+		t.Fatalf("NewBoltStore() error = %v", err)
+	}
+	defer store.Close()
+
+	for i := 0; i < 3; i++ {
+		key := fmt.Sprintf("FED%d|a|b|", i)
+		if err := store.Set(key, Entry{FederationID: key, Tournaments: tournaments("1")}); err != nil {
+			t.Fatalf("Set() error = %v", err)
+		}
+	}
+
+	count := 0
+	if err := store.ForEach(func(string, Entry) error { count++; return nil }); err != nil {
+		t.Fatalf("ForEach() error = %v", err)
+	}
+	if count != 3 {
+		t.Errorf("ForEach visited %d entries, want 3", count)
+	}
+
+	if err := store.Delete("FED1|a|b|"); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if _, found, _ := store.Get("FED1|a|b|"); found {
+		t.Error("entry still present after Delete")
+	}
+}
+
+func TestBoltStoreMissingKey(t *testing.T) {
+	store, err := NewBoltStore(t.TempDir() + "/results.bolt")
+	if err != nil {
+		t.Fatalf("NewBoltStore() error = %v", err)
+	}
+	defer store.Close()
+
+	if _, found, err := store.Get("does-not-exist"); err != nil || found {
+		t.Errorf("Get(missing) = found %v, err %v; want not found, nil", found, err)
+	}
+}

--- a/backend/pkg/resultcache/store.go
+++ b/backend/pkg/resultcache/store.go
@@ -1,0 +1,168 @@
+package resultcache
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"go.etcd.io/bbolt"
+)
+
+// resultsBucket holds tournament results. It is separate from the
+// geocoordinates bucket so the two caches can be reasoned about and cleared
+// independently.
+const resultsBucket = "tournament_results"
+
+// BoltStore persists cache entries in BoltDB.
+type BoltStore struct {
+	db *bbolt.DB
+}
+
+// NewBoltStore opens (or creates) the cache database at dbPath.
+func NewBoltStore(dbPath string) (*BoltStore, error) {
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	db, err := bbolt.Open(dbPath, 0o600, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open result cache at %s: %w", dbPath, err)
+	}
+
+	if err := db.Update(func(tx *bbolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte(resultsBucket))
+		return err
+	}); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to create result bucket: %w", err)
+	}
+
+	return &BoltStore{db: db}, nil
+}
+
+func (s *BoltStore) Get(key string) (Entry, bool, error) {
+	var entry Entry
+	var found bool
+
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(resultsBucket))
+		if bucket == nil {
+			return nil
+		}
+		data := bucket.Get([]byte(key))
+		if data == nil {
+			return nil
+		}
+
+		decoded, err := decode(data)
+		if err != nil {
+			// Treat unreadable data as a miss rather than failing the request;
+			// it will be overwritten by the next refresh.
+			return nil
+		}
+		entry, found = decoded, true
+		return nil
+	})
+
+	return entry, found, err
+}
+
+func (s *BoltStore) Set(key string, entry Entry) error {
+	data, err := encode(entry)
+	if err != nil {
+		return err
+	}
+
+	return s.db.Update(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(resultsBucket))
+		if bucket == nil {
+			return fmt.Errorf("bucket %s does not exist", resultsBucket)
+		}
+		return bucket.Put([]byte(key), data)
+	})
+}
+
+func (s *BoltStore) Delete(key string) error {
+	return s.db.Update(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(resultsBucket))
+		if bucket == nil {
+			return nil
+		}
+		return bucket.Delete([]byte(key))
+	})
+}
+
+func (s *BoltStore) ForEach(fn func(key string, entry Entry) error) error {
+	return s.db.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(resultsBucket))
+		if bucket == nil {
+			return nil
+		}
+		return bucket.ForEach(func(k, v []byte) error {
+			entry, err := decode(v)
+			if err != nil {
+				return nil // skip corrupt entries
+			}
+			return fn(string(k), entry)
+		})
+	})
+}
+
+func (s *BoltStore) Close() error {
+	if s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+// MemoryStore keeps entries in memory. It is used by tests and as a fallback
+// when the persistent store cannot be opened, so caching still works (just
+// without surviving a restart).
+type MemoryStore struct {
+	mu      sync.RWMutex
+	entries map[string]Entry
+}
+
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{entries: make(map[string]Entry)}
+}
+
+func (s *MemoryStore) Get(key string) (Entry, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.entries[key]
+	return entry, ok, nil
+}
+
+func (s *MemoryStore) Set(key string, entry Entry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[key] = entry
+	return nil
+}
+
+func (s *MemoryStore) Delete(key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.entries, key)
+	return nil
+}
+
+func (s *MemoryStore) ForEach(fn func(key string, entry Entry) error) error {
+	s.mu.RLock()
+	snapshot := make(map[string]Entry, len(s.entries))
+	for k, v := range s.entries {
+		snapshot[k] = v
+	}
+	s.mu.RUnlock()
+
+	for k, v := range snapshot {
+		if err := fn(k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *MemoryStore) Close() error { return nil }

--- a/backend/pkg/scheduler/scheduler.go
+++ b/backend/pkg/scheduler/scheduler.go
@@ -2,7 +2,9 @@ package scheduler
 
 import (
 	"os"
+	"strconv"
 	"sync"
+	"time"
 
 	"github.com/robfig/cron/v3"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
@@ -14,6 +16,10 @@ type Config struct {
 	CronSpec    string // e.g. "0 2 * * *" (server local time)
 	CompType    string // optional, e.g. "Herren+Einzel"
 	Federations string // optional, comma-separated IDs, empty = all
+	// WarmupDays is how far ahead the scheduled run pre-fetches. It should
+	// cover the range users actually browse, otherwise their requests miss the
+	// cache and scrape live anyway.
+	WarmupDays int
 }
 
 type Scheduler struct {
@@ -28,7 +34,39 @@ func FromEnv() Config {
 		CronSpec:    firstNonEmpty(os.Getenv("TTF_SCHEDULER_CRON"), "0 2 * * *"),
 		CompType:    os.Getenv("TTF_SCHEDULER_COMP_TYPE"),
 		Federations: os.Getenv("TTF_SCHEDULER_FEDERATIONS"),
+		WarmupDays:  warmupDaysFromEnv(),
 	}
+}
+
+// defaultWarmupDays covers the typical browsing window.
+const defaultWarmupDays = 30
+
+func warmupDaysFromEnv() int {
+	raw := os.Getenv("TTF_SCHEDULER_WARMUP_DAYS")
+	if raw == "" {
+		return defaultWarmupDays
+	}
+	days, err := strconv.Atoi(raw)
+	if err != nil || days <= 0 {
+		return defaultWarmupDays
+	}
+	return days
+}
+
+// runWarmup pre-fetches the configured window into the result cache.
+func runWarmup(cfg Config) {
+	days := cfg.WarmupDays
+	if days <= 0 {
+		days = defaultWarmupDays
+	}
+
+	now := time.Now()
+	dateFrom := now.Format("02.01.2006")
+	dateTo := now.AddDate(0, 0, days).Format("02.01.2006")
+
+	logger.Info("Scheduler tick: warming cache for %s..%s", dateFrom, dateTo)
+	total := tournament.Warmup(dateFrom, dateTo, cfg.CompType, cfg.Federations)
+	logger.Info("Scheduler warmup done, tournaments fetched: %d", total)
 }
 
 func New(cfg Config) (*Scheduler, error) {
@@ -37,9 +75,7 @@ func New(cfg Config) (*Scheduler, error) {
 		config: cfg,
 	}
 	_, err := s.c.AddFunc(cfg.CronSpec, func() {
-		logger.Info("Scheduler tick: running warmup job")
-		total := tournament.Warmup("", "", cfg.CompType, cfg.Federations)
-		logger.Info("Scheduler warmup done, tournaments fetched: %d", total)
+		runWarmup(cfg)
 	})
 	if err != nil {
 		return nil, err
@@ -72,6 +108,7 @@ func (s *Scheduler) Reload() error {
 	if s.config.CronSpec == newConfig.CronSpec &&
 		s.config.CompType == newConfig.CompType &&
 		s.config.Federations == newConfig.Federations &&
+		s.config.WarmupDays == newConfig.WarmupDays &&
 		s.config.Enabled == newConfig.Enabled {
 		logger.Info("Scheduler configuration unchanged, no restart needed")
 		return nil
@@ -89,9 +126,7 @@ func (s *Scheduler) Reload() error {
 	if newConfig.Enabled {
 		newCron := cron.New()
 		_, err := newCron.AddFunc(newConfig.CronSpec, func() {
-			logger.Info("Scheduler tick: running warmup job")
-			total := tournament.Warmup("", "", newConfig.CompType, newConfig.Federations)
-			logger.Info("Scheduler warmup done, tournaments fetched: %d", total)
+			runWarmup(newConfig)
 		})
 		if err != nil {
 			// Restore old scheduler on error

--- a/backend/pkg/scheduler/scheduler_test.go
+++ b/backend/pkg/scheduler/scheduler_test.go
@@ -1,0 +1,190 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFromEnvDefaults(t *testing.T) {
+	t.Setenv("TTF_SCHEDULER_ENABLED", "")
+	t.Setenv("TTF_SCHEDULER_CRON", "")
+	t.Setenv("TTF_SCHEDULER_COMP_TYPE", "")
+	t.Setenv("TTF_SCHEDULER_FEDERATIONS", "")
+	t.Setenv("TTF_SCHEDULER_WARMUP_DAYS", "")
+
+	cfg := FromEnv()
+
+	if cfg.Enabled {
+		t.Error("Enabled = true, want disabled by default")
+	}
+	if cfg.CronSpec != "0 2 * * *" {
+		t.Errorf("CronSpec = %q, want the 02:00 default", cfg.CronSpec)
+	}
+	if cfg.WarmupDays != defaultWarmupDays {
+		t.Errorf("WarmupDays = %d, want %d", cfg.WarmupDays, defaultWarmupDays)
+	}
+}
+
+func TestFromEnvReadsValues(t *testing.T) {
+	t.Setenv("TTF_SCHEDULER_ENABLED", "true")
+	t.Setenv("TTF_SCHEDULER_CRON", "30 3 * * *")
+	t.Setenv("TTF_SCHEDULER_COMP_TYPE", "Damen+Einzel")
+	t.Setenv("TTF_SCHEDULER_FEDERATIONS", "BAD,WTB")
+	t.Setenv("TTF_SCHEDULER_WARMUP_DAYS", "45")
+
+	cfg := FromEnv()
+
+	if !cfg.Enabled {
+		t.Error("Enabled = false, want true")
+	}
+	if cfg.CronSpec != "30 3 * * *" {
+		t.Errorf("CronSpec = %q", cfg.CronSpec)
+	}
+	if cfg.CompType != "Damen+Einzel" {
+		t.Errorf("CompType = %q", cfg.CompType)
+	}
+	if cfg.Federations != "BAD,WTB" {
+		t.Errorf("Federations = %q", cfg.Federations)
+	}
+	if cfg.WarmupDays != 45 {
+		t.Errorf("WarmupDays = %d, want 45", cfg.WarmupDays)
+	}
+}
+
+func TestFromEnvAcceptsNumericEnabledFlag(t *testing.T) {
+	t.Setenv("TTF_SCHEDULER_ENABLED", "1")
+	if !FromEnv().Enabled {
+		t.Error("Enabled = false for \"1\", want true")
+	}
+}
+
+// TestWarmupDaysFallsBackOnInvalidInput guards against a typo silently
+// disabling the pre-fetch window.
+func TestWarmupDaysFallsBackOnInvalidInput(t *testing.T) {
+	for _, v := range []string{"not-a-number", "-5", "0", ""} {
+		t.Setenv("TTF_SCHEDULER_WARMUP_DAYS", v)
+		if got := warmupDaysFromEnv(); got != defaultWarmupDays {
+			t.Errorf("warmupDaysFromEnv() = %d for %q, want %d", got, v, defaultWarmupDays)
+		}
+	}
+}
+
+func TestNewRejectsInvalidCronSpec(t *testing.T) {
+	if _, err := New(Config{Enabled: true, CronSpec: "not a cron spec"}); err == nil {
+		t.Error("New() accepted an invalid cron spec")
+	}
+}
+
+func TestNewAcceptsValidCronSpec(t *testing.T) {
+	s, err := New(Config{Enabled: true, CronSpec: "0 2 * * *", WarmupDays: 30})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if got := s.GetConfig().WarmupDays; got != 30 {
+		t.Errorf("WarmupDays = %d, want 30", got)
+	}
+}
+
+func TestStartStopIsSafe(t *testing.T) {
+	s, err := New(Config{Enabled: true, CronSpec: "0 2 * * *"})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	// Must not panic or dead-lock.
+	s.Start()
+	s.Stop()
+}
+
+// TestReloadDetectsWarmupDaysChange makes sure the new setting participates in
+// the "did anything change?" comparison, otherwise a reload would silently
+// keep the old window.
+func TestReloadDetectsWarmupDaysChange(t *testing.T) {
+	t.Setenv("TTF_SCHEDULER_ENABLED", "true")
+	t.Setenv("TTF_SCHEDULER_CRON", "0 2 * * *")
+	t.Setenv("TTF_SCHEDULER_WARMUP_DAYS", "30")
+
+	s, err := New(FromEnv())
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	s.Start()
+	defer s.Stop()
+
+	t.Setenv("TTF_SCHEDULER_WARMUP_DAYS", "60")
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload() error = %v", err)
+	}
+
+	if got := s.GetConfig().WarmupDays; got != 60 {
+		t.Errorf("WarmupDays after reload = %d, want 60", got)
+	}
+}
+
+func TestReloadDisablesScheduler(t *testing.T) {
+	t.Setenv("TTF_SCHEDULER_ENABLED", "true")
+	t.Setenv("TTF_SCHEDULER_CRON", "0 2 * * *")
+
+	s, err := New(FromEnv())
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	s.Start()
+
+	t.Setenv("TTF_SCHEDULER_ENABLED", "false")
+	if err := s.Reload(); err != nil {
+		t.Fatalf("Reload() error = %v", err)
+	}
+
+	if s.GetConfig().Enabled {
+		t.Error("scheduler still enabled after reload")
+	}
+}
+
+func TestReloadRestoresConfigOnInvalidCron(t *testing.T) {
+	t.Setenv("TTF_SCHEDULER_ENABLED", "true")
+	t.Setenv("TTF_SCHEDULER_CRON", "0 2 * * *")
+
+	s, err := New(FromEnv())
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	s.Start()
+	defer s.Stop()
+
+	t.Setenv("TTF_SCHEDULER_CRON", "totally invalid")
+	if err := s.Reload(); err == nil {
+		t.Fatal("Reload() accepted an invalid cron spec")
+	}
+
+	// The previous working configuration must remain in place.
+	if got := s.GetConfig().CronSpec; got != "0 2 * * *" {
+		t.Errorf("CronSpec = %q, want the previous value to be restored", got)
+	}
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	if got := firstNonEmpty("", "", "third"); got != "third" {
+		t.Errorf("firstNonEmpty() = %q, want third", got)
+	}
+	if got := firstNonEmpty("first", "second"); got != "first" {
+		t.Errorf("firstNonEmpty() = %q, want first", got)
+	}
+	if got := firstNonEmpty(); got != "" {
+		t.Errorf("firstNonEmpty() = %q, want empty", got)
+	}
+}
+
+// TestWarmupWindowCoversConfiguredDays documents the relationship between the
+// scheduler window and the cache: a window shorter than what users browse
+// leaves their requests scraping live.
+func TestWarmupWindowCoversConfiguredDays(t *testing.T) {
+	cfg := Config{WarmupDays: 45}
+
+	now := time.Now()
+	to := now.AddDate(0, 0, cfg.WarmupDays)
+
+	if got := to.Sub(now).Hours() / 24; got < 44 || got > 46 {
+		t.Errorf("warmup window spans %.0f days, want ~45", got)
+	}
+}

--- a/backend/pkg/tournament/e2e_test.go
+++ b/backend/pkg/tournament/e2e_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/openstreetmap"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/resultcache"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/tournament"
 )
 
@@ -604,5 +605,286 @@ func TestMockServersUseAbsoluteURLs(t *testing.T) {
 	u, err := url.Parse(srv.URL)
 	if err != nil || !u.IsAbs() {
 		t.Fatalf("httptest server URL %q is not absolute: %v", srv.URL, err)
+	}
+}
+
+// withResultCache installs a fresh in-memory result cache for one test.
+func withResultCache(t *testing.T, opts resultcache.Options) *resultcache.Cache {
+	t.Helper()
+
+	cache := resultcache.New(resultcache.NewMemoryStore(), opts)
+	tournament.SetResultCache(cache)
+	t.Cleanup(func() { tournament.SetResultCache(nil) })
+
+	return cache
+}
+
+// TestEndToEndResultsAreCachedAcrossRequests is the core benefit of the result
+// cache: repeated user requests must not re-scrape the federation.
+func TestEndToEndResultsAreCachedAcrossRequests(t *testing.T) {
+	initIsolatedCache(t)
+	mockNominatim(t, "Karlsruhe, Baden-Württemberg, Deutschland", "49.0069", "8.4037")
+	withResultCache(t, resultcache.Options{TTL: time.Hour, StaleTTL: 24 * time.Hour})
+
+	var fetches int64
+	fedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&fetches, 1)
+		fmt.Fprint(w, oldAPIResponse)
+	}))
+	defer fedSrv.Close()
+
+	fed := models.Federation{
+		Id: "BAD", Url: fedSrv.URL, State: "Baden-Württemberg", ApiVersion: "old",
+		Geocoordinates: models.Geocoordinates{Lat: "49.0", Lon: "8.4"},
+	}
+
+	for i := 0; i < 5; i++ {
+		tournaments, results := tournament.CollectTournaments(
+			context.Background(), []models.Federation{fed}, "01.08.2026", "15.08.2026", "")
+
+		if results[0].Err != nil {
+			t.Fatalf("run %d error: %v", i, results[0].Err)
+		}
+		if len(tournaments) != 1 {
+			t.Fatalf("run %d returned %d tournaments, want 1", i, len(tournaments))
+		}
+		if i > 0 && !results[0].Cached {
+			t.Errorf("run %d was not served from cache", i)
+		}
+	}
+
+	if got := atomic.LoadInt64(&fetches); got != 1 {
+		t.Errorf("scraped the federation %d times across 5 requests, want 1", got)
+	}
+}
+
+// TestEndToEndStaleDataSurvivesFederationOutage covers the resilience the
+// cache buys: an upstream going down must not empty the map.
+func TestEndToEndStaleDataSurvivesFederationOutage(t *testing.T) {
+	initIsolatedCache(t)
+	mockNominatim(t, "Karlsruhe, Baden-Württemberg, Deutschland", "49.0069", "8.4037")
+
+	clock := &testClock{now: time.Now()}
+	withResultCache(t, resultcache.Options{
+		TTL: time.Hour, StaleTTL: 24 * time.Hour, Now: clock.Now,
+	})
+
+	var healthy atomic.Bool
+	healthy.Store(true)
+
+	fedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !healthy.Load() {
+			http.Error(w, "down for maintenance", http.StatusBadGateway)
+			return
+		}
+		fmt.Fprint(w, oldAPIResponse)
+	}))
+	defer fedSrv.Close()
+
+	fed := models.Federation{
+		Id: "BAD", Url: fedSrv.URL, State: "Baden-Württemberg", ApiVersion: "old",
+		Geocoordinates: models.Geocoordinates{Lat: "49.0", Lon: "8.4"},
+	}
+
+	// Populate the cache while the federation is healthy.
+	if _, results := tournament.CollectTournaments(
+		context.Background(), []models.Federation{fed}, "01.08.2026", "15.08.2026", ""); results[0].Err != nil {
+		t.Fatalf("warmup error: %v", results[0].Err)
+	}
+
+	// Expire the entry and take the federation down.
+	clock.Advance(2 * time.Hour)
+	healthy.Store(false)
+
+	tournaments, results := tournament.CollectTournaments(
+		context.Background(), []models.Federation{fed}, "01.08.2026", "15.08.2026", "")
+
+	if len(tournaments) != 1 {
+		t.Fatalf("got %d tournaments during the outage, want the stale copy", len(tournaments))
+	}
+	if !results[0].Stale {
+		t.Error("result was not reported as stale")
+	}
+	if results[0].Status() != "stale" {
+		t.Errorf("Status() = %q, want stale", results[0].Status())
+	}
+	if results[0].Age < 2*time.Hour {
+		t.Errorf("Age = %v, want at least 2h", results[0].Age)
+	}
+}
+
+// TestEndToEndConcurrentRequestsScrapeOnce covers the stampede guard in the
+// real request path.
+func TestEndToEndConcurrentRequestsScrapeOnce(t *testing.T) {
+	initIsolatedCache(t)
+	mockNominatim(t, "Karlsruhe, Baden-Württemberg, Deutschland", "49.0069", "8.4037")
+	withResultCache(t, resultcache.Options{TTL: time.Hour, StaleTTL: 24 * time.Hour})
+
+	var fetches int64
+	fedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&fetches, 1)
+		time.Sleep(50 * time.Millisecond) // widen the race window
+		fmt.Fprint(w, oldAPIResponse)
+	}))
+	defer fedSrv.Close()
+
+	fed := models.Federation{
+		Id: "BAD", Url: fedSrv.URL, State: "Baden-Württemberg", ApiVersion: "old",
+		Geocoordinates: models.Geocoordinates{Lat: "49.0", Lon: "8.4"},
+	}
+
+	const callers = 20
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			tournament.CollectTournaments(
+				context.Background(), []models.Federation{fed}, "01.08.2026", "15.08.2026", "")
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&fetches); got != 1 {
+		t.Errorf("scraped %d times for %d concurrent requests, want 1", got, callers)
+	}
+}
+
+func TestEndToEndFullFormatReportsFederationStatus(t *testing.T) {
+	initIsolatedCache(t)
+	withResultCache(t, resultcache.Options{TTL: time.Hour, StaleTTL: 24 * time.Hour})
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/?dateFrom=01.08.2026&dateTo=02.08.2026&federations=DOES_NOT_EXIST&format=full", nil)
+	rec := httptest.NewRecorder()
+
+	tournament.GetTournaments(rec, req)
+
+	res := rec.Result()
+	defer res.Body.Close()
+
+	var decoded tournament.TournamentsResponse
+	if err := json.NewDecoder(res.Body).Decode(&decoded); err != nil {
+		t.Fatalf("response is not the full format: %v", err)
+	}
+
+	if decoded.Tournaments == nil {
+		t.Error("tournaments must be an empty array, not null")
+	}
+	if decoded.Partial {
+		t.Error("Partial = true, want false when nothing failed")
+	}
+}
+
+// TestEndToEndLegacyFormatUnchanged protects the deployed frontend: the
+// default response must stay a bare JSON array.
+func TestEndToEndLegacyFormatUnchanged(t *testing.T) {
+	initIsolatedCache(t)
+	withResultCache(t, resultcache.Options{TTL: time.Hour, StaleTTL: 24 * time.Hour})
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/?dateFrom=01.08.2026&dateTo=02.08.2026&federations=DOES_NOT_EXIST", nil)
+	rec := httptest.NewRecorder()
+
+	tournament.GetTournaments(rec, req)
+
+	body := rec.Body.String()
+	if !strings.HasPrefix(strings.TrimSpace(body), "[") {
+		t.Errorf("legacy response = %q, want a bare JSON array", body)
+	}
+
+	var decoded []models.Tournament
+	if err := json.Unmarshal([]byte(body), &decoded); err != nil {
+		t.Fatalf("legacy response does not decode as an array: %v", err)
+	}
+}
+
+// testClock drives cache expiry deterministically.
+type testClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *testClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *testClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// TestEndToEndWarmupRefreshesCache is the property that makes the scheduler
+// useful: a scheduled run must fetch current data rather than reading back the
+// cache it is supposed to refresh.
+func TestEndToEndWarmupRefreshesCache(t *testing.T) {
+	initIsolatedCache(t)
+	mockNominatim(t, "Karlsruhe, Baden-Württemberg, Deutschland", "49.0069", "8.4037")
+	withResultCache(t, resultcache.Options{TTL: time.Hour, StaleTTL: 24 * time.Hour})
+
+	var fetches int64
+	fedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&fetches, 1)
+		fmt.Fprint(w, oldAPIResponse)
+	}))
+	defer fedSrv.Close()
+
+	fed := models.Federation{
+		Id: "BAD", Url: fedSrv.URL, State: "Baden-Württemberg", ApiVersion: "old",
+		Geocoordinates: models.Geocoordinates{Lat: "49.0", Lon: "8.4"},
+	}
+
+	// Populate the cache through the normal request path.
+	tournament.CollectTournaments(
+		context.Background(), []models.Federation{fed}, "01.08.2026", "15.08.2026", "")
+	afterRequest := atomic.LoadInt64(&fetches)
+
+	// A scheduled refresh invalidates first, so it must re-fetch despite the
+	// entry still being fresh.
+	tournament.InvalidateCache([]models.Federation{fed}, "01.08.2026", "15.08.2026", "")
+	tournament.CollectTournaments(
+		context.Background(), []models.Federation{fed}, "01.08.2026", "15.08.2026", "")
+
+	if got := atomic.LoadInt64(&fetches); got <= afterRequest {
+		t.Errorf("warmup made no new fetch (%d before, %d after); the cache was served back to itself",
+			afterRequest, got)
+	}
+}
+
+// TestEndToEndCacheKeysAreQuerySpecific ensures a different date range or
+// competition filter is not served stale data from another query.
+func TestEndToEndCacheKeysAreQuerySpecific(t *testing.T) {
+	initIsolatedCache(t)
+	mockNominatim(t, "Karlsruhe, Baden-Württemberg, Deutschland", "49.0069", "8.4037")
+	withResultCache(t, resultcache.Options{TTL: time.Hour, StaleTTL: 24 * time.Hour})
+
+	var fetches int64
+	fedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&fetches, 1)
+		fmt.Fprint(w, oldAPIResponse)
+	}))
+	defer fedSrv.Close()
+
+	fed := models.Federation{
+		Id: "BAD", Url: fedSrv.URL, State: "Baden-Württemberg", ApiVersion: "old",
+		Geocoordinates: models.Geocoordinates{Lat: "49.0", Lon: "8.4"},
+	}
+
+	queries := []struct{ from, to, comp string }{
+		{"01.08.2026", "15.08.2026", ""},
+		{"01.09.2026", "15.09.2026", ""},
+		{"01.08.2026", "15.08.2026", "Damen+Einzel"},
+	}
+
+	for _, q := range queries {
+		tournament.CollectTournaments(
+			context.Background(), []models.Federation{fed}, q.from, q.to, q.comp)
+	}
+
+	if got := atomic.LoadInt64(&fetches); got != int64(len(queries)) {
+		t.Errorf("made %d fetches for %d distinct queries, want one each", got, len(queries))
 	}
 }

--- a/backend/pkg/tournament/tournament.go
+++ b/backend/pkg/tournament/tournament.go
@@ -18,6 +18,7 @@ import (
 	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/openstreetmap"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/resultcache"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/util"
 )
 
@@ -48,6 +49,103 @@ type FederationResult struct {
 	Federation  models.Federation
 	Tournaments []models.Tournament
 	Err         error
+	// Cached reports that the result came from the cache without contacting
+	// the federation.
+	Cached bool
+	// Stale reports that the cached copy had expired but the refresh failed,
+	// so this is older data served deliberately instead of nothing.
+	Stale bool
+	// Age is how old the returned data is; zero for a fresh fetch.
+	Age time.Duration
+}
+
+// Status summarises a federation result for API consumers.
+func (r FederationResult) Status() string {
+	switch {
+	case r.Err != nil && len(r.Tournaments) == 0:
+		return "error"
+	case r.Stale:
+		return "stale"
+	case r.Cached:
+		return "cached"
+	default:
+		return "ok"
+	}
+}
+
+// resultCache is the process-wide tournament cache. It is nil when caching is
+// disabled, in which case every request loads directly.
+var (
+	resultCache   *resultcache.Cache
+	resultCacheMu sync.RWMutex
+)
+
+// SetResultCache installs the cache used by CollectTournaments.
+func SetResultCache(c *resultcache.Cache) {
+	resultCacheMu.Lock()
+	defer resultCacheMu.Unlock()
+	resultCache = c
+}
+
+// ResultCache returns the installed cache, or nil.
+func ResultCache() *resultcache.Cache {
+	resultCacheMu.RLock()
+	defer resultCacheMu.RUnlock()
+	return resultCache
+}
+
+// FederationStatus is the per-federation metadata returned alongside results,
+// so clients can tell "no tournaments" apart from "this source failed".
+type FederationStatus struct {
+	Id     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"` // ok | cached | stale | error
+	Count  int    `json:"count"`
+	// AgeSeconds is how old the data is; 0 for a fresh fetch.
+	AgeSeconds int `json:"age_seconds,omitempty"`
+	// Message is a short, non-sensitive error description.
+	Message string `json:"message,omitempty"`
+}
+
+// TournamentsResponse is the richer response shape.
+//
+// The legacy clients expect a bare JSON array, so this is only returned when
+// the caller opts in with ?format=full.
+type TournamentsResponse struct {
+	Tournaments []models.Tournament `json:"tournaments"`
+	Federations []FederationStatus  `json:"federations"`
+	// Partial reports that at least one federation failed or is stale.
+	Partial bool `json:"partial"`
+}
+
+// buildFederationStatuses converts internal results into API metadata.
+func buildFederationStatuses(results []FederationResult) ([]FederationStatus, bool) {
+	statuses := make([]FederationStatus, 0, len(results))
+	partial := false
+
+	for _, res := range results {
+		status := FederationStatus{
+			Id:     res.Federation.Id,
+			Name:   res.Federation.Name,
+			Status: res.Status(),
+			Count:  len(res.Tournaments),
+		}
+		if res.Age > 0 {
+			status.AgeSeconds = int(res.Age.Seconds())
+		}
+		if res.Err != nil {
+			// Keep the message short and free of internal detail.
+			status.Message = "Turnierdaten konnten nicht aktualisiert werden"
+			partial = true
+		}
+		if res.Stale {
+			partial = true
+		}
+
+		statuses = append(statuses, status)
+	}
+
+	return statuses, partial
 }
 
 func GetTournaments(w http.ResponseWriter, r *http.Request) {
@@ -83,9 +181,26 @@ func GetTournaments(w http.ResponseWriter, r *http.Request) {
 
 	filteredFederations := FilterFederations(federations, selectedFederations)
 
-	tournaments, _ := CollectTournaments(r.Context(), filteredFederations, dateFrom, dateTo, compType)
+	tournaments, results := CollectTournaments(r.Context(), filteredFederations, dateFrom, dateTo, compType)
 
 	w.Header().Set("Content-Type", "application/json")
+
+	// The historic contract is a bare array of tournaments. Returning an
+	// object unconditionally would break every deployed client, so the richer
+	// shape is opt-in.
+	if r.URL.Query().Get("format") == "full" {
+		statuses, partial := buildFederationStatuses(results)
+		response := TournamentsResponse{
+			Tournaments: tournaments,
+			Federations: statuses,
+			Partial:     partial,
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			logger.Error("Failed to encode tournaments response: %v", err)
+		}
+		return
+	}
+
 	if err := json.NewEncoder(w).Encode(tournaments); err != nil {
 		logger.Error("Failed to encode tournaments response: %v", err)
 	}
@@ -115,6 +230,30 @@ func FilterFederations(federations []models.Federation, selectedFederations stri
 	return filtered
 }
 
+// InvalidateCache drops cached entries for the given federations and query, so
+// the next fetch goes upstream.
+//
+// Scheduled refreshes use this: without it a warmup would read the cache it is
+// meant to refresh and become a no-op.
+func InvalidateCache(federations []models.Federation, dateFrom, dateTo, compType string) {
+	cache := ResultCache()
+	if cache == nil {
+		return
+	}
+
+	for _, fed := range federations {
+		key := resultcache.Key{
+			FederationID: fed.Id,
+			DateFrom:     dateFrom,
+			DateTo:       dateTo,
+			CompType:     compType,
+		}
+		if err := cache.Invalidate(key); err != nil {
+			logger.Warn("Failed to invalidate cache for %s: %v", fed.Id, err)
+		}
+	}
+}
+
 // CollectTournaments fetches all federations concurrently and merges the
 // results deterministically.
 //
@@ -122,8 +261,12 @@ func FilterFederations(federations []models.Federation, selectedFederations stri
 // mutated concurrently. Results are ordered by the federation's input position,
 // which keeps responses stable regardless of goroutine scheduling. A failure in
 // one federation never discards results from the others.
+//
+// Results are served from the cache when available, so a user request usually
+// performs no upstream scraping at all.
 func CollectTournaments(ctx context.Context, federations []models.Federation, dateFrom, dateTo, compType string) ([]models.Tournament, []FederationResult) {
 	results := make([]FederationResult, len(federations))
+	cache := ResultCache()
 
 	var wg sync.WaitGroup
 	for i, fed := range federations {
@@ -142,13 +285,31 @@ func CollectTournaments(ctx context.Context, federations []models.Federation, da
 				}
 			}()
 
-			tournaments, err := fetchFederation(ctx, fed, dateFrom, dateTo, compType)
-			if err != nil {
-				logger.Error("Federation %s failed: %v", fed.Id, err)
+			key := resultcache.Key{
+				FederationID: fed.Id,
+				DateFrom:     dateFrom,
+				DateTo:       dateTo,
+				CompType:     compType,
 			}
 
-			results[idx].Tournaments = tournaments
-			results[idx].Err = err
+			res := cache.Get(ctx, key, func(ctx context.Context, _ resultcache.Key) ([]models.Tournament, error) {
+				return fetchFederation(ctx, fed, dateFrom, dateTo, compType)
+			})
+
+			if res.Err != nil {
+				if res.Stale {
+					logger.Warn("Federation %s: serving cached data aged %s after refresh failure: %v",
+						fed.Id, res.Age.Round(time.Minute), res.Err)
+				} else {
+					logger.Error("Federation %s failed: %v", fed.Id, res.Err)
+				}
+			}
+
+			results[idx].Tournaments = res.Tournaments
+			results[idx].Err = res.Err
+			results[idx].Cached = res.Cached
+			results[idx].Stale = res.Stale
+			results[idx].Age = res.Age
 		}(i, fed)
 	}
 	wg.Wait()

--- a/backend/pkg/tournament/warmup.go
+++ b/backend/pkg/tournament/warmup.go
@@ -9,7 +9,8 @@ import (
 )
 
 // Warmup preloads tournaments for the given date range and optional filters.
-// It reuses the same code paths as the HTTP handler so geocoding caches are filled.
+// It reuses the same code paths as the HTTP handler, so it fills both the
+// result cache and the geocoding cache.
 // dateFrom/dateTo format: "02.01.2006". Empty values default to today..today+14d.
 // compType and selectedFederations are optional (comma-separated IDs).
 func Warmup(dateFrom, dateTo, compType, selectedFederations string) int {
@@ -17,6 +18,10 @@ func Warmup(dateFrom, dateTo, compType, selectedFederations string) int {
 }
 
 // WarmupContext behaves like Warmup but honours cancellation via ctx.
+//
+// Cached entries are invalidated first: the point of a scheduled run is to
+// fetch current data, so serving the cache back to itself would make the job a
+// no-op and let entries age out into staleness.
 func WarmupContext(ctx context.Context, dateFrom, dateTo, compType, selectedFederations string) int {
 	// Defaults
 	today := time.Now()
@@ -32,15 +37,22 @@ func WarmupContext(ctx context.Context, dateFrom, dateTo, compType, selectedFede
 	logger.Info("Warmup: from %s to %s, compType: %s, federations: %s",
 		dateFrom, dateTo, compType, selectedFederations)
 
+	// Drop cached entries first: reading back the cache would make the
+	// scheduled refresh a no-op and let entries age into staleness.
+	InvalidateCache(filteredFederations, dateFrom, dateTo, compType)
+
 	tournaments, results := CollectTournaments(ctx, filteredFederations, dateFrom, dateTo, compType)
 
+	var failed int
 	for _, res := range results {
 		if res.Err != nil {
+			failed++
 			logger.Warn("Warmup: federation %s reported an error: %v", res.Federation.Id, res.Err)
 		}
 	}
 
-	logger.Info("Warmup finished. Tournaments fetched: %d", len(tournaments))
+	logger.Info("Warmup finished. Tournaments fetched: %d (%d/%d federations failed)",
+		len(tournaments), failed, len(filteredFederations))
 
 	return len(tournaments)
 }

--- a/css/main.css
+++ b/css/main.css
@@ -601,3 +601,33 @@ body {
         width: 100%;
     }
 }
+/* Notice shown when some federations are unavailable or serving older data.
+   Silently returning fewer tournaments would leave users unable to tell
+   "no matches" apart from "this source is down". */
+.data-notice {
+    padding: 8px 12px;
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.4;
+    text-align: center;
+    border-bottom: 1px solid transparent;
+}
+
+.data-notice.warning {
+    background-color: #fff4e5;
+    border-bottom-color: #f0c07a;
+    color: #7a4b00;
+}
+
+.data-notice.error {
+    background-color: #fdecea;
+    border-bottom-color: #f3b0aa;
+    color: #8b1a10;
+}
+
+@media (max-width: 768px) {
+    .data-notice {
+        font-size: 3.2vw;
+        padding: 2vw 3vw;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -279,6 +279,7 @@
             </form>
         </div>
     </div>
+    <div id="dataNotice" class="data-notice" role="status" aria-live="polite" style="display: none;"></div>
     <div id="map">
         <div id="loading" class="loading">Loading&#8230;</div>
     </div>

--- a/script/main.js
+++ b/script/main.js
@@ -18,7 +18,9 @@ const urlGoogleQuery = "https://maps.google.com/maps?q="
 
 const initDateFrom = new Date(Date.now());
 const initDateTo = new Date(Date.now() + (7 * 86400000));
-const MAX_SELECTED_FEDERATIONS = 3;
+// Results are cached per federation on the server, so querying many at once no
+// longer means scraping them all live.
+const MAX_SELECTED_FEDERATIONS = 0; // 0 = no limit
 const FILTER_AUTO_CLOSE_BREAKPOINT = 1024; // px
 
 document.getElementById('dateFrom').value = formatDateToInput(initDateFrom);
@@ -109,7 +111,10 @@ function getTournamentsByDate(dateFrom, dateTo, compType, federations) {
         dateFrom = formatDateToAPI(dateFrom);
         dateTo = formatDateToAPI(dateTo);
         getTournaments(dateFrom, dateTo, compType, federations)
-        .then(tournaments => {
+        .then(response => {
+            const tournaments = response.tournaments || [];
+            renderDataNotice(response, tournaments.length);
+
             map.removeLayer(markers);
             markers = createMarkerClusterGroup();
             for (const tournament of tournaments) {
@@ -161,7 +166,7 @@ function getTournamentsByDate(dateFrom, dateTo, compType, federations) {
 
 async function getTournaments(dateFrom, dateTo, compType, federations) {
     showSpinner();
-    let url = urlBackend + `?dateFrom=${dateFrom}&dateTo=${dateTo}`;
+    let url = urlBackend + `?dateFrom=${dateFrom}&dateTo=${dateTo}&format=full`;
     if (compType && compType !== "") {
         url += `&compType=${encodeURIComponent(compType)}`;
     }
@@ -169,26 +174,30 @@ async function getTournaments(dateFrom, dateTo, compType, federations) {
         url += `&federations=${encodeURIComponent(federations.join(','))}`;
     }
     return fetch(url)
-        .then(res => res.json())
+        .then(res => {
+            if (!res.ok) {
+                throw new Error(`Server antwortete mit Status ${res.status}`);
+            }
+            return res.json();
+        })
         .then(result => {
             hideSpinner();
-            // console.log(result);
-            return result;
+            // The backend still returns a bare array for older clients; accept both.
+            if (Array.isArray(result)) {
+                return { tournaments: result, federations: [], partial: false };
+            }
+            return {
+                tournaments: result.tournaments || [],
+                federations: result.federations || [],
+                partial: Boolean(result.partial)
+            };
         })
         .catch(error => {
             hideSpinner();
-            console.log('error', error);
-            return [
-                {
-                    title: "Test Tennis Turnier",
-                    url: "https://spieler.tennis.de",
-                    date: "01.01. bis 02.01.",
-                    location: "Karslruhe",
-                    organizer: "MTV Karslruhe",
-                    lat: "49.0229711",
-                    lon: "8.4179256"
-                }
-            ]
+            console.error('Failed to load tournaments:', error);
+            // Showing invented data would be worse than showing nothing: the
+            // user cannot tell a real tournament from a placeholder.
+            return { tournaments: [], federations: [], partial: true, failed: true };
         });
 }
 
@@ -244,9 +253,8 @@ function getSelectedFederations() {
 
 function selectAllFederations() {
     const checkboxes = document.querySelectorAll('input[name="federations"]');
-    // Only select up to the configured maximum federations
     checkboxes.forEach((checkbox, index) => {
-        checkbox.checked = index < MAX_SELECTED_FEDERATIONS;
+        checkbox.checked = MAX_SELECTED_FEDERATIONS <= 0 || index < MAX_SELECTED_FEDERATIONS;
     });
     updateFederationSelectionState();
 }
@@ -264,10 +272,10 @@ function setupFederationLimits() {
         checkbox.addEventListener('change', function () {
             const checkedBoxes = document.querySelectorAll('input[name="federations"]:checked');
 
-            if (checkedBoxes.length > MAX_SELECTED_FEDERATIONS) {
+            if (MAX_SELECTED_FEDERATIONS > 0 && checkedBoxes.length > MAX_SELECTED_FEDERATIONS) {
                 // If more than the allowed number are selected, uncheck the current one
                 this.checked = false;
-                alert(`Sie können maximal ${MAX_SELECTED_FEDERATIONS} Verbände gleichzeitig auswählen, um die Serverbelastung zu reduzieren.`);
+                alert(`Sie können maximal ${MAX_SELECTED_FEDERATIONS} Verbände gleichzeitig auswählen.`);
             }
 
             updateFederationSelectionState();
@@ -277,13 +285,15 @@ function setupFederationLimits() {
     // Respect the pre-selection from the markup, but never exceed the limit.
     // Falling back to "the first N checkboxes" would silently change which
     // federations are queried whenever the list order changes.
-    const preselected = Array.from(checkboxes).filter(cb => cb.checked);
-    if (preselected.length === 0 || preselected.length > MAX_SELECTED_FEDERATIONS) {
-        const keep = (preselected.length ? preselected : Array.from(checkboxes))
-            .slice(0, MAX_SELECTED_FEDERATIONS);
-        checkboxes.forEach(cb => {
-            cb.checked = keep.includes(cb);
-        });
+    if (MAX_SELECTED_FEDERATIONS > 0) {
+        const preselected = Array.from(checkboxes).filter(cb => cb.checked);
+        if (preselected.length === 0 || preselected.length > MAX_SELECTED_FEDERATIONS) {
+            const keep = (preselected.length ? preselected : Array.from(checkboxes))
+                .slice(0, MAX_SELECTED_FEDERATIONS);
+            checkboxes.forEach(cb => {
+                cb.checked = keep.includes(cb);
+            });
+        }
     }
     updateFederationSelectionState();
 }
@@ -291,15 +301,56 @@ function setupFederationLimits() {
 function updateFederationSelectionState() {
     const checkboxes = document.querySelectorAll('input[name="federations"]');
     const checkedBoxes = document.querySelectorAll('input[name="federations"]:checked');
-    
-    // Disable unchecked boxes if limit is reached
+
+    // Disable unchecked boxes only when a limit is configured
     checkboxes.forEach(checkbox => {
-        if (!checkbox.checked && checkedBoxes.length >= MAX_SELECTED_FEDERATIONS) {
+        if (MAX_SELECTED_FEDERATIONS > 0 && !checkbox.checked &&
+            checkedBoxes.length >= MAX_SELECTED_FEDERATIONS) {
             checkbox.disabled = true;
         } else {
             checkbox.disabled = false;
         }
     });
+}
+
+// renderDataNotice surfaces stale or failed federations.
+//
+// Silently returning fewer tournaments is the worst outcome: the user cannot
+// tell "no tournaments match" from "this federation is down".
+function renderDataNotice(response, tournamentCount) {
+    const notice = document.getElementById('dataNotice');
+    if (!notice) {
+        return;
+    }
+
+    if (response.failed) {
+        notice.textContent = 'Turnierdaten konnten nicht geladen werden. Bitte später erneut versuchen.';
+        notice.className = 'data-notice error';
+        notice.style.display = 'block';
+        return;
+    }
+
+    const problems = (response.federations || []).filter(f => f.status === 'error' || f.status === 'stale');
+    if (problems.length === 0) {
+        notice.style.display = 'none';
+        notice.textContent = '';
+        return;
+    }
+
+    const failed = problems.filter(f => f.status === 'error').map(f => f.id);
+    const stale = problems.filter(f => f.status === 'stale').map(f => f.id);
+
+    const parts = [];
+    if (failed.length > 0) {
+        parts.push(`${failed.join(', ')} nicht erreichbar`);
+    }
+    if (stale.length > 0) {
+        parts.push(`${stale.join(', ')} zeigt ältere Daten`);
+    }
+
+    notice.textContent = `Hinweis: ${parts.join(' · ')}. Angezeigt werden ${tournamentCount} Turniere.`;
+    notice.className = 'data-notice warning';
+    notice.style.display = 'block';
 }
 
 function toggleFilters() {


### PR DESCRIPTION
Adds the per-federation result cache from #35 and makes partial failures visible (#43). Together they remove the reason the frontend limited users to three federations.

## Measured effect

Live, against all 15 federations over a 30-day window (`cmd/cachebench`):

```
cold (scraping): 4.595s
warm (cached):   16ms      -> 294x faster
tournaments: cold 881, warm 881
served from cache on warm run: 15/15 federations
```

## Cache design

Keyed by federation, date range and competition type, so one slow federation never holds up the others and a refresh only redoes what actually expired.

* **Persistent** (BoltDB, separate bucket from the geocoding cache) — a restart keeps whatever the scheduler fetched.
* **Stale-tolerant** — when the TTL has passed but the federation is unreachable, the expired copy is served and flagged stale. An out-of-date tournament list is far more useful to a player than an empty map. Beyond the stale window it is dropped.
* **Stampede-safe** — concurrent misses collapse to one upstream load, which matters most exactly when the cache is cold.
* **Empty results are cached** — a federation legitimately having no tournaments must not be retried on every request.
* **Failures are never cached** — a transient outage cannot pin an error in place for the whole TTL.
* A broken cache degrades to loading directly rather than failing requests.

Defaults: 2h TTL, 24h stale window, both configurable. Tournament calendars change slowly, so an hour-old list is materially the same list.

## Federation status (#43)

`?format=full` returns per-federation status so a client can tell *"no tournaments match"* from *"this federation is down"*:

```json
{
  "tournaments": [ ... ],
  "federations": [
    { "id": "BAD", "status": "ok", "count": 141 },
    { "id": "WTV", "status": "stale", "count": 131, "age_seconds": 7200 }
  ],
  "partial": true
}
```

The default response **stays a bare JSON array**. Changing it unconditionally would break every deployed client, so the richer shape is opt-in and a test asserts the legacy format is unchanged.

## Frontend

* **Three-federation limit removed.** It existed *"um die Serverbelastung zu reduzieren"*; with caching that reason is gone. The constant is kept as a switch (`0` = no limit) rather than ripping the logic out.
* **Banner** naming federations that are unreachable or serving older data. Previously a failed federation just meant fewer pins.
* **Stopped inventing data.** The fetch error path returned a hardcoded *"Test Tennis Turnier"* in Karlsruhe. A user cannot tell that apart from a real tournament, and it could send someone to a venue that does not exist. Failures now show an error banner and no markers.
* Non-2xx responses are handled instead of falling through to `res.json()`.

## Scheduler

The job warmed only the geocoding cache over a fixed 14-day range. It now warms tournament results over a configurable window (`TTF_SCHEDULER_WARMUP_DAYS`, default 30) and **invalidates before fetching** — otherwise it would read back the cache it is meant to refresh and become a no-op. It also reports how many federations failed, so a run that quietly stopped working is visible.

## Testing

| Package | Coverage |
| --- | --- |
| `federation` | 100.0% |
| `addressprovider` | 97.3% |
| `ratelimit` | 95.8% |
| `util` | 92.6% |
| `placename` | 89.7% |
| `tournament` | 86.1% |
| `resultcache` | 83.6% |
| `clublocations` | 81.1% |
| `scheduler` | 80.0% |
| `openstreetmap` | 77.2% |

Cache tests use an injected clock (no sleeping) and cover TTL expiry, stale fallback, the stale window ending, 50 concurrent callers collapsing to one load, key separation, cacheable empty results, uncached failures and BoltDB persistence across a reopen. End-to-end tests cover the same behaviour through the real request path, including a simulated federation outage.

The scheduler had no tests before; it now covers env parsing, invalid input fallback, cron validation and reload semantics including configuration rollback.

`go test -race`, `go vet`, `gofmt` and `go mod tidy` all clean.

Closes #35, closes #43
