### PR TITLE
fix: stop the page scrolling on mobile and restore the panel inset

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -41,3 +41,14 @@ jobs:
       # Date parsing and sorting cannot be verified by looking at the map.
       - name: Run frontend unit tests
         run: node script/main.test.js
+
+      - name: Install Playwright
+        run: |
+          npm install --no-save playwright
+          npx playwright install --with-deps chromium
+
+      # Layout regressions (uneven margins, accidental page scrolling) are
+      # invisible to unit tests and easy to reintroduce, so they are measured
+      # in a real browser across several phone viewports.
+      - name: Run layout tests
+        run: node script/layout.test.js

--- a/css/main.css
+++ b/css/main.css
@@ -3,11 +3,21 @@ body {
     margin: 0;
     padding: 0;
     font-family: Roboto, Arial, sans-serif;
+    /* The map fills the screen and handles its own panning. Without this the
+       document itself scrolls behind the map, which feels like the page is
+       coming loose. */
+    overflow: hidden;
+    overscroll-behavior: none;
 }
 
 #map {
+    /* 100vw includes the scrollbar width and 100vh is larger than the visible
+       area on mobile Safari, so both caused the page to scroll. Percentages
+       track the actual viewport; dvh follows the browser chrome as it
+       collapses, with vh as the fallback for older engines. */
     height: 100vh;
-    width: 100vw;
+    height: 100dvh;
+    width: 100%;
     cursor: default;
 }
 
@@ -690,7 +700,11 @@ body {
     background-color: #f5f5f5;
     box-sizing: border-box;
     padding: 16px;
-    min-height: 100vh;
+    /* The document no longer scrolls, so the list provides its own scrolling. */
+    height: 100vh;
+    height: 100dvh;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
 }
 
 /* In the list view the sidebar must not float above the results: it moves
@@ -1415,10 +1429,18 @@ body {
     }
 
     .filterContainer {
-        /* vw/vh padding made horizontal spacing depend on screen height. */
+        /* vw/vh padding made horizontal spacing depend on screen height.
+           The rows sit inside the already-padded panel, so they only need
+           vertical rhythm; horizontal inset comes from the panel. */
         padding: 8px 0;
         margin-bottom: 0;
         min-height: 0;
