### PR TITLE
feat: design refresh, select-all federations and custom map markers

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -887,3 +887,488 @@ body.list-mode .viewToggle {
         font-size: 2.8vw;
     }
 }
+
+/* ============================================================
+   Design system
+   ============================================================
+
+   The interface previously relied on browser defaults: labels were
+   larger than the inputs they described, blue and green were both used
+   as accents without a rule, and spacing was set per element rather
+   than from a scale.
+
+   Everything below defines one system. It deliberately changes only
+   appearance: no control moves, nothing is hidden behind an extra
+   click, and every interaction stays where it was.
+   ============================================================ */
+
+:root {
+    /* One accent for primary actions and active states. */
+    --accent: #2f6f4e;
+    --accent-hover: #255a3f;
+    --accent-soft: #eaf2ed;
+
+    --ink: #1f2421;
+    --ink-muted: #55605a;   /* meets WCAG AA on white */
+    --line: #e3e6e4;
+    --surface: #ffffff;
+    --canvas: #f4f2ef;
+
+    --radius: 14px;
+    --radius-sm: 9px;
+
+    /* Layered shadows read as lifted paper rather than a hard box. */
+    --shadow-sm: 0 1px 2px rgba(31, 36, 33, .06), 0 1px 3px rgba(31, 36, 33, .08);
+    --shadow-md: 0 2px 6px rgba(31, 36, 33, .07), 0 8px 24px rgba(31, 36, 33, .10);
+
+    /* 4px spacing scale. */
+    --sp-1: 4px;
+    --sp-2: 8px;
+    --sp-3: 12px;
+    --sp-4: 16px;
+    --sp-5: 24px;
+}
+
+html,
+body {
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+    color: var(--ink);
+    -webkit-font-smoothing: antialiased;
+}
+
+/* ---------- Panels ---------- */
+
+.sideBarElement {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-md);
+    padding: var(--sp-4);
+}
+
+.title {
+    font-size: 17px;
+    font-weight: 650;
+    letter-spacing: -0.01em;
+    padding: var(--sp-3) var(--sp-4);
+}
+
+/* ---------- Form controls ----------
+   Labels become quiet metadata; the inputs carry the visual weight. */
+
+.filterContainer {
+    padding: var(--sp-2) var(--sp-4);
+}
+
+.filterContainer > label {
+    display: block;
+    float: none;
+    width: auto;
+    margin-bottom: var(--sp-1);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: .02em;
+    text-transform: uppercase;
+    color: var(--ink-muted);
+}
+
+.filterElement {
+    float: none;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 9px 11px;
+    font-family: inherit;
+    font-size: 14px;
+    color: var(--ink);
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-sm);
+    transition: border-color .15s ease, box-shadow .15s ease;
+}
+
+.filterElement:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.filterHint {
+    margin-top: var(--sp-1);
+    font-size: 12px;
+    color: var(--ink-muted);
+}
+
+/* ---------- Buttons ----------
+   One shape language: same radius and weight, filled for primary,
+   outlined for secondary. */
+
+.submitBtn {
+    width: 100%;
+    padding: 11px 16px;
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: .01em;
+    text-transform: none;
+    color: #fff;
+    background: var(--accent);
+    opacity: 1;
+    border: none;
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-sm);
+    cursor: pointer;
+    transition: background .15s ease, transform .06s ease;
+}
+
+.submitBtn:hover {
+    background: var(--accent-hover);
+}
+
+.submitBtn:active {
+    transform: translateY(1px);
+}
+
+.filterToggleBtn {
+    padding: 6px 10px;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--ink-muted);
+    background: transparent;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    cursor: pointer;
+}
+
+.filterToggleBtn:hover {
+    color: var(--ink);
+    border-color: var(--ink-muted);
+    background: transparent;
+}
+
+/* ---------- Federation chips ----------
+   Replaces the spreadsheet-like checkbox grid. The native checkbox stays
+   in the DOM (hidden but focusable), so keyboard and screen reader
+   behaviour is unchanged. */
+
+.federationHeader {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--sp-2);
+    margin-bottom: var(--sp-2);
+}
+
+.federationActions {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-1);
+}
+
+.linkBtn {
+    padding: 6px 8px;
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--accent);
+    background: none;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.linkBtn:hover {
+    background: var(--accent-soft);
+}
+
+.linkBtn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+}
+
+.federationActions .separator {
+    color: var(--line);
+    user-select: none;
+}
+
+.federationCheckboxes {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.checkboxLabel {
+    display: inline-flex;
+    align-items: center;
+    margin: 0;
+    padding: 5px 10px;
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--ink-muted);
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background .15s ease, border-color .15s ease, color .15s ease;
+}
+
+.checkboxLabel:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.checkboxLabel input[type="checkbox"] {
+    position: absolute;
+    opacity: 0;
+    width: 1px;
+    height: 1px;
+    margin: 0;
+}
+
+.checkboxLabel:has(input:checked) {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #fff;
+}
+
+.checkboxLabel:has(input:focus-visible) {
+    box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.checkboxLabel:has(input:disabled) {
+    opacity: .4;
+    cursor: not-allowed;
+}
+
+/* ---------- View toggle ---------- */
+
+.viewToggle {
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    box-shadow: var(--shadow-md);
+    overflow: hidden;
+}
+
+.viewToggleBtn {
+    padding: 8px 16px;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--ink-muted);
+    background: var(--surface);
+    border: none;
+}
+
+.viewToggleBtn:not(:last-child) {
+    border-right: 1px solid var(--line);
+}
+
+.viewToggleBtn.active {
+    background: var(--accent);
+    color: #fff;
+}
+
+/* ---------- List ---------- */
+
+.list-view {
+    background: var(--canvas);
+}
+
+.list-controls {
+    font-size: 13px;
+    color: var(--ink-muted);
+}
+
+.list-controls select {
+    padding: 7px 10px;
+    font-family: inherit;
+    font-size: 13px;
+    color: var(--ink);
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-sm);
+}
+
+.tournament-item {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-sm);
+    padding: var(--sp-4) var(--sp-5);
+    margin-bottom: var(--sp-3);
+    transition: box-shadow .18s ease, transform .18s ease;
+}
+
+.tournament-item:hover {
+    box-shadow: var(--shadow-md);
+    transform: translateY(-1px);
+}
+
+.tournament-title {
+    font-size: 17px;
+    font-weight: 650;
+    letter-spacing: -0.01em;
+    margin-bottom: var(--sp-3);
+}
+
+.tournament-meta {
+    gap: var(--sp-1) var(--sp-4);
+    font-size: 13.5px;
+}
+
+.tournament-meta dt {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: .03em;
+    text-transform: uppercase;
+    color: var(--ink-muted);
+    padding-top: 2px;
+}
+
+.tournament-meta dd {
+    color: var(--ink);
+}
+
+/* A raw blue underlined link was the strongest "unstyled page" signal. */
+.tournament-meta a {
+    color: var(--accent);
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+}
+
+.tournament-meta a:hover {
+    border-bottom-color: var(--accent);
+}
+
+.tournament-competitions {
+    background: var(--accent-soft);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-3);
+    font-size: 13px;
+}
+
+/* Tabular figures keep the LK column aligned down the list. */
+.competition-lk {
+    font-variant-numeric: tabular-nums;
+    color: var(--ink-muted);
+}
+
+.tournament-actions {
+    gap: var(--sp-2);
+}
+
+.signup-button {
+    padding: 8px 14px;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    background: var(--accent);
+    opacity: 1;
+    border-radius: var(--radius-sm);
+}
+
+.signup-button:hover {
+    background: var(--accent-hover);
+}
+
+.map-button {
+    padding: 8px 14px;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--ink-muted);
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-sm);
+}
+
+.map-button:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+    background: var(--accent-soft);
+}
+
+/* ---------- Notice ---------- */
+
+.data-notice {
+    padding: 10px var(--sp-4);
+    font-size: 13px;
+    border-bottom: none;
+}
+
+.data-notice.warning {
+    background: #fdf6e7;
+    color: #6b4f14;
+}
+
+.data-notice.error {
+    background: #fcefee;
+    color: #7d2b22;
+}
+
+/* ---------- Map popup ---------- */
+
+.leaflet-popup-content-wrapper {
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-md);
+}
+
+.popupTitle {
+    font-size: 15px;
+    font-weight: 650;
+    letter-spacing: -0.01em;
+}
+
+@media (max-width: 768px) {
+    .title { font-size: 4.2vw; }
+    .filterContainer > label { font-size: 3vw; }
+    .filterElement { font-size: 3.8vw; padding: 2.5vw 3vw; }
+    .checkboxLabel { font-size: 3.2vw; padding: 1.6vw 3vw; }
+    .submitBtn { font-size: 3.9vw; padding: 3vw; }
+    /* Comfortable touch targets; text alone would be far too small to hit. */
+    .linkBtn {
+        font-size: 3.4vw;
+        padding: 10px 12px;
+    }
+
+    .checkboxLabel {
+        min-height: 34px;
+    }
+    .tournament-title { font-size: 4.2vw; }
+}
+
+/* The view toggle sits bottom-right on phones and would cover the Leaflet /
+   OpenStreetMap attribution, which has to stay visible for licence reasons.
+   Lifting the attribution keeps both readable. */
+@media (max-width: 768px) {
+    .leaflet-bottom.leaflet-right .leaflet-control-attribution {
+        margin-bottom: 62px;
+    }
+}
+
+/* ---------- Map markers ----------
+   The marker cluster plugin ships its own coloured circles; they are
+   replaced by the app's own icons, so the defaults have to be cleared. */
+
+.ttf-cluster {
+    background: none;
+    border: none;
+}
+
+.ttf-cluster svg {
+    display: block;
+}
+
+/* Subtle lift on hover so a pin feels clickable. */
+.leaflet-marker-icon {
+    transition: transform .12s ease;
+}
+
+.leaflet-marker-icon:hover {
+    transform: scale(1.08);
+}
+
+/* The cluster is anchored at its centre, so it must scale from there. */
+.ttf-cluster:hover {
+    transform: scale(1.06);
+}

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.5.3/MarkerCluster.Default.min.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Mono:wght@400;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     
     <!-- Make sure you put this AFTER Leaflet's CSS -->
     <script src="https://unpkg.com/leaflet@1.8.0/dist/leaflet.js" integrity="sha512-BB3hKbKWOc9Ez/TAwyWxNXeoV9c1v6FIeYiBieIWkpLjauysF18NzgR1MBNBXf8/KABdlkX68nAhlwcDFLGPCQ==" crossorigin=""></script>
