### PR TITLE
feat: add list view and close out the address-source investigation

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,43 @@
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/frontend.yml"
+      - "index.html"
+      - "css/**"
+      - "script/**"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/frontend.yml"
+      - "index.html"
+      - "css/**"
+      - "script/**"
+
+name: Test Frontend
+jobs:
+  test:
+    name: Syntax & Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # A syntax error in main.js breaks the whole app silently, since the
+      # page still renders but no script runs.
+      - name: Check JavaScript syntax
+        run: |
+          node --check script/main.js
+          node --check script/mobile-gesture.js
+          node --check service-worker.js
+
+      # Date parsing and sorting cannot be verified by looking at the map.
+      - name: Run frontend unit tests
+        run: node script/main.test.js

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
   * [Württembergischer Tennis Bund (WTB)](https://www.wtb-tennis.de/)
   * [Westfälischer Tennis-Verband (WTV)](https://www.wtv.de)
 * Helps you finding the tournaments around you
+* Map and list view, with the list sortable by date, title or organizer
 * Lets you filter tournaments by date, competition type, and federation
 * Short link to the official Tournament at [tennis.de](https://spieler.tennis.de/web/guest/turniersuche) in order to sign up for the tournament
 * Link to address on Google Maps.
@@ -155,6 +156,20 @@ tournaments match" apart from "this federation is down":
 `status` is one of `ok`, `cached`, `stale` or `error`. `partial` is true when
 any federation failed or is serving stale data; the frontend surfaces that as a
 banner instead of silently showing fewer tournaments.
+
+## Frontend Development
+
+### Running the tests
+
+```bash
+node --check script/main.js     # syntax
+node script/main.test.js        # date parsing, sorting and escaping
+```
+
+Date parsing is the fragile part: federations publish dates as free text in
+several formats (`22.08. bis 23.08.`, `Sa, 15.8.2026 abgesagt`,
+`So, 16.8. – Fr, 21.8.2026`), so changes there should always be covered by a
+test case.
 
 ### Geocoding and map pins
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,23 @@ If a tournament shows up in the wrong place, add an entry to
 
 A different file can be supplied with `TTF_CLUB_LOCATIONS`.
 
+#### Finding wrong pins
+
+`cmd/pincheck` lists tournaments that fell back to their federation's default
+coordinates, which is what produces a stack of unrelated tournaments on one
+marker. Those are the pins worth fixing:
+
+```bash
+cd backend
+go run ./cmd/pincheck -days 30            # report fallback pins
+go run ./cmd/pincheck -days 30 -json      # emit override stubs to paste
+```
+
+Note that venue-exact addresses are **not** available from the upstream
+sources: tennis.de requires a login for tournament details (see issue #55), and
+nuLiga does not expose club addresses. Overrides are therefore the supported
+way to correct a location.
+
 #### Measuring accuracy
 
 `cmd/geobench` resolves a benchmark set of real club names against a live

--- a/backend/cmd/geobench/main.go
+++ b/backend/cmd/geobench/main.go
@@ -62,6 +62,10 @@ var cases = []benchCase{
 	{organizer: "Lohausener Sport-Verein", state: "Nordrhein-Westfalen", wantCity: "Düsseldorf"},
 	{organizer: "Post Südstadt Karlsruhe", state: "Baden-Württemberg", wantCity: "Karlsruhe"},
 
+	// Ambiguous or district-only names, only solvable via the override file.
+	{organizer: "TC Freiberg", state: "Baden-Württemberg", wantCity: "Freiberg am Neckar"},
+	{organizer: "Tennisclub Rot 1971 e.V.", state: "Baden-Württemberg", wantCity: "St. Leon-Rot"},
+
 	// Multi-state federations: the tournament sits in the secondary state.
 	{organizer: "TC Bad Saarow", state: "Berlin",
 		states: []string{"Berlin", "Brandenburg"}, wantCity: "Bad Saarow"},

--- a/backend/cmd/pincheck/main.go
+++ b/backend/cmd/pincheck/main.go
@@ -1,0 +1,197 @@
+// Command pincheck reports which tournaments fall back to their federation's
+// default coordinates, so wrong map pins can be found and fixed deliberately
+// instead of waiting for a user to notice.
+//
+// Venue-exact addresses are not available from the upstream sources without a
+// login (see issue #55), so the practical way to correct a pin is to add an
+// entry to club-locations.json. This tool produces that list, and can emit
+// ready-to-paste JSON for the clubs it could not resolve.
+//
+// It makes real network requests and is a manual tool, never run by CI.
+//
+// Usage:
+//
+//	go run ./cmd/pincheck                    # next 30 days, all federations
+//	go run ./cmd/pincheck -days 60 -fed BAD  # narrow it down
+//	go run ./cmd/pincheck -json              # emit override stubs
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/timoknapp/tennis-tournament-finder/pkg/federation"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/placename"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/tournament"
+)
+
+type fallback struct {
+	Organizer  string
+	Federation string
+	State      string
+	Count      int
+	Candidates []string
+}
+
+func main() {
+	days := flag.Int("days", 30, "size of the date window in days")
+	feds := flag.String("fed", "", "comma-separated federation IDs (default: all)")
+	asJSON := flag.Bool("json", false, "emit override stubs for club-locations.json")
+	flag.Parse()
+
+	logger.SetLogLevel(logger.ErrorLevel)
+
+	tmp, err := os.MkdirTemp("", "pincheck")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to create temp dir:", err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(tmp)
+	os.Setenv("TTF_CACHE_PATH", tmp+"/cache.bolt")
+
+	selected := tournament.FilterFederations(federation.GetFederations(), *feds)
+
+	now := time.Now()
+	dateFrom := now.Format("02.01.2006")
+	dateTo := now.AddDate(0, 0, *days).Format("02.01.2006")
+
+	fmt.Fprintf(os.Stderr, "Checking %s .. %s across %d federations (this is rate limited, please wait)\n\n",
+		dateFrom, dateTo, len(selected))
+
+	// Index federations so a tournament's pin can be compared against the
+	// federation default it would fall back to.
+	defaults := make(map[string]models.Geocoordinates, len(selected))
+	states := make(map[string]string, len(selected))
+	for _, fed := range selected {
+		defaults[fed.Id] = fed.Geocoordinates
+		states[fed.Id] = fed.State
+	}
+
+	var total int
+	byOrganizer := make(map[string]*fallback)
+
+	for _, fed := range selected {
+		tournaments, results := tournament.CollectTournaments(
+			context.Background(), []models.Federation{fed}, dateFrom, dateTo, "")
+		if results[0].Err != nil {
+			fmt.Fprintf(os.Stderr, "  %s: %v\n", fed.Id, results[0].Err)
+			continue
+		}
+
+		def := defaults[fed.Id]
+		for _, t := range tournaments {
+			total++
+			// A tournament pinned exactly at the federation default did not
+			// resolve to a real place.
+			if t.Lat != def.Lat || t.Lon != def.Lon {
+				continue
+			}
+
+			key := fed.Id + "|" + t.Organizer
+			if entry, ok := byOrganizer[key]; ok {
+				entry.Count++
+				continue
+			}
+			byOrganizer[key] = &fallback{
+				Organizer:  t.Organizer,
+				Federation: fed.Id,
+				State:      states[fed.Id],
+				Count:      1,
+				Candidates: placename.Candidates(t.Organizer),
+			}
+		}
+	}
+
+	list := make([]*fallback, 0, len(byOrganizer))
+	for _, f := range byOrganizer {
+		list = append(list, f)
+	}
+	// Most-affected clubs first: fixing those helps the most users.
+	sort.Slice(list, func(i, j int) bool {
+		if list[i].Count != list[j].Count {
+			return list[i].Count > list[j].Count
+		}
+		return list[i].Organizer < list[j].Organizer
+	})
+
+	var affected int
+	for _, f := range list {
+		affected += f.Count
+	}
+
+	if *asJSON {
+		emitStubs(list)
+	} else {
+		emitTable(list)
+	}
+
+	fmt.Fprintf(os.Stderr, "\n%d tournaments checked, %d on a fallback pin (%.1f%%), %d distinct clubs\n",
+		total, affected, percent(affected, total), len(list))
+	if len(list) > 0 && !*asJSON {
+		fmt.Fprintln(os.Stderr, "Re-run with -json to get override stubs for club-locations.json")
+	}
+}
+
+func emitTable(list []*fallback) {
+	fmt.Printf("%-6s %-45s %-6s %s\n", "FED", "ORGANIZER", "COUNT", "CANDIDATES TRIED")
+	fmt.Println(strings.Repeat("-", 110))
+	for _, f := range list {
+		cands := strings.Join(f.Candidates, ", ")
+		if len(cands) > 42 {
+			cands = cands[:41] + "…"
+		}
+		fmt.Printf("%-6s %-45s %-6d %s\n", f.Federation, truncate(f.Organizer, 44), f.Count, cands)
+	}
+}
+
+// emitStubs prints entries ready to paste into club-locations.json, with the
+// city left blank so it has to be filled in deliberately.
+func emitStubs(list []*fallback) {
+	type stub struct {
+		Contains string `json:"contains"`
+		City     string `json:"city"`
+		State    string `json:"state"`
+		Note     string `json:"note"`
+	}
+
+	stubs := make([]stub, 0, len(list))
+	for _, f := range list {
+		stubs = append(stubs, stub{
+			Contains: f.Organizer,
+			City:     "TODO",
+			State:    f.State,
+			Note: fmt.Sprintf("%d tournament(s) fell back to the %s default pin; tried: %s",
+				f.Count, f.Federation, strings.Join(f.Candidates, ", ")),
+		})
+	}
+
+	out, err := json.MarshalIndent(map[string]any{"overrides": stubs}, "", "  ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to encode stubs:", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(out))
+}
+
+func percent(part, total int) float64 {
+	if total == 0 {
+		return 0
+	}
+	return 100 * float64(part) / float64(total)
+}
+
+func truncate(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n-1]) + "…"
+}

--- a/backend/pkg/clublocations/data/club-locations.json
+++ b/backend/pkg/clublocations/data/club-locations.json
@@ -45,6 +45,18 @@
       "city": "Mannheim",
       "state": "Baden-Württemberg",
       "note": "Neckarau is a district of Mannheim."
+    },
+    {
+      "contains": "TC Freiberg",
+      "city": "Freiberg am Neckar",
+      "state": "Baden-Württemberg",
+      "note": "Several places are called Freiberg; the WTB one is Freiberg am Neckar, while the plain name resolves to Freiberg in Sachsen."
+    },
+    {
+      "contains": "Tennisclub Rot 1971",
+      "city": "Sankt Leon-Rot",
+      "state": "Baden-Württemberg",
+      "note": "The club name carries the district 'Rot' only; the municipality is Sankt Leon-Rot, so nothing usable can be derived from the name."
     }
   ]
 }

