### PR TITLE
fix: centre the filter panel on mobile

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1372,3 +1372,66 @@ body {
 .ttf-cluster:hover {
     transform: scale(1.06);
 }
+
+/* ---------- Mobile filter panel geometry ----------
+
+   Two long-standing issues made the panel look off-centre on phones:
+
+   1. The 45px offset that keeps the panel clear of the Leaflet zoom
+      controls was applied twice: once as .sideBar's left position, and
+      again in .sideBarElement's width. The panel therefore ended 45px
+      short on the right while sitting 45px from the left, so the two
+      margins never matched.
+
+   2. Horizontal padding used vh units (1.5vh, 1vh), which derive from the
+      viewport *height*. Left/right spacing consequently changed with the
+      device's aspect ratio instead of staying constant.
+
+   Measured before: content sat at 86px from the left and 70px from the
+   right on a 390px viewport. */
+
+@media (max-width: 768px) {
+    .sideBar {
+        /* The panel clears the Leaflet zoom controls on the left, so the same
+           gap is mirrored on the right; otherwise the card looks pushed off
+           to one side. The offset is owned by the container alone. */
+        left: 12px;
+        width: calc(100% - 24px);
+        box-sizing: border-box;
+    }
+
+    /* The title row starts below the zoom controls, so the panel no longer
+       has to dodge them horizontally. The base rule adds an 8px left margin
+       for the desktop layout, which would push the card off-centre here. */
+    .sideBar .title {
+        margin: 52px 0 10px 0;
+    }
+
+    .sideBarElement {
+        /* Fill the container instead of subtracting the offset a second time. */
+        width: 100%;
+        box-sizing: border-box;
+        padding: 12px 14px;
+    }
+
+    .filterContainer {
+        /* vw/vh padding made horizontal spacing depend on screen height. */
+        padding: 8px 0;
+        margin-bottom: 0;
+        min-height: 0;
+    }
+
+    .submitBtn {
+        /* A percentage width left uneven side margins inside a padded box. */
+        width: 100%;
+        font-size: 3.9vw;
+    }
+
+    .filter {
+        /* .filter carries left: 8px for the desktop map layout, which shifts
+           the whole panel out of its container on mobile. */
+        left: 0;
+        /* Equal padding on both sides; the scrollbar sits inside it. */
+        padding: 12px 14px;
+    }
+}


### PR DESCRIPTION
Good catch. Measuring it confirmed the imbalance: on a 390px viewport the content sat **86px from the left but only 70px from the right**.

## Three compounding causes

All pre-existing, all in the mobile media query:

**1. The 45px offset was applied twice.** It keeps the panel clear of the Leaflet zoom controls, but it was set once as `.sideBar`'s `left` *and* again in `.sideBarElement`'s `width: calc(100% - 45px)`:

```
.sideBar        left=45, width=345  →  spans 45..390   (right gap 0)
.sideBarElement width=calc(100% - 45px) of 345 = 300  →  right gap 45
```

**2. Horizontal padding used `vh` units.**

```css
padding: 1.5vw 1.5vh 1.5vw 1.5vh;   /* ← left/right derived from viewport HEIGHT */
```

So the side spacing changed with the device's aspect ratio instead of staying constant.

**3. Desktop offsets leaked into mobile.** `.title` carries `margin-left: 8px` and `.filter` carries `left: 8px` for the desktop map layout; on mobile both pushed their content out of the container.

## The fix

One symmetric inset, and the panel now starts *below* the zoom controls rather than dodging them sideways. The submit button fills the content width instead of `80%`, which had left uneven side margins inside an already-padded box.

## Verified by measurement, not by eye

```
iPhone SE           375px  panel  12/12  input  27/27  overflow 0  ok
iPhone 12           390px  panel  12/12  input  27/27  overflow 0  ok
iPhone 14 Pro Max   430px  panel  12/12  input  27/27  overflow 0  ok
Pixel 7             412px  panel  12/12  input  27/27  overflow 0  ok
tablet portrait     768px  panel  12/12  input  27/27  overflow 0  ok
```

Every size symmetric, no horizontal overflow.

**Desktop is deliberately excluded** — the panel is left-aligned over the map there by design, so its margins are asymmetric on purpose. Confirmed unchanged after the fix.

CSS only; no markup or behaviour changed. Frontend tests (26) and backend checks still pass.
