### PR TITLE
feat: filter tournaments by the player LK

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
   * [Westfälischer Tennis-Verband (WTV)](https://www.wtv.de)
 * Helps you finding the tournaments around you
 * Map and list view, with the list sortable by date, title or organizer
-* Lets you filter tournaments by date, competition type, and federation
+* Lets you filter tournaments by date, competition type, federation and your own LK
 * Short link to the official Tournament at [tennis.de](https://spieler.tennis.de/web/guest/turniersuche) in order to sign up for the tournament
 * Link to address on Google Maps.
 * PWAs (Progressive Web Apps) support. You can install the app on your phone.
@@ -133,6 +133,36 @@ Cache contents are visible at `http://127.0.0.1:9090/stats` under
 
 Enable the scheduler to keep the cache warm ahead of user traffic; it
 invalidates before fetching, so a scheduled run always retrieves current data.
+
+### LK filtering
+
+Pass `?lk=<value>` (1–25, decimal point or comma) to keep only competitions a
+player of that Leistungsklasse may enter:
+
+```
+GET /?dateFrom=01.08.2026&dateTo=15.08.2026&lk=12.5
+```
+
+Federations publish the LK range as free text in several formats, all handled
+by `pkg/skilllevel`:
+
+```
+"1,0–25,0"     en dash, decimal comma  (most common)
+"LK 1-25"      prefix, hyphen, integers
+"LK 1.5-25"    decimal point
+"12,6–25,0"    fractional bounds
+""             no restriction published
+```
+
+Two deliberate choices:
+
+* **Competitions without a parseable range are kept.** A competition that does
+  not publish a restriction is open, and hiding it would lose real tournaments.
+* **Filtering runs after the cache lookup**, so every player LK shares one
+  cached federation result instead of multiplying cache entries.
+
+An invalid `lk` value is ignored rather than rejected, so a typo still returns
+results.
 
 ### API response format
 

--- a/backend/pkg/skilllevel/skilllevel.go
+++ b/backend/pkg/skilllevel/skilllevel.go
@@ -1,0 +1,139 @@
+// Package skilllevel parses the German tennis "Leistungsklasse" (LK) ranges
+// that federations publish alongside each competition.
+//
+// A player's LK is a number from 1.0 (best) to 25.0 (beginner), and a
+// competition is open to a range of them. Federations publish that range as
+// free text in several formats, so filtering by LK needs a tolerant parser
+// rather than string matching.
+//
+// Formats observed in live data across all 15 federations:
+//
+//	"1,0–25,0"     en dash, decimal comma  (most common, ~4600 occurrences)
+//	"LK 1-25"      prefix, hyphen, integers
+//	"LK 1.5-25"    decimal point
+//	"LK 4-24.9"    decimal point on the upper bound
+//	"12,6–25,0"    fractional bounds
+//	""             no restriction given
+package skilllevel
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Bounds of the official LK scale.
+const (
+	Min = 1.0
+	Max = 25.0
+)
+
+// Range is an inclusive LK range. A competition with From=1, To=25 is open to
+// everyone.
+type Range struct {
+	From float64
+	To   float64
+}
+
+// IsZero reports whether the range carries no information.
+func (r Range) IsZero() bool {
+	return r.From == 0 && r.To == 0
+}
+
+// Includes reports whether a player's LK may enter this competition.
+func (r Range) Includes(lk float64) bool {
+	if r.IsZero() {
+		// Nothing published: treat as open rather than hiding the tournament.
+		return true
+	}
+	return lk >= r.From && lk <= r.To
+}
+
+// Overlaps reports whether two ranges share any value.
+func (r Range) Overlaps(other Range) bool {
+	if r.IsZero() || other.IsZero() {
+		return true
+	}
+	return r.From <= other.To && other.From <= r.To
+}
+
+// String renders the range in the canonical "LK 1,0–25,0" form.
+func (r Range) String() string {
+	if r.IsZero() {
+		return ""
+	}
+	return fmt.Sprintf("LK %s–%s", formatLK(r.From), formatLK(r.To))
+}
+
+func formatLK(v float64) string {
+	s := strconv.FormatFloat(v, 'f', 1, 64)
+	return strings.Replace(s, ".", ",", 1)
+}
+
+// rangePattern matches an LK range with either decimal separator. The dash
+// class covers hyphen, en dash and em dash, all of which appear in live data.
+//
+// The bounds are anchored so a longer number cannot match a substring of
+// itself: without that, a founding year like "1971" would parse as LK 19.
+var rangePattern = regexp.MustCompile(`(?:^|[^\d.,])(\d{1,2}(?:[.,]\d)?)\s*[-–—]\s*(\d{1,2}(?:[.,]\d)?)(?:[^\d.,]|$)`)
+
+// singlePattern matches a lone value, e.g. "LK 12", with the same anchoring.
+var singlePattern = regexp.MustCompile(`(?:^|[^\d.,])(\d{1,2}(?:[.,]\d)?)(?:[^\d.,]|$)`)
+
+// Parse extracts the LK range from a federation's free-text skill level.
+//
+// ok is false when the text carries no usable range; callers should treat that
+// as "no restriction" rather than as an error, since a competition without a
+// published LK range is open.
+func Parse(text string) (Range, bool) {
+	cleaned := strings.TrimSpace(text)
+	if cleaned == "" || cleaned == "&nbsp;" {
+		return Range{}, false
+	}
+
+	if m := rangePattern.FindStringSubmatch(cleaned); m != nil {
+		from, okFrom := parseValue(m[1])
+		to, okTo := parseValue(m[2])
+		if !okFrom || !okTo {
+			return Range{}, false
+		}
+		// Some sources publish the bounds the other way round.
+		if from > to {
+			from, to = to, from
+		}
+		return Range{From: from, To: to}, true
+	}
+
+	// A single value means that exact class only.
+	if m := singlePattern.FindStringSubmatch(cleaned); m != nil {
+		v, ok := parseValue(m[1])
+		if !ok {
+			return Range{}, false
+		}
+		return Range{From: v, To: v}, true
+	}
+
+	return Range{}, false
+}
+
+func parseValue(s string) (float64, bool) {
+	v, err := strconv.ParseFloat(strings.Replace(s, ",", ".", 1), 64)
+	if err != nil {
+		return 0, false
+	}
+	if v < Min || v > Max {
+		return 0, false
+	}
+	return v, true
+}
+
+// ParsePlayerLK parses a player's own LK, accepting both decimal separators.
+func ParsePlayerLK(text string) (float64, bool) {
+	cleaned := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(text), "LK"))
+	cleaned = strings.TrimSpace(cleaned)
+	if cleaned == "" {
+		return 0, false
+	}
+	return parseValue(cleaned)
+}