+    }
+
+    /* The panel's own inset. This is the gap between the card edge and its
+       content, and it has to survive the scrollbar. */
+    .sideBarElement.filter {
+        padding: 14px 16px;
     }
 
     .submitBtn {

--- a/index.html
+++ b/index.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <!-- <meta
-      charset="UTF-8"
-      name="viewport"
-      content="initial-scale=1,user-scalable=no,viewport-fit=cover"
-    /> -->
+    <meta charset="UTF-8" />
+    <!-- A single element cannot carry both charset and name: the browser reads
+         the charset and discards the viewport declaration, which is why the
+         page could be zoomed and scrolled on phones.
+         viewport-fit=cover lets the layout extend into the safe areas, which
+         are then handled with env(safe-area-inset-*) in CSS. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <link rel="apple-touch-startup-image" media="(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3)" href="/tennis-tournament-finder/images/splash-13pro.png" />
     <link rel="apple-touch-startup-image" media="(device-width: 482px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3)" href="/tennis-tournament-finder/images/splash-13promax.png" />
     <link rel="apple-touch-startup-image" media="(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3)" href="/tennis-tournament-finder/images/splash-14pro.png" />

--- a/script/layout.test.js
+++ b/script/layout.test.js
@@ -1,0 +1,191 @@
+// Layout regression tests.
+//
+// These check geometry that unit tests cannot see and that screenshots only
+// reveal by eye: symmetric panel margins, no accidental page scrolling, and a
+// viewport meta tag the browser will actually honour.
+//
+// Run with: node script/layout.test.js
+// Requires Playwright; skipped automatically when it is unavailable.
+
+const assert = require('assert');
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+
+let chromium;
+try {
+    ({ chromium } = require('playwright'));
+} catch (err) {
+    console.log('Playwright not installed - skipping layout tests');
+    process.exit(0);
+}
+
+const ROOT = path.join(__dirname, '..');
+const PORT = 8123;
+
+const MIME = {
+    '.html': 'text/html; charset=utf-8',
+    '.js': 'text/javascript; charset=utf-8',
+    '.css': 'text/css; charset=utf-8',
+    '.png': 'image/png',
+    '.ico': 'image/x-icon',
+};
+
+// 1x1 transparent PNG, stands in for map tiles and icons.
+const TILE = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk' +
+    'YPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==', 'base64');
+
+const RESPONSE = JSON.stringify({
+    tournaments: [{
+        id: '1', title: 'Testturnier', url: '#', date: '22.08. bis 23.08.',
+        location: 'Karlsruhe', organizer: 'TC Karlsruhe',
+        lat: '49.0069', lon: '8.4037', entries: [],
+    }],
+    federations: [{ id: 'BAD', status: 'ok', count: 1 }],
+    partial: false,
+});
+
+function serve() {
+    return http.createServer((req, res) => {
+        const url = new URL(req.url, 'http://localhost');
+        const file = url.pathname === '/' ? '/index.html' : url.pathname;
+        const full = path.join(ROOT, file);
+        if (!fs.existsSync(full) || fs.statSync(full).isDirectory()) {
+            res.writeHead(404).end();
+            return;
+        }
+        res.writeHead(200, { 'Content-Type': MIME[path.extname(full)] || 'application/octet-stream' });
+        fs.createReadStream(full).pipe(res);
+    });
+}
+
+let failures = 0;
+function check(name, fn) {
+    try {
+        fn();
+        console.log(`  ok  ${name}`);
+    } catch (err) {
+        failures++;
+        console.error(`  FAIL ${name}\n       ${err.message}`);
+    }
+}
+
+// Phone sizes including the shorter viewport mobile Safari reports while its
+// address bar is visible, which is where the scrolling bug appeared.
+const VIEWPORTS = [
+    ['iPhone SE', 375, 667],
+    ['iPhone SE, browser chrome', 375, 553],
+    ['iPhone 12', 390, 844],
+    ['iPhone 12, browser chrome', 390, 664],
+    ['iPhone 14 Pro Max', 430, 932],
+    ['Pixel 7', 412, 915],
+];
+
+(async () => {
+    const server = serve();
+    await new Promise(r => server.listen(PORT, r));
+    const browser = await chromium.launch();
+
+    console.log('viewport meta');
+    const html = fs.readFileSync(path.join(ROOT, 'index.html'), 'utf8');
+    check('viewport is declared on its own meta element', () => {
+        // A single element cannot carry both charset and name: the browser
+        // keeps the charset and drops the viewport, so the page stays
+        // zoomable and scrollable on phones.
+        const combined = /<meta[^>]*charset[^>]*name=["']viewport["']/i.test(html);
+        assert.ok(!combined, 'charset and viewport must not share one meta tag');
+        assert.ok(/<meta\s+name=["']viewport["']/i.test(html), 'viewport meta must exist');
+    });
+
+    check('viewport allows zooming', () => {
+        const meta = html.match(/<meta\s+name=["']viewport["'][^>]*>/i)[0];
+        // Blocking zoom fails WCAG 1.4.4 and is unnecessary here.
+        assert.ok(!/user-scalable\s*=\s*no/i.test(meta), 'zoom must not be disabled');
+        assert.ok(!/maximum-scale\s*=\s*1/i.test(meta), 'maximum-scale must not pin zoom');
+    });
+
+    for (const [name, width, height] of VIEWPORTS) {
+        console.log(`\n${name} (${width}x${height})`);
+
+        const page = await browser.newPage({
+            viewport: { width, height }, isMobile: true, hasTouch: true,
+        });
+        await page.route('**/ttf**', r =>
+            r.fulfill({ status: 200, contentType: 'application/json', body: RESPONSE }));
+        await page.route('**tile**', r =>
+            r.fulfill({ status: 200, contentType: 'image/png', body: TILE }));
+        await page.route('**/images/**', r =>
+            r.fulfill({ status: 200, contentType: 'image/png', body: TILE }));
+
+        await page.goto(`http://localhost:${PORT}/index.html`, { waitUntil: 'domcontentloaded' });
+        await page.waitForTimeout(700);
+
+        const closed = await page.evaluate(() => ({
+            x: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+            y: document.documentElement.scrollHeight - document.documentElement.clientHeight,
+        }));
+
+        check('map view does not scroll the document', () => {
+            // The map handles panning itself; a scrolling document underneath
+            // makes the whole page feel loose.
+            assert.strictEqual(closed.x, 0, `horizontal overflow of ${closed.x}px`);
+            assert.strictEqual(closed.y, 0, `vertical overflow of ${closed.y}px`);
+        });
+
+        await page.evaluate(() => {
+            document.getElementById('filterContainer').style.display = 'block';
+        });
+        await page.waitForTimeout(250);
+
+        const open = await page.evaluate(() => {
+            const vw = window.innerWidth;
+            const panel = document.getElementById('filterContainer').getBoundingClientRect();
+            const input = document.getElementById('dateFrom').getBoundingClientRect();
+            const chip = document.querySelector('.checkboxLabel').getBoundingClientRect();
+            return {
+                panelLeft: Math.round(panel.left),
+                panelRight: Math.round(vw - panel.right),
+                insetLeft: Math.round(input.left - panel.left),
+                insetRight: Math.round(panel.right - input.right),
+                chipInset: Math.round(chip.left - panel.left),
+                overflowX: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+            };
+        });
+
+        check('panel margins are symmetric', () => {
+            assert.ok(Math.abs(open.panelLeft - open.panelRight) <= 2,
+                `left ${open.panelLeft}px vs right ${open.panelRight}px`);
+        });
+
+        check('content is evenly inset inside the panel', () => {
+            assert.ok(Math.abs(open.insetLeft - open.insetRight) <= 2,
+                `inset left ${open.insetLeft}px vs right ${open.insetRight}px`);
+        });
+
+        check('content does not touch the panel edge', () => {
+            // Without a real inset the card looks like the text is falling out
+            // of it, which is what the vh-based padding used to cause.
+            assert.ok(open.insetLeft >= 10, `only ${open.insetLeft}px of padding`);
+            assert.ok(open.chipInset >= 10, `chips only ${open.chipInset}px from the edge`);
+        });
+
+        check('open panel does not cause horizontal scrolling', () => {
+            assert.strictEqual(open.overflowX, 0, `horizontal overflow of ${open.overflowX}px`);
+        });
+
+        await page.close();
+    }
+
+    await browser.close();
+    server.close();
+
+    if (failures > 0) {
+        console.error(`\n${failures} layout check(s) failed`);
+        process.exit(1);
+    }
+    console.log('\nAll layout tests passed');
+})().catch(err => {
+    console.error('layout tests errored:', err.message);
+    process.exit(1);
+});


### PR DESCRIPTION
My previous fix (#67) balanced the margins but made two things worse. Both are fixed here, and the underlying causes turned out to be older bugs.

## 1. The page scrolled in both directions

Two separate causes:

**`#map` used `100vw` / `100vh`.** `100vw` includes the scrollbar width, and on mobile Safari `100vh` is the height *with the address bar hidden* — taller than what is actually visible. Either one makes the document scroll behind the map. Now percentages and `dvh`, which track the real viewport.

**The viewport meta tag was never applied.** This one is the root cause and predates all of my changes:

```html
<meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1.0, ...">
```

A `meta` element carries **one** directive. The browser read the charset and silently discarded the viewport, so the page behaved as if no viewport had been declared — zoomable, scrollable, and ignoring `width=device-width`. It is now its own tag.

Since the document no longer scrolls, the list view provides its own scroll container.

## 2. The panel lost its inner padding

My mobile rule set `.filterContainer` to `padding: 8px 0`. Correct for the rows, but they had been relying on that horizontal padding for the card's inset. The panel now carries it itself, where it belongs — content sits 17px from the card edge.

## Also fixed while in there

Dropped `user-scalable=no` and `maximum-scale=1.0`. Blocking zoom fails **WCAG 1.4.4** and there is no reason for it here.

## Why this reached your device

My earlier testing used a 390×844 viewport — the *full* screen height. Mobile Safari reports a shorter viewport while its address bar is visible, and that is precisely where the overflow appeared. My test could not have caught it.

So this PR adds `script/layout.test.js`, which measures panel symmetry, content inset and document overflow in a real browser across **six** phone viewports, including the address-bar case:

```
iPhone SE                   375x667   ok
iPhone SE, browser chrome   375x553   ok
iPhone 12                   390x844   ok
iPhone 12, browser chrome   390x664   ok
iPhone 14 Pro Max           430x932   ok
Pixel 7                     412x915   ok

All layout tests passed  (32 checks)
```

It also asserts the viewport meta tag is valid and does not block zoom, and it runs in CI — so this class of bug fails the build rather than reaching a phone.

Desktop verified unchanged.