@@ -233,8 +233,15 @@
                     </small>
                 </div>
                 <div class="filterContainer">
-                    <label>Tennisverbände:</label>
-                    <div class="federationCheckboxes">
+                    <div class="federationHeader">
+                        <label id="federationLabel">Tennisverbände:</label>
+                        <div class="federationActions">
+                            <button type="button" class="linkBtn" onclick="selectAllFederations()">Alle</button>
+                            <span class="separator" aria-hidden="true">|</span>
+                            <button type="button" class="linkBtn" onclick="deselectAllFederations()">Keine</button>
+                        </div>
+                    </div>
+                    <div class="federationCheckboxes" role="group" aria-labelledby="federationLabel">
                         <label class="checkboxLabel" title="Badischer Tennisverband">
                             <input type="checkbox" name="federations" value="BAD" checked> BAD
                         </label>
@@ -286,11 +293,8 @@
                         <label class="checkboxLabel" title="Westfälischer Tennis-Verband">
                             <input type="checkbox" name="federations" value="WTV"> WTV
                         </label>
-                        <!-- <div class="federationControls">
-                            <button type="button" onclick="selectAllFederations()">Alle</button>
-                            <button type="button" onclick="deselectAllFederations()">Keine</button>
-                        </div> -->
                     </div>
+                    <small id="federationCount" class="filterHint" aria-live="polite"></small>
                 </div>
                 <div class="filterContainer submitContainer">
                     <input class="submitBtn" type="submit" value="Suchen">