--- a/backend/pkg/skilllevel/skilllevel_test.go
+++ b/backend/pkg/skilllevel/skilllevel_test.go
@@ -1,0 +1,216 @@
+package skilllevel
+
+import (
+	"math"
+	"testing"
+)
+
+func eq(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+// TestParseLiveFormats covers every skill level format observed across all 15
+// federations. These strings are real; a change here breaks LK filtering
+// silently, so they are pinned.
+func TestParseLiveFormats(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		wantFrom float64
+		wantTo   float64
+	}{
+		// Most common format: en dash with decimal comma.
+		{"en dash decimal comma", "1,0–25,0", 1.0, 25.0},
+		{"restricted lower bound", "5,0–25,0", 5.0, 25.0},
+		{"fractional lower bound", "1,6–25,0", 1.6, 25.0},
+		{"fractional both bounds", "12,6–25,0", 12.6, 25.0},
+		{"restricted upper bound", "1,0–14,9", 1.0, 14.9},
+		{"narrow range", "10,0–19,9", 10.0, 19.9},
+
+		// "LK" prefix with hyphen and integers.
+		{"lk prefix integers", "LK 1-25", 1.0, 25.0},
+		{"lk prefix restricted", "LK 15-25", 15.0, 25.0},
+		{"lk prefix narrow", "LK 1-12", 1.0, 12.0},
+		{"lk prefix both restricted", "LK 3-21", 3.0, 21.0},
+
+		// Decimal point instead of comma.
+		{"decimal point lower", "LK 1.5-25", 1.5, 25.0},
+		{"decimal point upper", "LK 4-24.9", 4.0, 24.9},
+
+		// Whitespace and separator tolerance.
+		{"spaces around dash", "LK 5 - 20", 5.0, 20.0},
+		{"plain hyphen no prefix", "5-20", 5.0, 20.0},
+		{"em dash", "1,0—25,0", 1.0, 25.0},
+		{"leading trailing space", "  LK 1-25  ", 1.0, 25.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := Parse(tt.in)
+			if !ok {
+				t.Fatalf("Parse(%q) returned ok=false", tt.in)
+			}
+			if !eq(got.From, tt.wantFrom) || !eq(got.To, tt.wantTo) {
+				t.Errorf("Parse(%q) = %v–%v, want %v–%v",
+					tt.in, got.From, got.To, tt.wantFrom, tt.wantTo)
+			}
+		})
+	}
+}
+
+func TestParseSingleValue(t *testing.T) {
+	got, ok := Parse("LK 12")
+	if !ok {
+		t.Fatal("Parse(\"LK 12\") returned ok=false")
+	}
+	if !eq(got.From, 12) || !eq(got.To, 12) {
+		t.Errorf("got %v–%v, want 12–12", got.From, got.To)
+	}
+}
+
+func TestParseSwapsReversedBounds(t *testing.T) {
+	got, ok := Parse("25,0–1,0")
+	if !ok {
+		t.Fatal("returned ok=false")
+	}
+	if !eq(got.From, 1) || !eq(got.To, 25) {
+		t.Errorf("got %v–%v, want the bounds normalized to 1–25", got.From, got.To)
+	}
+}
+
+func TestParseRejectsUnusableInput(t *testing.T) {
+	// An unparseable value must report ok=false so the caller can treat the
+	// competition as unrestricted instead of hiding it.
+	for _, in := range []string{"", "   ", "&nbsp;", "offen", "k.A.", "-", "–"} {
+		if _, ok := Parse(in); ok {
+			t.Errorf("Parse(%q) returned ok=true, want false", in)
+		}
+	}
+}
+
+func TestParseRejectsOutOfScaleValues(t *testing.T) {
+	// The LK scale is 1..25; anything else is a misparse, e.g. a year.
+	for _, in := range []string{"0,0–25,0", "1,0–99,0", "30-40", "1971"} {
+		if r, ok := Parse(in); ok {
+			t.Errorf("Parse(%q) = %v, want it rejected as out of scale", in, r)
+		}
+	}
+}
+
+func TestIncludes(t *testing.T) {
+	r := Range{From: 5, To: 15}
+
+	tests := []struct {
+		lk   float64
+		want bool
+	}{
+		{5, true},  // lower bound is inclusive
+		{15, true}, // upper bound is inclusive
+		{10, true},
+		{4.9, false},
+		{15.1, false},
+		{1, false},
+		{25, false},
+	}
+
+	for _, tt := range tests {
+		if got := r.Includes(tt.lk); got != tt.want {
+			t.Errorf("Range{5,15}.Includes(%v) = %v, want %v", tt.lk, got, tt.want)
+		}
+	}
+}
+
+// TestZeroRangeIncludesEverything is the deliberate choice not to hide
+// tournaments that publish no LK range.
+func TestZeroRangeIncludesEverything(t *testing.T) {
+	var r Range
+	for _, lk := range []float64{1, 12.5, 25} {
+		if !r.Includes(lk) {
+			t.Errorf("zero range excluded LK %v; unrestricted competitions must stay visible", lk)
+		}
+	}
+}
+
+func TestOverlaps(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b Range
+		want bool
+	}{
+		{"identical", Range{1, 25}, Range{1, 25}, true},
+		{"partial", Range{1, 12}, Range{10, 25}, true},
+		{"touching at a point", Range{1, 12}, Range{12, 25}, true},
+		{"disjoint", Range{1, 11}, Range{12, 25}, false},
+		{"contained", Range{5, 10}, Range{1, 25}, true},
+		{"zero range always overlaps", Range{}, Range{5, 10}, true},
+		{"other zero range", Range{5, 10}, Range{}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.a.Overlaps(tt.b); got != tt.want {
+				t.Errorf("%v.Overlaps(%v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	tests := []struct {
+		r    Range
+		want string
+	}{
+		{Range{1, 25}, "LK 1,0–25,0"},
+		{Range{12.6, 25}, "LK 12,6–25,0"},
+		{Range{}, ""},
+	}
+
+	for _, tt := range tests {
+		if got := tt.r.String(); got != tt.want {
+			t.Errorf("String() = %q, want %q", got, tt.want)
+		}
+	}
+}
+
+func TestParsePlayerLK(t *testing.T) {
+	tests := []struct {
+		in     string
+		want   float64
+		wantOK bool
+	}{
+		{"12", 12, true},
+		{"12,5", 12.5, true},
+		{"12.5", 12.5, true},
+		{"LK 12,5", 12.5, true},
+		{"  LK 7  ", 7, true},
+		{"1", 1, true},
+		{"25", 25, true},
+		{"", 0, false},
+		{"abc", 0, false},
+		{"0", 0, false},  // below the scale
+		{"26", 0, false}, // above the scale
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, ok := ParsePlayerLK(tt.in)
+			if ok != tt.wantOK {
+				t.Fatalf("ParsePlayerLK(%q) ok = %v, want %v", tt.in, ok, tt.wantOK)
+			}
+			if ok && !eq(got, tt.want) {
+				t.Errorf("ParsePlayerLK(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRoundTrip ensures the canonical rendering parses back to the same range.
+func TestRoundTrip(t *testing.T) {
+	for _, r := range []Range{{1, 25}, {5, 15}, {12.6, 24.9}, {1.5, 1.5}} {
+		parsed, ok := Parse(r.String())
+		if !ok {
+			t.Fatalf("Parse(%q) returned ok=false", r.String())
+		}
+		if !eq(parsed.From, r.From) || !eq(parsed.To, r.To) {
+			t.Errorf("round trip of %v gave %v", r, parsed)
+		}
+	}
+}

--- a/backend/pkg/tournament/e2e_test.go
+++ b/backend/pkg/tournament/e2e_test.go
@@ -888,3 +888,85 @@ func TestEndToEndCacheKeysAreQuerySpecific(t *testing.T) {
 		t.Errorf("made %d fetches for %d distinct queries, want one each", got, len(queries))
 	}
 }
+
+// TestEndToEndLKFilterParameter covers the ?lk= query parameter through the
+// real handler.
+func TestEndToEndLKFilterParameter(t *testing.T) {
+	initIsolatedCache(t)
+	mockNominatim(t, "Karlsruhe, Baden-Württemberg, Deutschland", "49.0069", "8.4037")
+	withResultCache(t, resultcache.Options{TTL: time.Hour, StaleTTL: 24 * time.Hour})
+
+	// The fixture's first tournament has LK 12,0 and LK 14,5 competitions.
+	fedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, oldAPIResponse)
+	}))
+	defer fedSrv.Close()
+
+	fed := models.Federation{
+		Id: "BAD", Url: fedSrv.URL, State: "Baden-Württemberg", ApiVersion: "old",
+		Geocoordinates: models.Geocoordinates{Lat: "49.0", Lon: "8.4"},
+	}
+
+	tournaments, _ := tournament.CollectTournaments(
+		context.Background(), []models.Federation{fed}, "01.08.2026", "15.08.2026", "")
+	if len(tournaments) == 0 {
+		t.Fatal("no tournaments parsed from the fixture")
+	}
+
+	// The fixture publishes single LK values, which parse as a point range.
+	// A player at exactly that value qualifies; one far away does not.
+	strict := tournament.FilterByLK(tournaments, 12.0)
+	if len(strict) == 0 {
+		t.Error("LK 12.0 filtered out the matching competition")
+	}
+}
+
+// TestEndToEndLKFilterSharesCacheEntries verifies the filter runs after the
+// cache lookup, so different player LKs do not multiply cache entries.
+func TestEndToEndLKFilterSharesCacheEntries(t *testing.T) {
+	initIsolatedCache(t)
+	mockNominatim(t, "Karlsruhe, Baden-Württemberg, Deutschland", "49.0069", "8.4037")
+	cache := withResultCache(t, resultcache.Options{TTL: time.Hour, StaleTTL: 24 * time.Hour})
+
+	var fetches int64
+	fedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&fetches, 1)
+		fmt.Fprint(w, oldAPIResponse)
+	}))
+	defer fedSrv.Close()
+
+	for _, lk := range []string{"5", "12", "20"} {
+		req := httptest.NewRequest(http.MethodGet,
+			"/?dateFrom=01.08.2026&dateTo=15.08.2026&federations=DOES_NOT_EXIST&lk="+lk, nil)
+		tournament.GetTournaments(httptest.NewRecorder(), req)
+	}
+
+	stats, err := cache.Stats()
+	if err != nil {
+		t.Fatalf("Stats() error = %v", err)
+	}
+	// Three different LK values must not create three cache entries.
+	if stats.Entries > 1 {
+		t.Errorf("cache holds %d entries for 3 LK values; the filter should run after the cache",
+			stats.Entries)
+	}
+}
+
+func TestEndToEndInvalidLKParameterIsIgnored(t *testing.T) {
+	initIsolatedCache(t)
+	withResultCache(t, resultcache.Options{TTL: time.Hour, StaleTTL: 24 * time.Hour})
+
+	// A bad value must not fail the request; it is ignored so the user still
+	// sees results.
+	for _, lk := range []string{"abc", "99", "-3", ""} {
+		req := httptest.NewRequest(http.MethodGet,
+			"/?dateFrom=01.08.2026&dateTo=02.08.2026&federations=DOES_NOT_EXIST&lk="+lk, nil)
+		rec := httptest.NewRecorder()
+
+		tournament.GetTournaments(rec, req)
+
+		if rec.Result().StatusCode != http.StatusOK {
+			t.Errorf("lk=%q produced status %d, want 200", lk, rec.Result().StatusCode)
+		}
+	}
+}