--- a/css/main.css
+++ b/css/main.css
@@ -631,3 +631,242 @@ body {
         padding: 2vw 3vw;
     }
 }
+
+/* ===== View toggle and list view ===== */
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.viewToggle {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    /* Must sit above the sidebar (z-index 10000), which spans the full width
+       on small screens and would otherwise swallow the clicks. */
+    z-index: 10001;
+    display: flex;
+    box-shadow: 0 1px 5px rgba(0, 0, 0, 0.4);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.viewToggleBtn {
+    padding: 8px 14px;
+    border: none;
+    background-color: #fff;
+    color: #333;
+    font-family: inherit;
+    font-size: 14px;
+    cursor: pointer;
+}
+
+.viewToggleBtn:not(:last-child) {
+    border-right: 1px solid #ddd;
+}
+
+.viewToggleBtn.active {
+    background-color: #4a7c2f;
+    color: #fff;
+}
+
+/* Keyboard users must be able to see which control has focus. */
+.viewToggleBtn:focus-visible,
+.map-button:focus-visible,
+.tournament-list a:focus-visible {
+    outline: 3px solid #1a73e8;
+    outline-offset: 2px;
+}
+
+.list-view {
+    background-color: #f5f5f5;
+    box-sizing: border-box;
+    padding: 16px;
+    min-height: 100vh;
+}
+
+/* In the list view the sidebar must not float above the results: it moves
+   into the normal document flow so the filters sit above the list. */
+body.list-mode .sideBar {
+    position: static;
+    width: auto;
+    left: auto;
+    margin: 10px auto;
+    max-width: 900px;
+    /* The map layout offsets the sidebar and its children; in the normal flow
+       those offsets push content past the viewport and cause sideways
+       scrolling on phones. */
+    padding: 0 8px;
+    box-sizing: border-box;
+}
+
+body.list-mode .filter {
+    left: 0;
+}
+
+body.list-mode .sideBarElement {
+    width: 100%;
+    /* The map layout offsets the sidebar by 8px; in the normal flow that
+       offset pushes the element past the viewport and causes sideways
+       scrolling on phones. */
+    left: 0;
+}
+
+body.list-mode .viewToggle {
+    position: static;
+    margin: 10px auto 0;
+    max-width: 900px;
+    width: max-content;
+}
+
+.list-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    max-width: 900px;
+    margin: 0 auto 16px;
+    font-size: 14px;
+}
+
+.list-controls select {
+    padding: 6px 8px;
+    font-family: inherit;
+    font-size: 14px;
+}
+
+.list-count {
+    margin-left: auto;
+    color: #555;
+}
+
+.tournament-list {
+    list-style: none;
+    margin: 0 auto;
+    padding: 0;
+    max-width: 900px;
+}
+
+.tournament-item {
+    background-color: #fff;
+    border-radius: 6px;
+    padding: 14px 16px;
+    margin-bottom: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+}
+
+.tournament-title {
+    margin: 0 0 8px;
+    font-size: 16px;
+    line-height: 1.3;
+}
+
+.tournament-meta {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 2px 10px;
+    margin: 0 0 8px;
+    font-size: 14px;
+}
+
+.tournament-meta dt {
+    font-weight: bold;
+    color: #555;
+}
+
+.tournament-meta dd {
+    margin: 0;
+}
+
+.tournament-competitions {
+    list-style: none;
+    margin: 0 0 10px;
+    padding: 8px;
+    background-color: #f9f9f9;
+    border-radius: 4px;
+    font-size: 13px;
+}
+
+.tournament-competitions li {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 2px 0;
+}
+
+.competition-lk {
+    color: #555;
+    white-space: nowrap;
+}
+
+.tournament-actions {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.map-button {
+    padding: 6px 12px;
+    border: 1px solid #4a7c2f;
+    border-radius: 4px;
+    background-color: #fff;
+    color: #4a7c2f;
+    font-family: inherit;
+    font-size: 14px;
+    cursor: pointer;
+}
+
+.map-button:hover {
+    background-color: #f0f6ec;
+}
+
+.list-empty {
+    max-width: 900px;
+    margin: 24px auto;
+    text-align: center;
+    color: #555;
+}
+
+@media (max-width: 768px) {
+    /* On phones the sidebar occupies the top of the screen, so the toggle
+       moves to the bottom where it cannot collide with the filters. */
+    .viewToggle {
+        top: auto;
+        bottom: 12px;
+        right: 12px;
+    }
+
+    body.list-mode .viewToggle {
+        position: fixed;
+    }
+
+    /* Touch targets should be at least ~44px; the toggle is the primary way
+       to switch views on a phone. */
+    .viewToggleBtn {
+        padding: 12px 20px;
+        font-size: 3.8vw;
+        min-height: 44px;
+    }
+
+    .list-view {
+        padding: 14vw 3vw 6vw;
+    }
+
+    .list-controls,
+    .tournament-meta,
+    .tournament-item {
+        font-size: 3.4vw;
+    }
+
+    .tournament-title {
+        font-size: 4vw;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -280,9 +280,36 @@
         </div>
     </div>
     <div id="dataNotice" class="data-notice" role="status" aria-live="polite" style="display: none;"></div>
+
+    <div class="viewToggle" role="group" aria-label="Ansicht wählen">
+        <button type="button" id="viewMapBtn" class="viewToggleBtn active"
+                onclick="setView('map')" aria-pressed="true">Karte</button>
+        <button type="button" id="viewListBtn" class="viewToggleBtn"
+                onclick="setView('list')" aria-pressed="false">Liste</button>
+    </div>
+
     <div id="map">
         <div id="loading" class="loading">Loading&#8230;</div>
     </div>
+
+    <section id="listView" class="list-view" style="display: none;" aria-labelledby="listViewHeading">
+        <h2 id="listViewHeading" class="visually-hidden">Turnierliste</h2>
+
+        <div class="list-controls">
+            <label for="listSort">Sortieren nach:</label>
+            <select id="listSort" onchange="renderTournamentList()">
+                <option value="date">Datum</option>
+                <option value="title">Titel</option>
+                <option value="organizer">Veranstalter</option>
+            </select>
+            <span id="listCount" class="list-count" aria-live="polite"></span>
+        </div>
+
+        <ul id="tournamentList" class="tournament-list"></ul>
+        <p id="listEmpty" class="list-empty" style="display: none;">
+            Keine Turniere gefunden. Bitte Filter anpassen und erneut suchen.
+        </p>
+    </section>
     
     <!-- Update Notification Popup -->
     <div id="updateNotification" class="update-notification" style="display: none;" role="dialog" aria-labelledby="update-title" aria-describedby="update-message">

--- a/script/main.js
+++ b/script/main.js
@@ -106,6 +106,14 @@ function registerMapFilterAutoClose() {
 // Remove automatic initial request - user must manually submit
 // getTournamentsByDate(initDateFrom, initDateTo, "", getSelectedFederations());
 
+// Tournaments from the most recent search, shared by the map and list views so
+// both always show the same data.
+let currentTournaments = [];
+// Marker instances keyed by tournament id, so the list can open the matching
+// popup on the map.
+let markerById = new Map();
+let currentView = 'map';
+
 function getTournamentsByDate(dateFrom, dateTo, compType, federations) {
     if (dateFrom != "" && dateTo != "") {
         dateFrom = formatDateToAPI(dateFrom);
@@ -114,6 +122,9 @@ function getTournamentsByDate(dateFrom, dateTo, compType, federations) {
         .then(response => {
             const tournaments = response.tournaments || [];
             renderDataNotice(response, tournaments.length);
+
+            currentTournaments = tournaments;
+            markerById = new Map();
 
             map.removeLayer(markers);
             markers = createMarkerClusterGroup();
@@ -158,8 +169,12 @@ function getTournamentsByDate(dateFrom, dateTo, compType, federations) {
                 ${competitionDetails}
                 `)
                 markers.addLayer(marker);
+                if (tournament["id"]) {
+                    markerById.set(String(tournament["id"]), marker);
+                }
             }
             map.addLayer(markers);
+            renderTournamentList();
         });
     }
 }
@@ -381,4 +396,222 @@ function attachFilterAutoCloseToMarkers(group) {
     markerEvents.forEach(eventName => {
         group.on(eventName, closeFiltersForMapInteraction);
     });
+}
+// ===== List view =====
+//
+// The map alone makes it hard to compare dates and is awkward to use with a
+// keyboard or screen reader. The list shows the same data from the same state,
+// so the two views can never disagree.
+
+// parseTournamentDate extracts a sortable start date from the free-text date
+// string the federations publish.
+//
+// Formats seen in live data vary per federation, e.g.:
+//   "22.08. bis 23.08."          (old API, no year)
+//   "Sa, 15.8.2026 abgesagt"     (new API, weekday + trailing note)
+//   "So, 16.8. – Fr, 21.8.2026"  (new API, range)
+//
+// Returns null when nothing usable is found, so sorting can put those last
+// instead of guessing a wrong date.
+function parseTournamentDate(dateText) {
+    if (!dateText) {
+        return null;
+    }
+
+    // First day/month pair wins: it is the tournament's start in every format.
+    const match = String(dateText).match(/(\d{1,2})\.\s*(\d{1,2})\.\s*(\d{4})?/);
+    if (!match) {
+        return null;
+    }
+
+    const day = parseInt(match[1], 10);
+    const month = parseInt(match[2], 10);
+    if (!day || !month || month > 12 || day > 31) {
+        return null;
+    }
+
+    // Without a year, assume the search window: use the current year and roll
+    // over to the next one when the date already passed by more than a month.
+    let year = match[3] ? parseInt(match[3], 10) : new Date().getFullYear();
+    const parsed = new Date(year, month - 1, day);
+    if (!match[3]) {
+        const monthAgo = new Date();
+        monthAgo.setMonth(monthAgo.getMonth() - 1);
+        if (parsed < monthAgo) {
+            parsed.setFullYear(year + 1);
+        }
+    }
+
+    return isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function compareTournaments(a, b, sortBy) {
+    if (sortBy === 'title') {
+        return (a.title || '').localeCompare(b.title || '', 'de');
+    }
+    if (sortBy === 'organizer') {
+        return (a.organizer || '').localeCompare(b.organizer || '', 'de');
+    }
+
+    // Date: unparseable entries sort last rather than to 1970.
+    const da = parseTournamentDate(a.date);
+    const db = parseTournamentDate(b.date);
+    if (!da && !db) {
+        return (a.title || '').localeCompare(b.title || '', 'de');
+    }
+    if (!da) {
+        return 1;
+    }
+    if (!db) {
+        return -1;
+    }
+    if (da.getTime() !== db.getTime()) {
+        return da - db;
+    }
+    return (a.title || '').localeCompare(b.title || '', 'de');
+}
+
+function escapeHtml(value) {
+    return String(value == null ? '' : value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function renderTournamentList() {
+    const list = document.getElementById('tournamentList');
+    const empty = document.getElementById('listEmpty');
+    const count = document.getElementById('listCount');
+    const sortSelect = document.getElementById('listSort');
+
+    if (!list || !empty || !count) {
+        return;
+    }
+
+    const sortBy = sortSelect ? sortSelect.value : 'date';
+    const sorted = currentTournaments.slice().sort((a, b) => compareTournaments(a, b, sortBy));
+
+    count.textContent = sorted.length === 1
+        ? '1 Turnier'
+        : `${sorted.length} Turniere`;
+
+    list.innerHTML = '';
+
+    if (sorted.length === 0) {
+        empty.style.display = 'block';
+        return;
+    }
+    empty.style.display = 'none';
+
+    const fragment = document.createDocumentFragment();
+
+    for (const tournament of sorted) {
+        const entries = (tournament.entries || []).filter(entry =>
+            entry.competition || (entry.skill_level && entry.skill_level.trim() !== ''));
+
+        const item = document.createElement('li');
+        item.className = 'tournament-item';
+
+        const competitions = entries.length > 0
+            ? `<ul class="tournament-competitions">${entries.map(entry => `
+                    <li><span class="competition-name">${escapeHtml(entry.competition || '-')}</span>
+                        <span class="competition-lk">${escapeHtml(entry.skill_level || '')}</span></li>
+               `).join('')}</ul>`
+            : '';
+
+        const hasCoords = tournament.lat && tournament.lon;
+
+        item.innerHTML = `
+            <h3 class="tournament-title">${escapeHtml(tournament.title)}</h3>
+            <dl class="tournament-meta">
+                <dt>Datum</dt><dd>${escapeHtml(tournament.date)}</dd>
+                <dt>Veranstalter</dt>
+                <dd><a target="_blank" rel="noopener"
+                       href="${urlGoogleQuery + encodeURIComponent(tournament.organizer || '')}">
+                       ${escapeHtml(tournament.organizer)}</a></dd>
+            </dl>
+            ${competitions}
+            <div class="tournament-actions">
+                <a href="${escapeHtml(tournament.url)}" target="_blank" rel="noopener"
+                   class="signup-button">Anmelden</a>
+                ${hasCoords ? `<button type="button" class="map-button"
+                    data-tournament-id="${escapeHtml(tournament.id)}">Auf Karte zeigen</button>` : ''}
+            </div>
+        `;
+
+        if (hasCoords) {
+            const mapButton = item.querySelector('.map-button');
+            if (mapButton) {
+                mapButton.addEventListener('click', () => showTournamentOnMap(tournament));
+            }
+        }
+
+        fragment.appendChild(item);
+    }
+
+    list.appendChild(fragment);
+}
+
+// showTournamentOnMap switches to the map and opens the matching popup, so
+// selecting an entry in the list stays connected to the map view.
+function showTournamentOnMap(tournament) {
+    setView('map');
+
+    const lat = parseFloat(tournament.lat);
+    const lon = parseFloat(tournament.lon);
+    if (isNaN(lat) || isNaN(lon)) {
+        return;
+    }
+
+    map.setView([lat, lon], Math.max(map.getZoom(), 12));
+
+    const marker = markerById.get(String(tournament.id));
+    if (!marker) {
+        return;
+    }
+
+    // Markers live in a cluster group, so the cluster has to be expanded
+    // before the popup can open.
+    if (typeof markers.zoomToShowLayer === 'function') {
+        markers.zoomToShowLayer(marker, () => marker.openPopup());
+    } else {
+        marker.openPopup();
+    }
+}
+
+function setView(view) {
+    const mapEl = document.getElementById('map');
+    const listEl = document.getElementById('listView');
+    const mapBtn = document.getElementById('viewMapBtn');
+    const listBtn = document.getElementById('viewListBtn');
+
+    if (!mapEl || !listEl || !mapBtn || !listBtn) {
+        return;
+    }
+
+    currentView = view === 'list' ? 'list' : 'map';
+    const showList = currentView === 'list';
+
+    // The sidebar floats above the map by design. In the list view that would
+    // cover the first results, so the page switches to a normal document flow
+    // with the filters above the list.
+    document.body.classList.toggle('list-mode', showList);
+
+    mapEl.style.display = showList ? 'none' : 'block';
+    listEl.style.display = showList ? 'block' : 'none';
+
+    mapBtn.classList.toggle('active', !showList);
+    listBtn.classList.toggle('active', showList);
+    mapBtn.setAttribute('aria-pressed', String(!showList));
+    listBtn.setAttribute('aria-pressed', String(showList));
+
+    if (showList) {
+        renderTournamentList();
+    } else {
+        // Leaflet renders a grey area when the container was hidden while it
+        // resized, so the map has to be told its size changed.
+        setTimeout(() => map.invalidateSize(), 0);
+    }
 }

--- a/script/main.test.js
+++ b/script/main.test.js
@@ -1,0 +1,162 @@
+// Unit tests for the list view's date parsing and sorting.
+//
+// Federations publish dates as free text in several formats, so this logic is
+// easy to break and impossible to verify by looking at the map.
+//
+// Run with: node script/main.test.js
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+// main.js expects a browser. Load it in a sandbox with just enough DOM for the
+// pure functions under test, and stop before the Leaflet setup runs.
+const source = fs.readFileSync(path.join(__dirname, 'main.js'), 'utf8');
+const listSection = source.slice(source.indexOf('// ===== List view ====='));
+
+const sandbox = {
+    console,
+    Date,
+    document: { getElementById: () => null, querySelectorAll: () => [] },
+    window: {},
+    urlGoogleQuery: 'https://maps.google.com/maps?q=',
+    currentTournaments: [],
+    markerById: new Map(),
+    map: {},
+    markers: {},
+    setView: () => {},
+};
+vm.createContext(sandbox);
+vm.runInContext(listSection, sandbox);
+
+const { parseTournamentDate, compareTournaments, escapeHtml } = sandbox;
+
+let failures = 0;
+function test(name, fn) {
+    try {
+        fn();
+        console.log(`  ok  ${name}`);
+    } catch (err) {
+        failures++;
+        console.error(`  FAIL ${name}\n       ${err.message}`);
+    }
+}
+
+console.log('parseTournamentDate');
+
+test('parses the old API range format', () => {
+    const d = parseTournamentDate('22.08. bis 23.08.');
+    assert.ok(d, 'expected a date');
+    assert.strictEqual(d.getDate(), 22);
+    assert.strictEqual(d.getMonth(), 7); // August
+});
+
+test('parses the new API format with weekday and year', () => {
+    const d = parseTournamentDate('Sa, 15.8.2026');
+    assert.strictEqual(d.getDate(), 15);
+    assert.strictEqual(d.getMonth(), 7);
+    assert.strictEqual(d.getFullYear(), 2026);
+});
+
+test('parses a range and returns the start date', () => {
+    const d = parseTournamentDate('So, 16.8. – Fr, 21.8.2026');
+    assert.strictEqual(d.getDate(), 16);
+    assert.strictEqual(d.getMonth(), 7);
+});
+
+test('ignores trailing notes such as "abgesagt"', () => {
+    const d = parseTournamentDate('Sa, 15.8.2026 abgesagt');
+    assert.strictEqual(d.getDate(), 15);
+    assert.strictEqual(d.getFullYear(), 2026);
+});
+
+test('returns null for unusable input', () => {
+    for (const input of ['', null, undefined, 'demnächst', '99.99.']) {
+        assert.strictEqual(parseTournamentDate(input), null, `input: ${input}`);
+    }
+});
+
+test('rejects impossible months', () => {
+    assert.strictEqual(parseTournamentDate('01.13.2026'), null);
+});
+
+console.log('compareTournaments');
+
+test('sorts by date ascending', () => {
+    const list = [
+        { title: 'B', date: '22.08. bis 23.08.' },
+        { title: 'A', date: '01.08. bis 02.08.' },
+    ];
+    list.sort((a, b) => compareTournaments(a, b, 'date'));
+    assert.strictEqual(list[0].title, 'A');
+});
+
+test('puts entries with unparseable dates last', () => {
+    const list = [
+        { title: 'Unbekannt', date: 'wird noch bekannt gegeben' },
+        { title: 'Konkret', date: '01.08. bis 02.08.' },
+    ];
+    list.sort((a, b) => compareTournaments(a, b, 'date'));
+    assert.strictEqual(list[0].title, 'Konkret');
+    assert.strictEqual(list[1].title, 'Unbekannt');
+});
+
+test('sorts by title using German collation', () => {
+    const list = [
+        { title: 'Zwickau Open' },
+        { title: 'Ähringen Cup' },
+        { title: 'Berlin Masters' },
+    ];
+    list.sort((a, b) => compareTournaments(a, b, 'title'));
+    assert.deepStrictEqual(list.map(t => t.title),
+        ['Ähringen Cup', 'Berlin Masters', 'Zwickau Open']);
+});
+
+test('sorts by organizer', () => {
+    const list = [
+        { organizer: 'TC Ulm' },
+        { organizer: 'TC Aalen' },
+    ];
+    list.sort((a, b) => compareTournaments(a, b, 'organizer'));
+    assert.strictEqual(list[0].organizer, 'TC Aalen');
+});
+
+test('falls back to the title when dates are equal', () => {
+    const list = [
+        { title: 'B', date: '01.08.' },
+        { title: 'A', date: '01.08.' },
+    ];
+    list.sort((a, b) => compareTournaments(a, b, 'date'));
+    assert.strictEqual(list[0].title, 'A');
+});
+
+test('handles missing fields without throwing', () => {
+    const list = [{}, { title: 'A' }, { date: '01.08.' }];
+    assert.doesNotThrow(() => list.sort((a, b) => compareTournaments(a, b, 'date')));
+    assert.doesNotThrow(() => list.sort((a, b) => compareTournaments(a, b, 'title')));
+});
+
+console.log('escapeHtml');
+
+test('escapes markup so tournament data cannot inject HTML', () => {
+    assert.strictEqual(
+        escapeHtml('<img src=x onerror="alert(1)">'),
+        '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;');
+});
+
+test('escapes quotes and ampersands', () => {
+    assert.strictEqual(escapeHtml(`Rot & Weiß "TC" 'X'`),
+        'Rot &amp; Weiß &quot;TC&quot; &#39;X&#39;');
+});
+
+test('handles null and undefined', () => {
+    assert.strictEqual(escapeHtml(null), '');
+    assert.strictEqual(escapeHtml(undefined), '');
+});
+
+if (failures > 0) {
+    console.error(`\n${failures} test(s) failed`);
+    process.exit(1);
+}
+console.log('\nAll frontend tests passed');


### PR DESCRIPTION
Adds the list view from #50, and closes out the address-source investigation from #55 with a definitive answer.

> **Note:** stacked on #58 (result cache). The diff against `master` will shrink once that merges — review the last two commits.

## #50 — Sortable, accessible list view

A map alone makes it hard to compare dates and is awkward with a keyboard or screen reader.

* Toggle between map and list; both render from the **same state**, so they can never disagree.
* Sort by date, title or organizer, with German collation so umlauts order correctly.
* "Auf Karte zeigen" switches to the map, expands the marker cluster and opens the matching popup.
* Semantic markup (`section`/`h2`/`ul`/`dl`), `aria-pressed` on the toggle, live region for the result count, visible focus outlines.

### Date parsing is the fragile part

Federations publish dates as free text. Verified against live data:

```
"22.08. bis 23.08."           old API, no year
"Sa, 15.8.2026 abgesagt"      new API, weekday + trailing note
"So, 16.8. – Fr, 21.8.2026"   new API, range
```

The parser takes the first day/month pair, infers a missing year from the search window, and returns `null` when nothing usable is found — so those entries sort **last** instead of jumping to 1970.

### Layout bugs found by actually looking

I rendered the page in headless Chromium and screenshotted it rather than assuming it worked. Four real bugs came out of that:

1. The sidebar floats above the map by design (`z-index: 10000`) and **covered the first results** in list mode.
2. On a 390px viewport the sidebar spans the full width and **swallowed clicks on the view toggle** — the list was unreachable on a phone.
3. Once in normal flow, the sidebar's 8px offset caused **8px of horizontal scrolling** on mobile.
4. Toggle buttons were 36px tall, below the ~44px touch guidance.

### Frontend tests

There were none. Added 15 covering date parsing, sorting and HTML escaping, plus a CI workflow running them and `node --check`.

The escaping test matters: tournament data is rendered through `innerHTML`, so upstream markup would otherwise be injected directly.

## #55 — Login **is** required (investigation closed)

Captured the full ZK protocol in a real browser. Clicking a tournament title produces:

```
RES: ['zul.wnd.Window', ..., title:'Information',
     value:'Bitte logge dich ein, um nähere Informationen
            zum Turnier sehen zu können.'
     ['zul.wgt.Button','btn1',{label:'Login'}]]
```

My earlier finding was misleading: the widget payload *does* contain `Straße`, `PLZ und Ort` and `Platzanlage` — but those are **field captions of an empty form**. The values come from a server-side update gated on an authenticated session. Also checked: nuLiga `tournamentInfo`/`tournament` → 403, `clubSearch` → 200 but no address fields.

So the gate is server-side authorisation, not a protocol detail I could replay more carefully. Full write-up in #55.

### Consequence: make overrides findable

Since `club-locations.json` is now the *only* way to fix a pin, wrong pins should be discoverable rather than waiting for a user to report one.

`cmd/pincheck` lists tournaments sitting exactly on their federation's default coordinates, grouped by club, sorted by impact, with `-json` emitting paste-ready stubs.

Run over 21 days across BAD, WTB and TVBB: **2 of 175 tournaments (1.1%)** on a fallback pin. Both unsolvable by any heuristic:

* **TC Freiberg** — several German towns are called Freiberg; the plain name resolves to Freiberg in *Sachsen*, but the WTB club is in *Freiberg am Neckar*.
* **Tennisclub Rot 1971 e.V.** — the name carries only the district "Rot"; the municipality is *St. Leon-Rot*.

Both added to the override file and the benchmark, which is now **24/24** against live Nominatim.

## Verification

* `go test -race`, `go vet`, `gofmt`, `go mod tidy` — clean
* Frontend unit tests and syntax checks — pass
* List view verified in headless Chromium at 1280px and 390px: no overlap, no horizontal overflow, no console errors, 44px touch targets

Closes #50
