### PR TITLE
feat: add Schleswig-Holstein and Bavaria, completing federation coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@
 
 * Currently supported tennis federations:
   * [Badischer Tennis Verband (BAD)](https://www.badischertennisverband.de/)
+  * [Bayerischer Tennis-Verband (BTV)](https://www.btv.de)
   * [Hamburger Tennisverband (HAM)](https://www.hamburger-tennisverband.de)
   * [Hessischer Tennis Verband (HTV)](https://www.htv-tennis.de/)
   * [Rheinland-Pfälzischer Tennis Verband (RPTV)](https://www.rlp-tennis.de/)
   * [Saarländischer Tennisbund (STB)](https://www.stb-tennis.de)
+  * [Tennisverband Schleswig-Holstein (SLH)](https://www.tennis.de/slh.html)
   * [Sächsischer Tennis Verband (STV)](https://www.stv-tennis.de)
   * [Tennisverband Mecklenburg-Vorpommern (TMV)](https://www.tennis-mv.de)
   * [Tennisverband Niedersachsen-Bremen (TNB)](https://www.tnb-tennis.de)
@@ -39,12 +41,10 @@
 * Link to address on Google Maps.
 * PWAs (Progressive Web Apps) support. You can install the app on your phone.
 
+All 17 German regional federations are supported.
+
 ### Soon
 
-* Support for more tennis federations:
-  * [Bayerischer Tennis Verband (BTV)](https://www.btv.de) — no longer served by
-    liga.nu, so it needs its own parser
-  * [Tennisverband Schleswig-Holstein (TSH)](https://www.tennis.sh)
 * Store favorite tournaments (locally)
 
 ## Backend Development
@@ -133,6 +133,31 @@ Cache contents are visible at `http://127.0.0.1:9090/stats` under
 
 Enable the scheduler to keep the cache warm ahead of user traffic; it
 invalidates before fetching, so a scheduled run always retrieves current data.
+
+### Federation data sources
+
+Sixteen federations are served by the shared nuLiga platform and use one of two
+parsers (`old`/`new`). Two are special:
+
+| Federation | Note |
+| --- | --- |
+| SLH | Commonly abbreviated TSH, but nuLiga serves it as `slh.liga.nu` with `federation=SLH`. |
+| BTV | Bavaria left nuLiga. `btv.de` embeds a ZK (zkoss) widget hosted at `btv-prod.burdadigitalsystems.de`, handled by `pkg/btv`. |
+
+The BTV widget needs no authentication, but it is a stateful UI protocol rather
+than an API:
+
+1. `GET` the widget page for a `JSESSIONID` and the ZK desktop id.
+2. `POST` `onClientInfo` to render the result grid.
+3. `POST` `onPaging` per further page — the grid shows 10 rows at a time.
+
+Two details are easy to get wrong and are covered by tests:
+
+* **`ZK-SID` must increment per request.** With a constant value the server
+  treats later requests as duplicates and replays the first response, so
+  pagination silently returns page 0 forever.
+* **The paging widget's uuid is regenerated in every response** and has to be
+  re-read before the next request.
 
 ### LK filtering
 

--- a/backend/pkg/btv/btv.go
+++ b/backend/pkg/btv/btv.go
@@ -1,0 +1,444 @@
+// Package btv fetches tournaments from the Bayerischer Tennis-Verband.
+//
+// Bavaria left the shared nuLiga platform, so btv.de embeds its own tournament
+// search: a ZK (zkoss) application hosted at btv-prod.burdadigitalsystems.de.
+// It needs no authentication, unlike the tennis.de detail views (see #55).
+//
+// The protocol is small enough to drive directly:
+//
+//  1. GET the widget page. It returns a JSESSIONID cookie and bootstraps ZK
+//     with a desktop id (`dt`) and an update URI (`uu`).
+//  2. POST one `onClientInfo` command to the update URI. ZK replies with the
+//     rendered result grid as a JSON-ish payload.
+//
+// The payload is a ZK widget tree rather than an API response, so it is parsed
+// defensively: any field that cannot be read is skipped instead of failing the
+// whole federation.
+package btv
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/timoknapp/tennis-tournament-finder/pkg/httpclient"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/util"
+)
+
+// maxResponseBytes bounds how much of the widget response is read.
+const maxResponseBytes = 8 << 20 // 8 MiB
+
+// maxPages bounds pagination so a malformed or endlessly repeating response
+// can never loop forever. The widget renders 10 rows per page.
+const maxPages = 40
+
+var (
+	// bootstrapPattern extracts the ZK desktop id and update URI from the
+	// widget page, e.g. zkmx([0,'uuid',{dt:'z_abc',...,uu:'/btvtrnsearch/zkau'...
+	bootstrapPattern = regexp.MustCompile(`zkmx\(\s*\[0,'([^']+)',\{dt:'([^']+)'.*?uu:'([^']+)'`)
+
+	// pagingPattern finds the paging widget's uuid and its page count, which
+	// are needed to request the remaining pages.
+	pagingPattern = regexp.MustCompile(`\['zul\.mesh\.Paging','([^']+)',\{[^}]*pageCount:(\d+)`)
+
+	// zkEscapePattern matches the \xNN escapes ZK uses for non-ASCII output.
+	zkEscapePattern = regexp.MustCompile(`\\x([0-9A-Fa-f]{2})`)
+
+	// rowPattern splits the payload into individual result rows.
+	rowPattern = regexp.MustCompile(`\['zul\.grid\.Row'`)
+
+	// datePattern matches "10.08. - 16.08.2026 in Bad Füssing".
+	datePattern = regexp.MustCompile(`value:'(\d{2}\.\d{2}\.\s*-\s*\d{2}\.\d{2}\.\d{4})\s+in\s+([^']+)'`)
+
+	// linkPattern matches the tennis.de detail link and the tournament title.
+	linkPattern = regexp.MustCompile(`href=\\?'(https://[^'\\]+)\\?'[^>]*>([^<]+)<`)
+
+	// labelPattern matches any ZK label value, used for the competition list.
+	labelPattern = regexp.MustCompile(`value:'([^']*)'`)
+
+	// totalPattern reports how many tournaments the widget found.
+	totalPattern = regexp.MustCompile(`_totalSize:(\d+)`)
+
+	// idPattern extracts the tournament id from a tennis.de detail URL.
+	idPattern = regexp.MustCompile(`detail/(\d+)`)
+)
+
+// Client talks to the BTV tournament widget.
+type Client struct {
+	BaseURL string
+	// HTTPClient defaults to the shared federation client.
+	HTTPClient *http.Client
+}
+
+// New returns a client for the given widget base URL.
+func New(baseURL string) *Client {
+	return &Client{BaseURL: baseURL}
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return httpclient.Federation()
+}
+
+// session holds what one ZK conversation needs.
+type session struct {
+	desktopID string
+	updateURL string
+	cookies   []*http.Cookie
+	// sequence backs the ZK-SID header. ZK expects a monotonically
+	// increasing sequence number per desktop; sending a constant value makes
+	// it treat later requests as duplicates and replay the first response,
+	// which silently returns page 0 forever.
+	sequence int
+}
+
+// bootstrap performs the initial GET and extracts the ZK session details.
+func (c *Client) bootstrap(ctx context.Context) (*session, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create bootstrap request: %w", err)
+	}
+	httpclient.ApplyDefaultHeaders(req)
+	// The widget is embedded on btv.de and expects that origin.
+	req.Header.Set("Referer", "https://www.btv.de/")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml")
+
+	res, err := c.httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("bootstrap request failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bootstrap returned status %d", res.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(res.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read bootstrap response: %w", err)
+	}
+
+	m := bootstrapPattern.FindSubmatch(body)
+	if m == nil {
+		return nil, fmt.Errorf("no ZK bootstrap found; the widget markup may have changed")
+	}
+
+	updateURI := unescapeZK(string(m[3]))
+	updateURL, err := resolveURL(c.BaseURL, updateURI)
+	if err != nil {
+		return nil, err
+	}
+
+	return &session{
+		desktopID: unescapeZK(string(m[2])),
+		updateURL: updateURL,
+		cookies:   res.Cookies(),
+	}, nil
+}
+
+// fetchGrid asks ZK to render the result grid.
+func (c *Client) fetchGrid(ctx context.Context, s *session) (string, error) {
+	form := url.Values{}
+	form.Set("dtid", s.desktopID)
+	form.Set("cmd_0", "onClientInfo")
+	form.Set("opt_0", "i")
+	// Client metrics the widget expects; the values only affect layout.
+	form.Set("data_0", `{"":[0,1500,1200,24,1500,1200,0,0,"1.0","landscape"]}`)
+
+	return c.postCommand(ctx, s, form)
+}
+
+// fetchPage requests one further page of the result grid.
+func (c *Client) fetchPage(ctx context.Context, s *session, pagingUUID string, page int) (string, error) {
+	form := url.Values{}
+	form.Set("dtid", s.desktopID)
+	form.Set("cmd_0", "onPaging")
+	form.Set("uuid_0", pagingUUID)
+	form.Set("data_0", fmt.Sprintf(`{"":%d}`, page))
+
+	return c.postCommand(ctx, s, form)
+}
+
+// postCommand sends one ZK command and returns the decoded response.
+func (c *Client) postCommand(ctx context.Context, s *session, form url.Values) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.updateURL,
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("failed to create update request: %w", err)
+	}
+	httpclient.ApplyDefaultHeaders(req)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
+	s.sequence++
+	req.Header.Set("ZK-SID", strconv.Itoa(s.sequence))
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	req.Header.Set("Referer", c.BaseURL)
+	for _, cookie := range s.cookies {
+		req.AddCookie(cookie)
+	}
+
+	res, err := c.httpClient().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("update request failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("update returned status %d", res.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(res.Body, maxResponseBytes))
+	if err != nil {
+		return "", fmt.Errorf("failed to read update response: %w", err)
+	}
+
+	return unescapeZK(string(body)), nil
+}
+
+// GetTournaments fetches the current tournament list.
+//
+// The widget applies its own default date window, so dateFrom/dateTo are
+// accepted for interface symmetry but cannot be pushed upstream; results are
+// filtered locally by the caller if needed.
+func (c *Client) GetTournaments(ctx context.Context, fed models.Federation) ([]models.Tournament, error) {
+	s, err := c.bootstrap(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	payload, err := c.fetchGrid(ctx, s)
+	if err != nil {
+		return nil, err
+	}
+
+	tournaments := ParseGrid(payload, fed)
+	seen := make(map[string]struct{}, len(tournaments))
+	for _, t := range tournaments {
+		seen[dedupKey(t)] = struct{}{}
+	}
+
+	// The grid renders 10 rows per page, so the remaining pages have to be
+	// requested explicitly or most of Bavaria's tournaments would be missing.
+	//
+	// ZK re-renders the paging widget with a fresh uuid in every response, so
+	// it must be re-read each time; reusing the first one silently returns
+	// page 0 again.
+	pagingUUID, pageCount := parsePaging(payload)
+	if pagingUUID != "" && pageCount > 1 {
+		if pageCount > maxPages {
+			logger.Warn("BTV reports %d pages, capping at %d", pageCount, maxPages)
+			pageCount = maxPages
+		}
+
+		for page := 1; page < pageCount; page++ {
+			pagePayload, pageErr := c.fetchPage(ctx, s, pagingUUID, page)
+			if pageErr != nil {
+				// Keep what was fetched so far rather than failing outright.
+				logger.Warn("BTV page %d failed: %v", page, pageErr)
+				break
+			}
+
+			newOnPage := 0
+			for _, t := range ParseGrid(pagePayload, fed) {
+				key := dedupKey(t)
+				if _, dup := seen[key]; dup {
+					continue
+				}
+				seen[key] = struct{}{}
+				tournaments = append(tournaments, t)
+				newOnPage++
+			}
+
+			// Defensive: a page that adds nothing means the widget stopped
+			// honouring the offset.
+			if newOnPage == 0 {
+				break
+			}
+
+			// Pick up the regenerated paging uuid for the next request.
+			if nextUUID, _ := parsePaging(pagePayload); nextUUID != "" {
+				pagingUUID = nextUUID
+			}
+		}
+	}
+
+	if total := totalPattern.FindStringSubmatch(payload); total != nil {
+		if n, convErr := strconv.Atoi(total[1]); convErr == nil && n != len(tournaments) {
+			logger.Warn("BTV reports %d tournaments, parsed %d", n, len(tournaments))
+		}
+	}
+
+	return tournaments, nil
+}
+
+// parsePaging returns the paging widget's uuid and page count.
+func parsePaging(payload string) (string, int) {
+	m := pagingPattern.FindStringSubmatch(payload)
+	if m == nil {
+		return "", 0
+	}
+	count, err := strconv.Atoi(m[2])
+	if err != nil {
+		return "", 0
+	}
+	return m[1], count
+}
+
+// dedupKey identifies a tournament across pages.
+func dedupKey(t models.Tournament) string {
+	if t.Id != "" {
+		return t.Id
+	}
+	return t.Title + "|" + t.Date
+}
+
+// ParseGrid extracts tournaments from a ZK grid payload.
+//
+// It is exported so tests can run against a recorded fixture without any
+// network access.
+func ParseGrid(payload string, fed models.Federation) []models.Tournament {
+	var tournaments []models.Tournament
+
+	// Rows are self-contained; splitting on the row marker keeps one
+	// malformed row from corrupting its neighbours.
+	chunks := rowPattern.Split(payload, -1)
+	for _, chunk := range chunks[1:] {
+		if t, ok := parseRow(chunk, fed); ok {
+			tournaments = append(tournaments, t)
+		}
+	}
+
+	return tournaments
+}
+
+func parseRow(chunk string, fed models.Federation) (models.Tournament, bool) {
+	dateMatch := datePattern.FindStringSubmatch(chunk)
+	if dateMatch == nil {
+		return models.Tournament{}, false
+	}
+
+	linkMatch := linkPattern.FindStringSubmatch(chunk)
+	if linkMatch == nil {
+		return models.Tournament{}, false
+	}
+
+	tournament := models.Tournament{
+		Date:     util.NormalizeWhitespace(dateMatch[1]),
+		Location: util.NormalizeWhitespace(dateMatch[2]),
+		URL:      linkMatch[1],
+		Title:    util.NormalizeWhitespace(linkMatch[2]),
+		Entries:  []models.CompetitionEntry{},
+	}
+
+	if id := idPattern.FindStringSubmatch(tournament.URL); id != nil {
+		tournament.Id = id[1]
+	}
+
+	if tournament.Title == "" {
+		return models.Tournament{}, false
+	}
+
+	// BTV publishes no organizer, so the venue city stands in for it. The map
+	// popup and the Google Maps link both use this field.
+	tournament.Organizer = tournament.Location
+
+	tournament.Entries = parseCompetitions(chunk, dateMatch[0])
+
+	return tournament, true
+}
+
+// parseCompetitions reads the abbreviated competition list, e.g.
+// "W30/E, M40/D". The abbreviations are expanded so they read like the other
+// federations' values.
+func parseCompetitions(chunk, dateLabel string) []models.CompetitionEntry {
+	var entries []models.CompetitionEntry
+
+	for _, m := range labelPattern.FindAllStringSubmatch(chunk, -1) {
+		value := strings.TrimSpace(m[1])
+		// Skip the date label and the registration deadline.
+		if m[0] == dateLabel || value == "" || !strings.Contains(value, "/") {
+			continue
+		}
+
+		for _, part := range strings.Split(value, ",") {
+			if comp := expandCompetition(strings.TrimSpace(part)); comp != "" {
+				entries = append(entries, models.CompetitionEntry{Competition: comp})
+			}
+		}
+		break // the competition list is a single label
+	}
+
+	return entries
+}
+
+// expandCompetition turns "W30/E" into "Damen 30 Einzel".
+//
+// The codes are: W = women, M = men, X = mixed; a two-digit age group where 00
+// means open; E = singles, D = doubles.
+func expandCompetition(code string) string {
+	parts := strings.Split(code, "/")
+	if len(parts) != 2 || len(parts[0]) < 2 {
+		return ""
+	}
+
+	var gender string
+	switch parts[0][0] {
+	case 'W':
+		gender = "Damen"
+	case 'M':
+		gender = "Herren"
+	case 'X':
+		gender = "Mixed"
+	default:
+		return ""
+	}
+
+	age := strings.TrimSpace(parts[0][1:])
+
+	var discipline string
+	switch strings.TrimSpace(parts[1]) {
+	case "E":
+		discipline = "Einzel"
+	case "D":
+		discipline = "Doppel"
+	default:
+		return ""
+	}
+
+	if age == "" || age == "00" {
+		return gender + " " + discipline
+	}
+	return gender + " " + age + " " + discipline
+}
+
+// unescapeZK decodes the \xNN escapes ZK uses for non-ASCII characters.
+func unescapeZK(s string) string {
+	return zkEscapePattern.ReplaceAllStringFunc(s, func(m string) string {
+		v, err := strconv.ParseUint(m[2:], 16, 8)
+		if err != nil {
+			return m
+		}
+		return string(rune(v))
+	})
+}
+
+// resolveURL turns the ZK update URI into an absolute URL.
+func resolveURL(base, ref string) (string, error) {
+	baseURL, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("invalid base URL %q: %w", base, err)
+	}
+	refURL, err := url.Parse(ref)
+	if err != nil {
+		return "", fmt.Errorf("invalid update URI %q: %w", ref, err)
+	}
+	return baseURL.ResolveReference(refURL).String(), nil
+}

--- a/backend/pkg/btv/btv_test.go
+++ b/backend/pkg/btv/btv_test.go
@@ -1,0 +1,395 @@
+package btv
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
+)
+
+var testFederation = models.Federation{
+	Id:             "BTV",
+	Name:           "Bayerischer Tennis-Verband",
+	State:          "Bayern",
+	ApiVersion:     "btv",
+	Geocoordinates: models.Geocoordinates{Lat: "48.13", Lon: "11.57"},
+}
+
+func loadFixture(t *testing.T) string {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join("testdata", "grid_response.txt"))
+	if err != nil {
+		t.Fatalf("failed to read fixture: %v", err)
+	}
+	return string(data)
+}
+
+// TestParseGridFixture runs against a recorded response from the live widget,
+// so a change in the upstream markup shows up as a test failure rather than as
+// silently missing tournaments.
+func TestParseGridFixture(t *testing.T) {
+	tournaments := ParseGrid(loadFixture(t), testFederation)
+
+	if len(tournaments) == 0 {
+		t.Fatal("no tournaments parsed from the fixture")
+	}
+
+	first := tournaments[0]
+
+	if first.Title != "Bad Füssing Masters by npsports.de" {
+		t.Errorf("Title = %q", first.Title)
+	}
+	if first.Date != "10.08. - 16.08.2026" {
+		t.Errorf("Date = %q", first.Date)
+	}
+	if first.Location != "Bad Füssing" {
+		t.Errorf("Location = %q, want the venue city", first.Location)
+	}
+	// BTV publishes no organizer; the city stands in so the map popup and the
+	// Google Maps link still work.
+	if first.Organizer != "Bad Füssing" {
+		t.Errorf("Organizer = %q, want the venue city as a stand-in", first.Organizer)
+	}
+	if first.Id != "759920" {
+		t.Errorf("Id = %q, want the id from the tennis.de detail link", first.Id)
+	}
+	if !strings.HasPrefix(first.URL, "https://www.tennis.de/") {
+		t.Errorf("URL = %q, want the tennis.de detail link", first.URL)
+	}
+
+	if len(first.Entries) == 0 {
+		t.Fatal("no competitions parsed")
+	}
+	// "W30/E" must be expanded rather than passed through raw.
+	if got := first.Entries[0].Competition; got != "Damen 30 Einzel" {
+		t.Errorf("first competition = %q, want %q", got, "Damen 30 Einzel")
+	}
+}
+
+func TestParseGridExtractsEveryRow(t *testing.T) {
+	tournaments := ParseGrid(loadFixture(t), testFederation)
+
+	// The fixture holds five rows; every one must yield a tournament.
+	if len(tournaments) != 5 {
+		t.Fatalf("parsed %d tournaments, want 5", len(tournaments))
+	}
+
+	seen := make(map[string]bool)
+	for _, tr := range tournaments {
+		if tr.Title == "" {
+			t.Error("tournament without a title")
+		}
+		if tr.Id == "" {
+			t.Errorf("tournament %q has no id", tr.Title)
+		}
+		if seen[tr.Id] {
+			t.Errorf("duplicate tournament id %q", tr.Id)
+		}
+		seen[tr.Id] = true
+	}
+}
+
+func TestParseGridHandlesMalformedInput(t *testing.T) {
+	for _, name := range []string{"empty", "not zk", "truncated row", "no rows"} {
+		t.Run(name, func(t *testing.T) {
+			inputs := map[string]string{
+				"empty":         "",
+				"not zk":        "%%% not a zk payload %%%",
+				"truncated row": `['zul.grid.Row','x',{},{},[ ['zul.wgt.Label','y',{value:'10.08.`,
+				"no rows":       `{"rs":[],"rid":1}`,
+			}
+
+			// Must not panic and must not invent tournaments.
+			got := ParseGrid(inputs[name], testFederation)
+			if len(got) != 0 {
+				t.Errorf("got %d tournaments, want 0", len(got))
+			}
+		})
+	}
+}
+
+func TestExpandCompetition(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"W30/E", "Damen 30 Einzel"},
+		{"M40/D", "Herren 40 Doppel"},
+		{"X00/D", "Mixed Doppel"},
+		{"W00/E", "Damen Einzel"},
+		{"M00/E", "Herren Einzel"},
+		{"M85/E", "Herren 85 Einzel"},
+		{"W12/E", "Damen 12 Einzel"},
+
+		// Unusable codes must be dropped rather than guessed at.
+		{"", ""},
+		{"XX", ""},
+		{"Q30/E", ""},
+		{"W30/X", ""},
+		{"W30", ""},
+		{"/E", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := expandCompetition(tt.in); got != tt.want {
+				t.Errorf("expandCompetition(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnescapeZK(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{`Bad F\xFCssing`, "Bad Füssing"},
+		{`Gr\xF6benzell`, "Gröbenzell"},
+		{`plain`, "plain"},
+		{`\xZZ`, `\xZZ`}, // invalid escape stays as-is
+		{``, ``},
+	}
+
+	for _, tt := range tests {
+		if got := unescapeZK(tt.in); got != tt.want {
+			t.Errorf("unescapeZK(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestResolveURL(t *testing.T) {
+	tests := []struct {
+		base, ref, want string
+	}{
+		{
+			"https://btv-prod.burdadigitalsystems.de/btvtrnsearch/",
+			"/btvtrnsearch/zkau;jsessionid=ABC",
+			"https://btv-prod.burdadigitalsystems.de/btvtrnsearch/zkau;jsessionid=ABC",
+		},
+		{
+			"https://example.test/widget/",
+			"zkau",
+			"https://example.test/widget/zkau",
+		},
+	}
+
+	for _, tt := range tests {
+		got, err := resolveURL(tt.base, tt.ref)
+		if err != nil {
+			t.Fatalf("resolveURL(%q, %q) error = %v", tt.base, tt.ref, err)
+		}
+		if got != tt.want {
+			t.Errorf("resolveURL(%q, %q) = %q, want %q", tt.base, tt.ref, got, tt.want)
+		}
+	}
+}
+
+// TestGetTournamentsAgainstMockWidget exercises the full two-step ZK
+// conversation without touching the network.
+func TestGetTournamentsAgainstMockWidget(t *testing.T) {
+	fixture := loadFixture(t)
+
+	var gotBootstrap, gotUpdate bool
+	var forms []string
+	var sentCookie string
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	mux.HandleFunc("/btvtrnsearch/zkau", func(w http.ResponseWriter, r *http.Request) {
+		gotUpdate = true
+		if c, err := r.Cookie("JSESSIONID"); err == nil {
+			sentCookie = c.Value
+		}
+		body := make([]byte, 4096)
+		n, _ := r.Body.Read(body)
+		forms = append(forms, string(body[:n]))
+
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(fixture))
+	})
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		gotBootstrap = true
+		http.SetCookie(w, &http.Cookie{Name: "JSESSIONID", Value: "TESTSESSION"})
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body><script>
+zk.themeName='iceblue';zkmx(
+[0,'zQbU_',{dt:'z_test123',cu:'\x2Fbtvtrnsearch',uu:'\x2Fbtvtrnsearch\x2Fzkau',rsu:'x'}]
+)</script></body></html>`))
+	})
+
+	client := New(srv.URL + "/")
+	tournaments, err := client.GetTournaments(context.Background(), testFederation)
+	if err != nil {
+		t.Fatalf("GetTournaments() error = %v", err)
+	}
+
+	if !gotBootstrap {
+		t.Error("bootstrap request was not made")
+	}
+	if !gotUpdate {
+		t.Error("update request was not made")
+	}
+	if sentCookie != "TESTSESSION" {
+		t.Errorf("session cookie = %q, want it forwarded to the update request", sentCookie)
+	}
+	if len(forms) == 0 {
+		t.Fatal("no update request was recorded")
+	}
+	if !strings.Contains(forms[0], "dtid=z_test123") {
+		t.Errorf("update form %q does not carry the desktop id", forms[0])
+	}
+	if !strings.Contains(forms[0], "cmd_0=onClientInfo") {
+		t.Errorf("first update form %q does not carry the grid command", forms[0])
+	}
+
+	// The fixture advertises 18 pages, so the client must page through them
+	// rather than stopping at the first 10 rows.
+	if len(forms) < 2 {
+		t.Fatalf("made %d update requests, want the client to request further pages", len(forms))
+	}
+	if !strings.Contains(forms[1], "cmd_0=onPaging") {
+		t.Errorf("second update form %q is not a paging request", forms[1])
+	}
+
+	// Every page returns the same fixture, so deduplication must collapse them.
+	if len(tournaments) != 5 {
+		t.Errorf("got %d tournaments, want 5 after deduplication", len(tournaments))
+	}
+}
+
+// TestPaginationStopsWhenPagesRepeat guards against an endless loop if the
+// widget ever stops honouring the page offset.
+func TestPaginationStopsWhenPagesRepeat(t *testing.T) {
+	fixture := loadFixture(t)
+
+	var updates int
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	mux.HandleFunc("/btvtrnsearch/zkau", func(w http.ResponseWriter, r *http.Request) {
+		updates++
+		_, _ = w.Write([]byte(fixture))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "JSESSIONID", Value: "S"})
+		_, _ = w.Write([]byte(`<script>zkmx([0,'u',{dt:'z_1',uu:'\x2Fbtvtrnsearch\x2Fzkau'}])</script>`))
+	})
+
+	client := New(srv.URL + "/")
+	if _, err := client.GetTournaments(context.Background(), testFederation); err != nil {
+		t.Fatalf("GetTournaments() error = %v", err)
+	}
+
+	// One grid request plus one paging request that adds nothing new.
+	if updates > 3 {
+		t.Errorf("made %d update requests; pagination should stop once a page adds nothing", updates)
+	}
+}
+
+func TestParsePaging(t *testing.T) {
+	payload := `['zul.mesh.Paging','abc123',{$onPaging:true,totalSize:180,pageSize:10,pageCount:18,detailed:true}`
+
+	uuid, count := parsePaging(payload)
+	if uuid != "abc123" {
+		t.Errorf("uuid = %q, want abc123", uuid)
+	}
+	if count != 18 {
+		t.Errorf("pageCount = %d, want 18", count)
+	}
+
+	if uuid, count := parsePaging("no paging widget here"); uuid != "" || count != 0 {
+		t.Errorf("parsePaging(no match) = %q, %d; want empty", uuid, count)
+	}
+}
+
+func TestGetTournamentsReportsUpstreamFailures(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			name: "bootstrap 500",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "boom", http.StatusInternalServerError)
+			},
+		},
+		{
+			name: "no zk bootstrap in markup",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("<html><body>maintenance</body></html>"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(tt.handler)
+			defer srv.Close()
+
+			client := New(srv.URL + "/")
+			if _, err := client.GetTournaments(context.Background(), testFederation); err == nil {
+				t.Error("GetTournaments() returned nil error for a broken upstream")
+			}
+		})
+	}
+}
+
+func TestGetTournamentsRespectsContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := New(srv.URL + "/")
+	if _, err := client.GetTournaments(ctx, testFederation); err == nil {
+		t.Error("GetTournaments() with a cancelled context returned nil error")
+	}
+}
+
+// TestZKSequenceIncrements is the regression test for a subtle protocol
+// requirement: ZK expects a monotonically increasing ZK-SID per desktop.
+// Sending a constant value makes the server treat later requests as duplicates
+// and replay the first response, so pagination silently returned page 0 forever
+// and Bavaria appeared to have only 10 tournaments instead of 180.
+func TestZKSequenceIncrements(t *testing.T) {
+	fixture := loadFixture(t)
+
+	var sids []string
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	mux.HandleFunc("/btvtrnsearch/zkau", func(w http.ResponseWriter, r *http.Request) {
+		sids = append(sids, r.Header.Get("ZK-SID"))
+		_, _ = w.Write([]byte(fixture))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "JSESSIONID", Value: "S"})
+		_, _ = w.Write([]byte(`<script>zkmx([0,'u',{dt:'z_1',uu:'\x2Fbtvtrnsearch\x2Fzkau'}])</script>`))
+	})
+
+	client := New(srv.URL + "/")
+	if _, err := client.GetTournaments(context.Background(), testFederation); err != nil {
+		t.Fatalf("GetTournaments() error = %v", err)
+	}
+
+	if len(sids) < 2 {
+		t.Fatalf("recorded %d requests, want at least 2", len(sids))
+	}
+
+	for i, sid := range sids {
+		want := strconv.Itoa(i + 1)
+		if sid != want {
+			t.Errorf("request %d sent ZK-SID %q, want %q", i, sid, want)
+		}
+	}
+}

--- a/backend/pkg/btv/testdata/grid_response.txt
+++ b/backend/pkg/btv/testdata/grid_response.txt
@@ -1,0 +1,66 @@
+// Fixture: recorded ZK response from the BTV tournament widget
+// (btv-prod.burdadigitalsystems.de/btvtrnsearch/), captured 2026-08-15.
+//
+// Trimmed to the result grid and the first few rows. It covers: a date range
+// with a venue city, the tennis.de detail link carrying the tournament id,
+// and the abbreviated competition list (W30/E, M40/D, X00/D style codes).
+{},[
+['zul.mesh.Paging','sD1Qk0',{$onPaging:true,totalSize:180,pageSize:10,pageCount:18,detailed:true,autohide:true},{},[]],
+['zul.grid.Columns','sD1Ql0',{},{},[
+['zul.grid.Column','sD1Qm0',{id:'colanz',$onSort:true,$$0onSort:true,label:'180 TURNIERE GEFUNDEN'},{},[]],
+['zul.grid.Column','sD1Qn0',{id:'colms',$onSort:true,$$0onSort:true,width:'130px',label:'MELDESCHLUSS',align:'right'},{},[]]]],
+['zul.grid.Rows','sD1Qv0',{_offset:0,visibleItemCount:180},{},[
+['zul.grid.Row','sD1Qx0',{style:'background-color: #fff',_loaded:true,_index:0},{},[
+['zul.box.Vlayout','sD1Qsd',{vflex:'min'},{},[
+['zul.wgt.Div','sD1Qtd',{hflex:'min',sclass:'box-right'},{},[
+['zul.wgt.Label','sD1Qud',{sclass:'infotext',style:'font-size: 12px; margin-left: 10px; padding-right: 40px',value:'10.08. - 16.08.2026 in Bad Füssing'},{},[]]]],
+['zul.wgt.Html','sD1Qvd',{content:'<a href=\'https://www.tennis.de/spielen/turniersuche.html#detail/759920\' target=\'_blank\'>Bad Füssing Masters by npsports.de   <\/a>'},{},[]],
+['zul.wgt.Label','sD1Qwd',{sclass:'infotext',value:'W30/E, W40/E, W50/E, W55/E, W60/E, W65/E, W70/E, W75/E, W80/E, W85/E, M30/E, M40/E, M50/E, M55/E, M60/E, M65/E, M70/E, M75/E, M80/E, M85/E'},{},[]]]],
+['zul.box.Vlayout','sD1Qxd',{vflex:'min'},{},[
+['zul.wgt.Label','sD1Qyd',{sclass:'infotext',value:'03.08.2026'},{},[]],
+['zul.box.Hlayout','sD1Qzd',{},{},[
+['zul.wgt.Image','sD1Q_e',{src:'img/dtb_icon_18.png'},{},[]],
+['zul.wgt.Image','sD1Q0e',{src:'img/lk_icon_18.png'},{},[]]]]]]]],
+['zul.grid.Row','sD1Q01',{style:'background-color: #fff',_loaded:true,_index:1},{},[
+['zul.box.Vlayout','sD1Q1e',{vflex:'min'},{},[
+['zul.wgt.Div','sD1Q2e',{hflex:'min',sclass:'box-right'},{},[
+['zul.wgt.Label','sD1Q3e',{sclass:'infotext',style:'font-size: 12px; margin-left: 10px; padding-right: 40px',value:'13.08. - 16.08.2026 in Dachau'},{},[]]]],
+['zul.wgt.Html','sD1Q4e',{content:'<a href=\'https://www.tennis.de/spielen/turniersuche.html#detail/812299\' target=\'_blank\'>12. Offene Dachauer Stadtmeisterschaften 2026<\/a>'},{},[]],
+['zul.wgt.Label','sD1Q5e',{sclass:'infotext',value:'W00/E, W00/E, W00/D, W30/E, W40/E, W50/E, M00/E, M00/E, M00/E, M00/D, M30/E, M40/E, M40/D, M50/E, M55/E, M60/E, M65/E, M70/E, X00/D'},{},[]]]],
+['zul.box.Vlayout','sD1Q6e',{vflex:'min'},{},[
+['zul.wgt.Label','sD1Q7e',{sclass:'infotext',value:'10.08.2026'},{},[]],
+['zul.box.Hlayout','sD1Q8e',{},{},[
+['zul.wgt.Image','sD1Q9e',{src:'img/lk_icon_18.png'},{},[]]]]]]]],
+['zul.grid.Row','sD1Q41',{style:'background-color: #fff',_loaded:true,_index:2},{},[
+['zul.box.Vlayout','sD1Qae',{vflex:'min'},{},[
+['zul.wgt.Div','sD1Qbe',{hflex:'min',sclass:'box-right'},{},[
+['zul.wgt.Label','sD1Qce',{sclass:'infotext',style:'font-size: 12px; margin-left: 10px; padding-right: 40px',value:'13.08. - 16.08.2026 in Augsburg'},{},[]]]],
+['zul.wgt.Html','sD1Qde',{content:'<a href=\'https://www.tennis.de/spielen/turniersuche.html#detail/759021\' target=\'_blank\'>6. TC Rot-Weiß Sommer-Cup 2026<\/a>'},{},[]],
+['zul.wgt.Label','sD1Qee',{sclass:'infotext',value:'W00/E, M00/E'},{},[]]]],
+['zul.box.Vlayout','sD1Qfe',{vflex:'min'},{},[
+['zul.wgt.Label','sD1Qge',{sclass:'infotext',value:'10.08.2026'},{},[]],
+['zul.box.Hlayout','sD1Qhe',{},{},[
+['zul.wgt.Image','sD1Qie',{src:'img/dtb_icon_18.png'},{},[]],
+['zul.wgt.Image','sD1Qje',{src:'img/lk_icon_18.png'},{},[]]]]]]]],
+['zul.grid.Row','sD1Q81',{style:'background-color: #fff',_loaded:true,_index:3},{},[
+['zul.box.Vlayout','sD1Qke',{vflex:'min'},{},[
+['zul.wgt.Div','sD1Qle',{hflex:'min',sclass:'box-right'},{},[
+['zul.wgt.Label','sD1Qme',{sclass:'infotext',style:'font-size: 12px; margin-left: 10px; padding-right: 40px',value:'14.08. - 16.08.2026 in Burghausen'},{},[]]]],
+['zul.wgt.Html','sD1Qne',{content:'<a href=\'https://www.tennis.de/spielen/turniersuche.html#detail/754339\' target=\'_blank\'>Junior Open Burghausen <\/a>'},{},[]],
+['zul.wgt.Label','sD1Qoe',{sclass:'infotext',value:'W10/E, W12/E, W14/E, W16/E, M10/E, M12/E, M14/E, M14/E, M16/E, M16/E'},{},[]]]],
+['zul.box.Vlayout','sD1Qpe',{vflex:'min'},{},[
+['zul.wgt.Label','sD1Qqe',{sclass:'infotext',value:'11.08.2026'},{},[]],
+['zul.box.Hlayout','sD1Qre',{},{},[
+['zul.wgt.Image','sD1Qse',{src:'img/dtb_icon_18.png'},{},[]],
+['zul.wgt.Image','sD1Qte',{src:'img/lk_icon_18.png'},{},[]]]]]]]],
+['zul.grid.Row','sD1Qc1',{style:'background-color: #fff',_loaded:true,_index:4},{},[
+['zul.box.Vlayout','sD1Que',{vflex:'min'},{},[
+['zul.wgt.Div','sD1Qve',{hflex:'min',sclass:'box-right'},{},[
+['zul.wgt.Label','sD1Qwe',{sclass:'infotext',style:'font-size: 12px; margin-left: 10px; padding-right: 40px',value:'14.08. - 16.08.2026 in Burghausen'},{},[]]]],
+['zul.wgt.Html','sD1Qxe',{content:'<a href=\'https://www.tennis.de/spielen/turniersuche.html#detail/754343\' target=\'_blank\'>Nachwuchs Open Burghausen   <\/a>'},{},[]],
+['zul.wgt.Label','sD1Qye',{sclass:'infotext',value:'W21/E, M21/E'},{},[]]]],
+['zul.box.Vlayout','sD1Qze',{vflex:'min'},{},[
+['zul.wgt.Label','sD1Q_f',{sclass:'infotext',value:'11.08.2026'},{},[]],
+['zul.box.Hlayout','sD1Q0f',{},{},[
+['zul.wgt.Image','sD1Q1f',{src:'img/dtb_icon_18.png'},{},[]],
+['zul.wgt.Image','sD1Q2f',{src:'img/lk_icon_18.png'},{},[]]]]]]]],

--- a/backend/pkg/federation/federations.go
+++ b/backend/pkg/federation/federations.go
@@ -145,6 +145,28 @@ func GetFederations() []models.Federation {
 			ApiVersion:        "old",
 			TrustedProperties: "",
 		},
+		{
+			// The federation is commonly abbreviated TSH, but nuLiga serves it
+			// under the host and federation code SLH.
+			Id:                "SLH",
+			Url:               "https://slh.liga.nu/cgi-bin/WebObjects/nuLigaTENDE.woa/wa/tournamentCalendar",
+			Name:              "Tennisverband Schleswig-Holstein",
+			Geocoordinates:    models.Geocoordinates{Lat: "54.3232927", Lon: "10.1227652"},
+			State:             "Schleswig-Holstein",
+			ApiVersion:        "old",
+			TrustedProperties: "",
+		},
+		{
+			// Bavaria left nuLiga: btv.de embeds its own ZK widget, so this
+			// federation uses a dedicated client rather than a shared parser.
+			Id:                "BTV",
+			Url:               "https://btv-prod.burdadigitalsystems.de/btvtrnsearch/",
+			Name:              "Bayerischer Tennis-Verband",
+			Geocoordinates:    models.Geocoordinates{Lat: "48.1371079", Lon: "11.5753822"},
+			State:             "Bayern",
+			ApiVersion:        "btv",
+			TrustedProperties: "",
+		},
 	}
 	return federations
 }

--- a/backend/pkg/federation/federations_test.go
+++ b/backend/pkg/federation/federations_test.go
@@ -53,6 +53,11 @@ func TestFederationsAreWellFormed(t *testing.T) {
 				if fed.TrustedProperties == "" {
 					t.Error("new API federations require TrustedProperties")
 				}
+			case "btv":
+				// Bavaria runs its own ZK widget instead of nuLiga.
+				if fed.TrustedProperties != "" {
+					t.Error("the BTV widget does not use TrustedProperties")
+				}
 			default:
 				t.Errorf("unknown ApiVersion %q", fed.ApiVersion)
 			}
@@ -115,6 +120,9 @@ func TestExpectedFederationsArePresent(t *testing.T) {
 		"BAD", "HTV", "RLP", "STV", "TMV", "TSA", "TTV", "TVN", "WTB",
 		// Added for issue #49
 		"TVBB", "HAM", "TVM", "TNB", "STB", "WTV",
+		// Completing #49: Schleswig-Holstein (nuLiga code SLH) and Bavaria
+		// (own widget).
+		"SLH", "BTV",
 	}
 
 	got := make(map[string]bool)

--- a/backend/pkg/tournament/tournament.go
+++ b/backend/pkg/tournament/tournament.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/btv"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/federation"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/httpclient"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
@@ -381,9 +382,33 @@ func fetchFederation(ctx context.Context, fed models.Federation, dateFrom, dateT
 		return getTournamentsFromFederationOldApi(ctx, fed, dateFrom, dateTo, compType)
 	case "new":
 		return getTournamentsFromFederationNewApi(ctx, fed, dateFrom, dateTo, compType)
+	case "btv":
+		// Bavaria runs its own ZK widget rather than nuLiga.
+		return getTournamentsFromBTV(ctx, fed)
 	default:
 		return nil, fmt.Errorf("unknown API version %q for federation %s", fed.ApiVersion, fed.Id)
 	}
+}
+
+// getTournamentsFromBTV fetches and geocodes the Bavarian tournament list.
+func getTournamentsFromBTV(ctx context.Context, fed models.Federation) ([]models.Tournament, error) {
+	logger.Info("Get Tournaments in: %s (BTV widget)", fed.Id)
+
+	tournaments, err := btv.New(fed.Url).GetTournaments(ctx, fed)
+	if err != nil {
+		return nil, err
+	}
+
+	// The widget supplies a venue city but no coordinates.
+	for i := range tournaments {
+		geoCoords := resolveGeocoordinates(fed, tournaments[i], defaultGeocoder, tournaments[i].Location)
+		tournaments[i].Lat = geoCoords.Lat
+		tournaments[i].Lon = geoCoords.Lon
+	}
+
+	logger.Info("Federation %s: Found %d tournaments total", fed.Id, len(tournaments))
+
+	return tournaments, nil
 }
 
 // ageCategoryForCompType maps a competition type to the new API's age category.

--- a/index.html
+++ b/index.html
@@ -238,6 +238,9 @@
                         <label class="checkboxLabel" title="Badischer Tennisverband">
                             <input type="checkbox" name="federations" value="BAD" checked> BAD
                         </label>
+                        <label class="checkboxLabel" title="Bayerischer Tennis-Verband">
+                            <input type="checkbox" name="federations" value="BTV"> BTV
+                        </label>
                         <label class="checkboxLabel" title="Hamburger Tennisverband">
                             <input type="checkbox" name="federations" value="HAM"> HAM
                         </label>
@@ -246,6 +249,9 @@
                         </label>
                         <label class="checkboxLabel" title="Rheinland-Pfälzischer Tennisverband">
                             <input type="checkbox" name="federations" value="RLP"> RLP
+                        </label>
+                        <label class="checkboxLabel" title="Tennisverband Schleswig-Holstein">
+                            <input type="checkbox" name="federations" value="SLH"> SLH
                         </label>
                         <label class="checkboxLabel" title="Saarländischer Tennisbund">
                             <input type="checkbox" name="federations" value="STB"> STB


### PR DESCRIPTION
Adds the last two federations from the roadmap. **All 17 German regional federations are now supported.**

Thanks for the links — both turned out differently than I had assumed.

## Schleswig-Holstein: I had guessed the wrong host

My earlier probe failed because I derived the hostname from the abbreviation. The federation is commonly called **TSH**, but its own site links to `slh.liga.nu` with `federation=SLH`.

It works with the existing nuLiga parser unchanged, so this is **configuration only** — 53 tournaments in a 45-day window.

## Bavaria: own widget, no login

`btv.de` embeds a **ZK (zkoss) widget** hosted at `btv-prod.burdadigitalsystems.de`. Unlike the tennis.de detail views from #55, this one needs **no authentication**.

`pkg/btv` drives it directly:

1. `GET` the widget page → `JSESSIONID` + ZK desktop id
2. `POST onClientInfo` → renders the result grid
3. `POST onPaging` per further page (10 rows at a time)

### Two protocol details that cost real debugging time

**`ZK-SID` must increment per request.** This one was subtle: with a constant value the server treats later requests as duplicates and **replays the first response**. Pagination appeared to work — every page returned 10 rows — but they were always the *same* 10. Bavaria looked like it had 10 tournaments instead of 180. I only found it by diffing my request headers against the browser's:

```
mine:    ZK-SID: 1        → page 1 returns 10 ids, 0 new
browser: ZK-SID: 9784     → page 1 returns 10 ids, 10 new
```

**The paging widget's uuid is regenerated in every response** and has to be re-read before the next request.

Both are now regression-tested.

### Defensive parsing

The payload is a widget tree, not an API response, so a row that cannot be read is skipped rather than failing the whole federation. Competition codes (`W30/E`, `M40/D`, `X00/D`) are expanded to the wording the other federations use. BTV publishes no organizer, so the venue city stands in — that keeps the map popup and the Google Maps link working.

Tests run against a **recorded fixture from the live widget**, plus a mock server covering the full two-step conversation, upstream failures, context cancellation and the pagination guard.

## Live verification, all 17 federations

```
BAD 141  HTV 156  RLP 100  STV  18  TMV  15  TSA   4
TTV  11  TVN  61  WTB  92  TVBB 46  HAM  50  TVM  63
TNB 153  STB  23  WTV 130  SLH  53  BTV 180

17 federations, 0 errors, 0 empty
```

## Verification

* `go test -race ./...` — 12 packages, 0 failures
* `gofmt`, `go vet`, `go mod tidy` — clean
* Frontend syntax check passes; 17 federation checkboxes render

Closes #49