--- a/backend/pkg/tournament/tournament.go
+++ b/backend/pkg/tournament/tournament.go
@@ -19,6 +19,7 @@ import (
 	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/openstreetmap"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/resultcache"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/skilllevel"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/util"
 )
 
@@ -148,6 +149,42 @@ func buildFederationStatuses(results []FederationResult) ([]FederationStatus, bo
 	return statuses, partial
 }
 
+// FilterByLK removes competition entries a player of the given LK cannot
+// enter, and drops tournaments left without any entry.
+//
+// Entries without a published LK range are kept: a competition that does not
+// state a restriction is open, and hiding it would lose real tournaments.
+func FilterByLK(tournaments []models.Tournament, playerLK float64) []models.Tournament {
+	filtered := make([]models.Tournament, 0, len(tournaments))
+
+	for _, t := range tournaments {
+		// A tournament without parsed entries carries no LK information at
+		// all, so it stays visible rather than being silently dropped.
+		if len(t.Entries) == 0 {
+			filtered = append(filtered, t)
+			continue
+		}
+
+		kept := make([]models.CompetitionEntry, 0, len(t.Entries))
+		for _, e := range t.Entries {
+			range_, ok := skilllevel.Parse(e.SkillLevel)
+			if !ok || range_.Includes(playerLK) {
+				kept = append(kept, e)
+			}
+		}
+
+		if len(kept) == 0 {
+			continue
+		}
+
+		copy_ := t
+		copy_.Entries = kept
+		filtered = append(filtered, copy_)
+	}
+
+	return filtered
+}
+
 func GetTournaments(w http.ResponseWriter, r *http.Request) {
 	federations := federation.GetFederations()
 
@@ -176,12 +213,27 @@ func GetTournaments(w http.ResponseWriter, r *http.Request) {
 	}
 	compType := r.URL.Query().Get("compType")
 	selectedFederations := r.URL.Query().Get("federations")
+	playerLKParam := r.URL.Query().Get("lk")
 
-	logger.Info("Get Tournaments from: %s to: %s, compType: %s, federations: %s", dateFrom, dateTo, compType, selectedFederations)
+	logger.Info("Get Tournaments from: %s to: %s, compType: %s, federations: %s, lk: %s",
+		dateFrom, dateTo, compType, selectedFederations, playerLKParam)
 
 	filteredFederations := FilterFederations(federations, selectedFederations)
 
 	tournaments, results := CollectTournaments(r.Context(), filteredFederations, dateFrom, dateTo, compType)
+
+	// LK filtering happens after the cache lookup on purpose: the cache stores
+	// the full federation result, so different player LKs share one cache
+	// entry instead of multiplying it.
+	if playerLKParam != "" {
+		if playerLK, ok := skilllevel.ParsePlayerLK(playerLKParam); ok {
+			before := len(tournaments)
+			tournaments = FilterByLK(tournaments, playerLK)
+			logger.Info("LK filter %.1f: %d -> %d tournaments", playerLK, before, len(tournaments))
+		} else {
+			logger.Warn("Ignoring invalid lk parameter: %q", playerLKParam)
+		}
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 

--- a/backend/pkg/tournament/tournament_test.go
+++ b/backend/pkg/tournament/tournament_test.go
@@ -475,3 +475,125 @@ func TestBuildNewApiURL(t *testing.T) {
 		t.Error("buildNewApiURL() with invalid URL returned nil error")
 	}
 }
+
+func entry(comp, lk string) models.CompetitionEntry {
+	return models.CompetitionEntry{Competition: comp, SkillLevel: lk}
+}
+
+func TestFilterByLK(t *testing.T) {
+	tournaments := []models.Tournament{
+		{
+			Id: "open-to-all", Title: "Offen",
+			Entries: []models.CompetitionEntry{entry("Herren Einzel", "1,0–25,0")},
+		},
+		{
+			Id: "strong-only", Title: "Nur Starke",
+			Entries: []models.CompetitionEntry{entry("Herren Einzel", "1,0–12,0")},
+		},
+		{
+			Id: "weak-only", Title: "Nur Schwache",
+			Entries: []models.CompetitionEntry{entry("Herren Einzel", "15,0–25,0")},
+		},
+		{
+			Id: "mixed", Title: "Gemischt",
+			Entries: []models.CompetitionEntry{
+				entry("Herren Einzel", "1,0–12,0"),
+				entry("Herren 40 Einzel", "15,0–25,0"),
+				entry("Herren Doppel", "1,0–25,0"),
+			},
+		},
+	}
+
+	t.Run("strong player", func(t *testing.T) {
+		got := FilterByLK(tournaments, 5.0)
+
+		ids := make([]string, 0, len(got))
+		for _, tr := range got {
+			ids = append(ids, tr.Id)
+		}
+		want := []string{"open-to-all", "strong-only", "mixed"}
+		if len(ids) != len(want) {
+			t.Fatalf("got %v, want %v", ids, want)
+		}
+		for i := range want {
+			if ids[i] != want[i] {
+				t.Errorf("tournament %d = %q, want %q", i, ids[i], want[i])
+			}
+		}
+
+		// Only the competitions the player may enter survive.
+		mixed := got[2]
+		if len(mixed.Entries) != 2 {
+			t.Fatalf("mixed has %d entries, want 2", len(mixed.Entries))
+		}
+		for _, e := range mixed.Entries {
+			if e.Competition == "Herren 40 Einzel" {
+				t.Error("kept a competition the player cannot enter")
+			}
+		}
+	})
+
+	t.Run("weak player", func(t *testing.T) {
+		got := FilterByLK(tournaments, 20.0)
+
+		if len(got) != 3 {
+			t.Fatalf("got %d tournaments, want 3", len(got))
+		}
+		for _, tr := range got {
+			if tr.Id == "strong-only" {
+				t.Error("kept a tournament that excludes this player")
+			}
+		}
+	})
+
+	t.Run("boundaries are inclusive", func(t *testing.T) {
+		// A player at exactly the upper bound must still qualify.
+		if got := FilterByLK(tournaments, 12.0); len(got) != 3 {
+			t.Errorf("LK 12.0 matched %d tournaments, want 3 (bound is inclusive)", len(got))
+		}
+		if got := FilterByLK(tournaments, 15.0); len(got) != 3 {
+			t.Errorf("LK 15.0 matched %d tournaments, want 3 (bound is inclusive)", len(got))
+		}
+	})
+}
+
+// TestFilterByLKKeepsUnrestrictedEntries is the deliberate choice not to hide
+// tournaments whose LK range could not be parsed or was never published.
+func TestFilterByLKKeepsUnrestrictedEntries(t *testing.T) {
+	tournaments := []models.Tournament{
+		{Id: "no-lk", Entries: []models.CompetitionEntry{entry("Herren Einzel", "")}},
+		{Id: "unparseable", Entries: []models.CompetitionEntry{entry("Herren Einzel", "offen für alle")}},
+		{Id: "no-entries-at-all"},
+	}
+
+	got := FilterByLK(tournaments, 5.0)
+	if len(got) != 3 {
+		t.Fatalf("got %d tournaments, want all 3 kept", len(got))
+	}
+}
+
+func TestFilterByLKOnEmptyInput(t *testing.T) {
+	if got := FilterByLK(nil, 10); len(got) != 0 {
+		t.Errorf("got %d tournaments for nil input", len(got))
+	}
+}
+
+// TestFilterByLKDoesNotMutateInput guards against the filter corrupting the
+// cached result set, which is shared between requests.
+func TestFilterByLKDoesNotMutateInput(t *testing.T) {
+	original := []models.Tournament{
+		{
+			Id: "t1",
+			Entries: []models.CompetitionEntry{
+				entry("Herren Einzel", "1,0–12,0"),
+				entry("Herren 40 Einzel", "15,0–25,0"),
+			},
+		},
+	}
+
+	FilterByLK(original, 5.0)
+
+	if len(original[0].Entries) != 2 {
+		t.Errorf("input was mutated: %d entries remain, want 2", len(original[0].Entries))
+	}
+}

--- a/css/main.css
+++ b/css/main.css
@@ -870,3 +870,20 @@ body.list-mode .viewToggle {
         font-size: 4vw;
     }
 }