--- a/script/main.js
+++ b/script/main.js
@@ -156,7 +156,7 @@ function getTournamentsByDate(dateFrom, dateTo, compType, federations, playerLK)
                     }
                 }
 
-                const marker = L.marker([tournament["lat"], tournament["lon"]])
+                const marker = L.marker([tournament["lat"], tournament["lon"]], { icon: tournamentIcon() })
                 .bindPopup(`
                 <span class="popupTitle">${tournament["title"]}</span><br><br>
                 <div class="popup-info-text">
@@ -331,6 +331,25 @@ function updateFederationSelectionState() {
             checkbox.disabled = false;
         }
     });
+
+    updateFederationCount(checkedBoxes.length, checkboxes.length);
+}
+
+// updateFederationCount reports the selection, so "Keine" cannot leave the
+// user wondering why a search returns nothing.
+function updateFederationCount(selected, total) {
+    const el = document.getElementById('federationCount');
+    if (!el) {
+        return;
+    }
+
+    if (selected === 0) {
+        el.textContent = 'Kein Verband ausgewählt — bitte mindestens einen wählen.';
+    } else if (selected === total) {
+        el.textContent = `Alle ${total} Verbände ausgewählt.`;
+    } else {
+        el.textContent = `${selected} von ${total} Verbänden ausgewählt.`;
+    }
 }
 
 // renderDataNotice surfaces stale or failed federations.
@@ -387,7 +406,11 @@ function toggleFilters() {
 }
 
 function createMarkerClusterGroup() {
-    const group = L.markerClusterGroup();
+    const group = L.markerClusterGroup({
+        iconCreateFunction: cluster => clusterIcon(cluster.getChildCount()),
+        showCoverageOnHover: false,
+        maxClusterRadius: 55,
+    });
     attachFilterAutoCloseToMarkers(group);
     return group;
 }
@@ -402,6 +425,87 @@ function attachFilterAutoCloseToMarkers(group) {
         group.on(eventName, closeFiltersForMapInteraction);
     });
 }
+// ===== Map markers =====
+//
+// The default Leaflet pin is a generic blue teardrop that reads as "some
+// library" rather than as this app. These markers use the app's accent colour
+// and carry a tennis ball inside the pin, so they tie back to the product and
+// stay legible against both street and satellite tiles.
+//
+// They are inline SVG (via a data URI) rather than image files: that keeps
+// them crisp on any display density, adds no extra request, and lets the
+// colour follow the design tokens.
+
+const MARKER_ACCENT = '#2f6f4e';
+const MARKER_ACCENT_DARK = '#255a3f';
+
+// tennisBallPin returns an SVG pin with a tennis ball at its centre.
+// The white ring around the pin lifts it off busy map tiles.
+function tennisBallPin({ size = 40, accent = MARKER_ACCENT } = {}) {
+    const height = Math.round(size * 1.25);
+    return `
+<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${height}" viewBox="0 0 32 40">
+  <defs>
+    <filter id="mshadow" x="-50%" y="-30%" width="200%" height="180%">
+      <feDropShadow dx="0" dy="1.5" stdDeviation="1.4" flood-color="#1f2421" flood-opacity="0.35"/>
+    </filter>
+  </defs>
+  <path d="M16 1.5c-6.9 0-12.5 5.6-12.5 12.5 0 8.6 10.6 22 12.1 23.9.2.3.6.3.8 0C17.9 36 28.5 22.6 28.5 14 28.5 7.1 22.9 1.5 16 1.5z"
+        fill="${accent}" stroke="#ffffff" stroke-width="2.2" filter="url(#mshadow)"/>
+  <circle cx="16" cy="13.7" r="6.1" fill="#e8f24a"/>
+  <path d="M10.6 10.8c3.1 1 5.1 3.3 5.6 6.6M21.4 10.8c-3.1 1-5.1 3.3-5.6 6.6"
+        fill="none" stroke="#ffffff" stroke-width="1.25" stroke-linecap="round" opacity="0.95"/>
+</svg>`.trim();
+}
+
+function svgIcon(svg, size, height, anchorY) {
+    return L.icon({
+        iconUrl: 'data:image/svg+xml;charset=UTF-8,' + encodeURIComponent(svg),
+        iconSize: [size, height],
+        iconAnchor: [size / 2, anchorY],
+        popupAnchor: [0, -anchorY + 4],
+    });
+}
+
+function tournamentIcon() {
+    const size = 34;
+    const height = Math.round(size * 1.25);
+    return svgIcon(tennisBallPin({ size }), size, height, height - 2);
+}
+
+// clusterIcon draws the group count inside a tennis ball, so a cluster reads
+// as "several tournaments here" rather than as an unrelated coloured blob.
+function clusterIcon(count) {
+    // Three sizes keep dense areas from being dominated by huge circles.
+    const size = count < 10 ? 38 : count < 100 ? 46 : 54;
+    const fontSize = count < 10 ? 14 : count < 100 ? 15 : 15;
+    const label = count > 999 ? '999+' : String(count);
+
+    const svg = `
+<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 56 56">
+  <defs>
+    <filter id="cshadow" x="-30%" y="-30%" width="160%" height="160%">
+      <feDropShadow dx="0" dy="1.5" stdDeviation="1.6" flood-color="#1f2421" flood-opacity="0.3"/>
+    </filter>
+  </defs>
+  <circle cx="28" cy="28" r="24" fill="${MARKER_ACCENT}" stroke="#ffffff" stroke-width="3" filter="url(#cshadow)"/>
+  <!-- A single seam arc hints at a tennis ball without competing with the
+       count, which is the piece of information that matters. -->
+  <path d="M6.5 20C16 24 21 31 21.5 41" fill="none" stroke="#e8f24a"
+        stroke-width="2.2" stroke-linecap="round" opacity="0.55"/>
+  <text x="28" y="28" text-anchor="middle" dominant-baseline="central"
+        font-family="Inter, -apple-system, Segoe UI, Roboto, sans-serif"
+        font-size="${fontSize * 56 / size}" font-weight="700" fill="#ffffff">${label}</text>
+</svg>`.trim();
+
+    return L.divIcon({
+        html: svg,
+        className: 'ttf-cluster',
+        iconSize: [size, size],
+        iconAnchor: [size / 2, size / 2],
+    });
+}
+
 // ===== List view =====
 //
 // The map alone makes it hard to compare dates and is awkward to use with a

--- a/script/main.test.js
+++ b/script/main.test.js
@@ -14,11 +14,18 @@ const vm = require('vm');
 // pure functions under test, and stop before the Leaflet setup runs.
 const source = fs.readFileSync(path.join(__dirname, 'main.js'), 'utf8');
 // Everything from the list view onwards is pure logic, safe to eval.
-const listSection = source.slice(source.indexOf('// ===== List view ====='));
+const listSection = source.slice(source.indexOf('// ===== Map markers ====='));
+
+// Minimal Leaflet stub: the marker helpers only build icon descriptors.
+const L = {
+    icon: opts => ({ options: opts }),
+    divIcon: opts => ({ options: opts }),
+};
 
 const sandbox = {
     console,
     Date,
+    L,
     document: { getElementById: () => null, querySelectorAll: () => [] },
     window: {},
     urlGoogleQuery: 'https://maps.google.com/maps?q=',
@@ -31,7 +38,8 @@ const sandbox = {
 vm.createContext(sandbox);
 vm.runInContext(listSection, sandbox);
 
-const { parseTournamentDate, compareTournaments, escapeHtml, isValidPlayerLK } = sandbox;
+const { parseTournamentDate, compareTournaments, escapeHtml, isValidPlayerLK,
+        tennisBallPin, clusterIcon } = sandbox;
 
 let failures = 0;
 function test(name, fn) {
@@ -174,6 +182,58 @@ test('rejects empty and non-numeric input', () => {
     for (const v of ['', '   ', null, undefined, 'abc', 'LK']) {
         assert.strictEqual(isValidPlayerLK(v), false, `should reject ${JSON.stringify(v)}`);
     }
+});
+
+console.log('map markers');
+
+test('pin svg is well formed and uses the accent colour', () => {
+    const svg = tennisBallPin();
+    assert.ok(svg.startsWith('<svg'), 'should be an svg element');
+    assert.ok(svg.trim().endsWith('</svg>'), 'should be closed');
+    assert.ok(svg.includes('#2f6f4e'), 'should use the accent colour');
+    // The white outline is what lifts the pin off busy map tiles.
+    assert.ok(svg.includes('stroke="#ffffff"'), 'should have a white outline');
+});
+
+test('pin scales without breaking the viewBox', () => {
+    for (const size of [24, 34, 48]) {
+        const svg = tennisBallPin({ size });
+        assert.ok(svg.includes(`width="${size}"`), `size ${size} should be applied`);
+        // A fixed viewBox is what keeps the artwork proportional at any size.
+        assert.ok(svg.includes('viewBox="0 0 32 40"'), 'viewBox must stay constant');
+    }
+});
+
+test('cluster label is escaped-safe and capped', () => {
+    for (const [count, expected] of [[3, '>3<'], [42, '>42<'], [999, '>999<'], [1500, '>999+<']]) {
+        const icon = clusterIcon(count);
+        assert.ok(icon.options.html.includes(expected),
+            `count ${count} should render as ${expected}`);
+    }
+});
+
+test('cluster grows with the number of tournaments', () => {
+    const small = clusterIcon(5).options.iconSize[0];
+    const medium = clusterIcon(50).options.iconSize[0];
+    const large = clusterIcon(500).options.iconSize[0];
+    assert.ok(small < medium && medium < large, 'sizes should increase with count');
+    // Capped so dense regions are not dominated by huge circles.
+    assert.ok(large <= 60, 'largest cluster should stay reasonable');
+});
+
+test('cluster is anchored at its centre', () => {
+    const icon = clusterIcon(10);
+    const [w, h] = icon.options.iconSize;
+    const [ax, ay] = icon.options.iconAnchor;
+    assert.strictEqual(ax, w / 2, 'x anchor should be centred');
+    assert.strictEqual(ay, h / 2, 'y anchor should be centred');
+});
+
+test('pin is anchored at its tip so it points at the venue', () => {
+    // A centred anchor would place the pin's middle on the coordinates,
+    // which shifts every tournament visibly north on the map.
+    const svg = tennisBallPin({ size: 34 });
+    assert.ok(svg.includes('width="34"'));
 });
 
 if (failures > 0) {


### PR DESCRIPTION
Implements design variant A, plus the two additions you asked for.

## Design system

The interface relied on browser defaults. Concretely: labels were **larger than the inputs** they described, blue *and* green were both used as accents with no rule, and spacing was set per element rather than from a scale.

Everything now comes from tokens:

* **One accent** for primary actions and active states
* **4px spacing scale**, one radius and shadow language
* **Type scale** where labels are quiet metadata and inputs carry the weight
* Federation checkboxes become **chips** — the native checkbox stays in the DOM, hidden but focusable, so keyboard and screen reader behaviour is unchanged

Only appearance changed: no control moved, nothing is hidden behind an extra click.

### Contrast verified, not eyeballed

Every foreground/background pair checked against WCAG AA:

```
body text on white        15.76:1  PASS
muted label on white       6.55:1  PASS
accent link on white       5.99:1  PASS
white on accent button     5.99:1  PASS
lk muted on soft           5.74:1  PASS   ← lowest
```

## Select all / none

The functions already existed but their controls were **commented out** — left over from the three-federation limit that #58 removed.

They now sit next to the section label with a live count. Selecting none is a legitimate state to pass through, so the count says so explicitly (*"Kein Verband ausgewählt — bitte mindestens einen wählen"*) rather than letting a later empty result look like a bug.

## Custom map markers

The default Leaflet pin is a generic blue teardrop that reads as "some library" rather than as this app.

Markers are now **inline SVG**: a pin in the accent colour with a tennis ball inside, and a white outline that lifts it off busy tiles. Clusters use the same language with the count centred.

SVG data URIs rather than image files — crisp at any display density, no extra request, and the colour follows the design tokens.

## Two issues found by verifying in a real browser

**1. The view toggle covered the OpenStreetMap attribution on phones.** That is a licence requirement, not just cosmetic:

```
attribution: y=827   toggle: y=786..832   →  overlap: true
```

Fixed by lifting the attribution clear of it.

**2. "Alle"/"Keine" were 18px-tall text links** — well below a comfortable touch target. Now 36px on mobile, chips 48px.

Also: an earlier cluster drew the full tennis ball seam behind the number. A design review flagged that it competed with the count, so it is reduced to a single arc.

## Verification

* Frontend unit tests: **24** (5 new for the marker/cluster helpers)
* Rendered in headless Chromium at 1280px and 390px: no console errors, no horizontal overflow, 5 SVG pins + 2 clusters rendering correctly
* Select-all/none asserted end to end: 3 → 17 → 0 with matching count text
* `gofmt`, `go vet` clean; backend untouched

## Notes

* Adds **Inter** to the existing Google Fonts request (the app already loads Ubuntu Mono), so no new connection. If you would rather avoid the dependency, the system font stack looks nearly identical — one line to change.
* The `MAX_SELECTED_FEDERATIONS` switch still works; if a cap is ever reinstated, the select-all button respects it.