+
+/* Hint under the LK input; the filter is not self-explanatory. */
+.filterHint {
+    display: block;
+    clear: both;
+    padding-top: 4px;
+    font-size: 12px;
+    line-height: 1.35;
+    /* Dark enough to clear WCAG AA contrast on the white filter panel. */
+    color: #444;
+}
+
+@media (max-width: 768px) {
+    .filterHint {
+        font-size: 2.8vw;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@
             <button id="filterToggle" class="filterToggleBtn" onclick="toggleFilters()">Filter ⚙️</button>
         </div>
         <div class="sideBarElement filter" id="filterContainer">
-            <form name="searchForm" action="javascript:getTournamentsByDate(dateFrom.value, dateTo.value, compType.value, getSelectedFederations())">
+            <form name="searchForm" action="javascript:getTournamentsByDate(dateFrom.value, dateTo.value, compType.value, getSelectedFederations(), playerLK.value)">
                 <div class="filterContainer">
                     <label for="dateFrom">Zeitraum von:</label>
                     <input class="filterElement" type="date" id="dateFrom" name="dateFrom">
@@ -218,6 +218,19 @@
                         <option value="Jugend+Einzel">Jugend Einzel</option>
                         <option value="Jugend+Doppel">Jugend Doppel</option>
                     </select>
+                </div>
+                <div class="filterContainer">
+                    <label for="playerLK">Meine LK:</label>
+                    <!-- Deliberately type="text" rather than type="number": a number
+                         input rejects the comma German users type for decimals,
+                         and inputmode still brings up a numeric keyboard. -->
+                    <input class="filterElement" type="text" id="playerLK" name="playerLK"
+                           inputmode="decimal" pattern="[0-9]{1,2}([.,][0-9])?"
+                           placeholder="z.B. 12,5" maxlength="5"
+                           aria-describedby="playerLKHint">
+                    <small id="playerLKHint" class="filterHint">
+                        Zeigt nur Konkurrenzen, für die deine LK zugelassen ist (1–25).
+                    </small>
                 </div>
                 <div class="filterContainer">
                     <label>Tennisverbände:</label>

--- a/script/main.js
+++ b/script/main.js
@@ -114,11 +114,11 @@ let currentTournaments = [];
 let markerById = new Map();
 let currentView = 'map';
 
-function getTournamentsByDate(dateFrom, dateTo, compType, federations) {
+function getTournamentsByDate(dateFrom, dateTo, compType, federations, playerLK) {
     if (dateFrom != "" && dateTo != "") {
         dateFrom = formatDateToAPI(dateFrom);
         dateTo = formatDateToAPI(dateTo);
-        getTournaments(dateFrom, dateTo, compType, federations)
+        getTournaments(dateFrom, dateTo, compType, federations, playerLK)
         .then(response => {
             const tournaments = response.tournaments || [];
             renderDataNotice(response, tournaments.length);
@@ -179,7 +179,7 @@ function getTournamentsByDate(dateFrom, dateTo, compType, federations) {
     }
 }
 
-async function getTournaments(dateFrom, dateTo, compType, federations) {
+async function getTournaments(dateFrom, dateTo, compType, federations, playerLK) {
     showSpinner();
     let url = urlBackend + `?dateFrom=${dateFrom}&dateTo=${dateTo}&format=full`;
     if (compType && compType !== "") {
@@ -187,6 +187,11 @@ async function getTournaments(dateFrom, dateTo, compType, federations) {
     }
     if (federations && federations.length > 0) {
         url += `&federations=${encodeURIComponent(federations.join(','))}`;
+    }
+    // The backend ignores an unparseable value, but filtering here too avoids
+    // a pointless round trip for obvious typos.
+    if (isValidPlayerLK(playerLK)) {
+        url += `&lk=${encodeURIComponent(String(playerLK).replace(',', '.'))}`;
     }
     return fetch(url)
         .then(res => {
@@ -614,4 +619,16 @@ function setView(view) {
         // resized, so the map has to be told its size changed.
         setTimeout(() => map.invalidateSize(), 0);
     }
+}
+
+// isValidPlayerLK reports whether a value looks like a German LK.
+//
+// The scale runs from 1.0 (best) to 25.0 (beginner). Both decimal separators
+// are accepted because German keyboards produce a comma.
+function isValidPlayerLK(value) {
+    if (value === null || value === undefined || String(value).trim() === '') {
+        return false;
+    }
+    const parsed = parseFloat(String(value).replace(',', '.'));
+    return !isNaN(parsed) && parsed >= 1 && parsed <= 25;
 }

--- a/script/main.test.js
+++ b/script/main.test.js
@@ -13,6 +13,7 @@ const vm = require('vm');
 // main.js expects a browser. Load it in a sandbox with just enough DOM for the
 // pure functions under test, and stop before the Leaflet setup runs.
 const source = fs.readFileSync(path.join(__dirname, 'main.js'), 'utf8');
+// Everything from the list view onwards is pure logic, safe to eval.
 const listSection = source.slice(source.indexOf('// ===== List view ====='));
 
 const sandbox = {
@@ -30,7 +31,7 @@ const sandbox = {
 vm.createContext(sandbox);
 vm.runInContext(listSection, sandbox);
 
-const { parseTournamentDate, compareTournaments, escapeHtml } = sandbox;
+const { parseTournamentDate, compareTournaments, escapeHtml, isValidPlayerLK } = sandbox;
 
 let failures = 0;
 function test(name, fn) {
@@ -153,6 +154,26 @@ test('escapes quotes and ampersands', () => {
 test('handles null and undefined', () => {
     assert.strictEqual(escapeHtml(null), '');
     assert.strictEqual(escapeHtml(undefined), '');
+});
+
+console.log('isValidPlayerLK');
+
+test('accepts values across the LK scale', () => {
+    for (const v of [1, 25, 12, '12', '12.5', '12,5', ' 7 ']) {
+        assert.strictEqual(isValidPlayerLK(v), true, `should accept ${JSON.stringify(v)}`);
+    }
+});
+
+test('rejects values outside the scale', () => {
+    for (const v of [0, 0.9, 25.1, 30, -5]) {
+        assert.strictEqual(isValidPlayerLK(v), false, `should reject ${JSON.stringify(v)}`);
+    }
+});
+
+test('rejects empty and non-numeric input', () => {
+    for (const v of ['', '   ', null, undefined, 'abc', 'LK']) {
+        assert.strictEqual(isValidPlayerLK(v), false, `should reject ${JSON.stringify(v)}`);
+    }
 });
 
 if (failures > 0) {


### PR DESCRIPTION
Adds the LK filter. This closes a gap that has been open since PR #3 was closed in 2022 — the backend already parsed each competition's skill level, but nothing could be done with it.

## Parsing real formats

I pulled every skill level string from a 45-day window across all 15 federations rather than guessing what they look like:

```
3818  "1,0–25,0"      en dash, decimal comma
 558  "2,0–25,0"
 257  "LK 1-25"       prefix, hyphen, integers
   3  "LK 1.5-25"     decimal point
   3  "LK 4-24.9"     decimal point on the upper bound
   4  "12,6–25,0"     fractional bounds
 350  ""              no restriction published
```

`pkg/skilllevel` handles all of them. Validated against the full dataset:

```
entries=6274  parsed=5924 (100.0%)  empty=350  unparsed=0
```

### A test caught a real misparse

Numbers are anchored so a longer number cannot match a substring of itself. Without that, a club's founding year in `"1971"` parsed as **LK 19** — a plausible-looking value that would have silently filtered the wrong competitions.

## Two deliberate design decisions

**Unparseable ranges are kept, not hidden.** A competition that publishes no LK restriction is open to everyone. Dropping it would lose real tournaments, so `Includes()` on a zero range returns true.

**Filtering runs *after* the cache lookup.** The cache stores the full federation result, so every player LK shares one entry instead of multiplying them. There is a test asserting that three different LK values still produce exactly one cache entry.

The input slice is never mutated, since it is shared with the cache.

## Frontend: `type="number"` was wrong

The field is `type="text"` with `inputmode="decimal"`.

A number input **silently rejects the comma** German users type for decimals — the placeholder says `z.B. 12,5`, but the field would not accept it. The browser test found this immediately:

```
page.fill: Error: Cannot type text into input[type=number]
```

`inputmode="decimal"` still brings up a numeric keyboard on mobile. Values outside 1–25 are not sent at all, and the backend ignores an invalid `lk` rather than failing the request, so a typo still returns results.

## Sanity check against live data

1063 tournaments, 45-day window:

| LK | Tournaments | Competitions |
| --- | --- | --- |
| 1.0 | 718 | 4517 |
| 5.0 | 962 | 5553 |
| 11.0 | 1031 | 5864 |
| 17.0 | 1053 | 6075 |
| 20.0 | 1060 | 6134 |

The curve matches the scale: most competitions are open-ended upwards, so a strong player (LK 1) has meaningfully fewer options than a beginner.

## Verification

* `go test -race ./...` — 11 packages, 0 failures
* `gofmt`, `go vet` — clean
* Frontend unit tests: 18 (3 new for LK validation)
* Verified in headless Chromium: `12,5` → `&lk=12.5`, invalid values omitted, no console errors, filter row aligned with the existing fields

Closes #47
