### PR TITLE
feat: remove zoom buttons, centre the view toggle, fix mobile list scrolling

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1414,11 +1414,11 @@ body {
         box-sizing: border-box;
     }
 
-    /* The title row starts below the zoom controls, so the panel no longer
-       has to dodge them horizontally. The base rule adds an 8px left margin
-       for the desktop layout, which would push the card off-centre here. */
+    /* The base rule adds an 8px left margin for the desktop layout, which
+       would push the card off-centre here. The zoom buttons that the title
+       used to clear are gone, so the panel starts near the top. */
     .sideBar .title {
-        margin: 52px 0 10px 0;
+        margin: calc(10px + env(safe-area-inset-top, 0px)) 0 10px 0;
     }
 
     .sideBarElement {
@@ -1566,4 +1566,84 @@ select.filterElement {
     background-repeat: no-repeat;
     background-position: right 12px center;
     background-size: 12px 8px;
+}
+
+/* ---------- List view scrolling ----------
+
+   The map view locks the document so the map owns all gestures. The list view
+   is an ordinary scrolling page and needs that lock released, otherwise three
+   scroll containers end up stacked: the document (locked, so the filter panel
+   stays pinned), the filter panel, and the list itself. Reaching a result then
+   means scrolling the right one of the three, which is what made the list feel
+   stuck while the filter was open.
+
+   In list mode the document scrolls normally: the filter sits above the
+   results and moves out of the way as the page scrolls, like any other page. */
+
+body.list-mode,
+html:has(body.list-mode) {
+    overflow: auto;
+    overflow-x: hidden;
+    height: auto;
+}
+
+body.list-mode .list-view {
+    /* The document scrolls, so the list must not trap it in its own box. */
+    height: auto;
+    min-height: 0;
+    overflow: visible;
+}
+
+body.list-mode .filter {
+    /* Same reason: a scrollable filter inside a scrolling page means the user
+       has to guess which one responds to a swipe. */
+    max-height: none;
+    overflow: visible;
+}
+
+/* ---------- View toggle placement ----------
+
+   On a phone the toggle sat in the bottom-right corner, which is awkward for
+   a left thumb and crowds the Leaflet attribution. Centring it makes it
+   reachable with either hand and gives the attribution its corner back. */
+
+@media (max-width: 768px) {
+    .viewToggle {
+        top: auto;
+        bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+        left: 50%;
+        right: auto;
+        transform: translateX(-50%);
+        border-radius: 999px;
+        box-shadow: 0 2px 10px rgba(31, 36, 33, .28);
+    }
+
+    body.list-mode .viewToggle {
+        position: fixed;
+        margin: 0;
+        /* The fixed toggle would otherwise cover the last result. */
+        bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+        left: 50%;
+        transform: translateX(-50%);
+    }
+
+    /* Clearance so the final card is not hidden behind the floating toggle. */
+    body.list-mode .list-view {
+        padding-bottom: calc(76px + env(safe-area-inset-bottom, 0px));
+    }
+
+    /* The attribution keeps the corner now that the toggle has moved. */
+    .leaflet-bottom.leaflet-right .leaflet-control-attribution {
+        margin-bottom: 0;
+    }
+}
+
+@media (max-width: 768px) {
+    /* 70vh is measured against the viewport with the browser chrome hidden, so
+       the panel could extend past the visible area and clip its last line.
+       dvh follows the chrome, and the panel is bounded by the space actually
+       left between the title and the floating view toggle. */
+    .filter {
+        max-height: calc(100dvh - 150px - env(safe-area-inset-bottom, 0px));
+    }
 }

--- a/script/layout.test.js
+++ b/script/layout.test.js
@@ -269,6 +269,88 @@ const VIEWPORTS = [
                 `chip row inset left ${panel.chipLeft}px vs right ${panel.chipRight}px`);
         });
 
+        const controls = await page.evaluate(() => {
+            const toggle = document.querySelector('.viewToggle').getBoundingClientRect();
+            const panel = document.getElementById('filterContainer').getBoundingClientRect();
+            return {
+                zoomButtons: document.querySelectorAll('.leaflet-control-zoom').length,
+                toggleCentre: (toggle.left + toggle.right) / 2,
+                viewportCentre: window.innerWidth / 2,
+                panelBottom: panel.bottom,
+                toggleTop: toggle.top,
+                viewportHeight: window.innerHeight,
+            };
+        });
+
+        check('map has no zoom buttons', () => {
+            // Pinch, double-tap and the wheel all zoom, so the buttons only
+            // occupied the corner the filter panel needs.
+            assert.strictEqual(controls.zoomButtons, 0, 'zoom control should be disabled');
+        });
+
+        check('view toggle is horizontally centred', () => {
+            const off = Math.abs(controls.toggleCentre - controls.viewportCentre);
+            assert.ok(off <= 2, `toggle is ${off.toFixed(1)}px off centre`);
+        });
+
+        check('open panel fits the visible viewport', () => {
+            // A max-height in vh is measured against the viewport with the
+            // browser chrome hidden, so the panel could extend past what the
+            // user can see and clip its last line.
+            assert.ok(controls.panelBottom <= controls.viewportHeight,
+                `panel ends ${Math.round(controls.panelBottom - controls.viewportHeight)}px below the fold`);
+            assert.ok(controls.panelBottom <= controls.toggleTop,
+                'panel runs underneath the floating view toggle');
+        });
+
+        // The list view is a normal scrolling page; the map view is not. Both
+        // states have to work with the filter panel open, which is where the
+        // scroll containers previously fought each other.
+        await page.click('.submitBtn', { force: true });
+        await page.waitForTimeout(900);
+        await page.click('#viewListBtn', { force: true });
+        await page.waitForTimeout(500);
+
+        const list = await page.evaluate(async () => {
+            const scroller = document.scrollingElement;
+            const reach = scroller.scrollHeight - scroller.clientHeight;
+            scroller.scrollTop = 99999;
+            await new Promise(r => setTimeout(r, 250));
+            const scrolled = scroller.scrollTop;
+            const items = [...document.querySelectorAll('.tournament-item')];
+            const last = items[items.length - 1].getBoundingClientRect();
+            const toggle = document.querySelector('.viewToggle').getBoundingClientRect();
+            const nested = [...document.querySelectorAll('.list-view, .filter')]
+                .filter(el => el.scrollHeight > el.clientHeight + 2).length;
+            return {
+                reach, scrolled, nested,
+                lastHiddenByToggle: last.bottom > toggle.top,
+                toggleCentre: (toggle.left + toggle.right) / 2,
+                viewportCentre: window.innerWidth / 2,
+            };
+        });
+
+        check('list view scrolls', () => {
+            assert.ok(list.reach > 0, 'list should be taller than the viewport');
+            assert.ok(list.scrolled > 0, 'document did not scroll');
+        });
+
+        check('list view has a single scroll container', () => {
+            // Stacking the document, the filter panel and the list meant a
+            // swipe could land on the wrong one and appear to do nothing.
+            assert.strictEqual(list.nested, 0,
+                `${list.nested} nested scroll container(s) inside the page`);
+        });
+
+        check('last result is not hidden behind the toggle', () => {
+            assert.ok(!list.lastHiddenByToggle, 'the floating toggle covers the last result');
+        });
+
+        check('view toggle stays centred in the list view', () => {
+            const off = Math.abs(list.toggleCentre - list.viewportCentre);
+            assert.ok(off <= 2, `toggle is ${off.toFixed(1)}px off centre`);
+        });
+
         await page.close();
     }
 

--- a/script/main.js
+++ b/script/main.js
@@ -3,7 +3,10 @@ let map = L.map('map', {
   zoomDelta: 0.5,
   doubleClickZoom: true,
   inertia: true,
-  zoomAnimation: true
+  zoomAnimation: true,
+  // Pinch, double-tap and the scroll wheel all zoom, so the +/- buttons only
+  // occupied the corner the filter panel needs.
+  zoomControl: false
 }).setView([51.133481, 10.018343], 7);
 window.map = map; // expose map for gesture script
 L.tileLayer('http://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
@@ -714,6 +717,10 @@ function setView(view) {
     // cover the first results, so the page switches to a normal document flow
     // with the filters above the list.
     document.body.classList.toggle('list-mode', showList);
+    // The map view locks scrolling on the document so the map owns all
+    // gestures; the list view is an ordinary page and needs it released.
+    // Mirrored onto <html> because :has() is not available everywhere.
+    document.documentElement.classList.toggle('list-mode', showList);
 
     mapEl.style.display = showList ? 'none' : 'block';
     listEl.style.display = showList ? 'block' : 'none';


### PR DESCRIPTION
Three changes, all mobile-only.

## 1. Zoom buttons removed

Pinch, double-tap and the scroll wheel all zoom, so the `+`/`−` control only occupied the top-left corner the filter panel needs.

Side effect worth having: the panel no longer has to start *below* the buttons, so noticeably more of the form is visible on a phone.

## 2. View toggle centred

It sat bottom-right — awkward for a left thumb and crowding the Leaflet attribution. Now centred along the bottom edge, clear of the safe area:

```
390px viewport → toggle centre 195 vs 195
375px viewport → toggle centre 188 vs 188
```

Desktop keeps the top-right placement, where nothing competes for that space.

## 3. List view scrolling

The real problem. **Three scroll containers were stacked:**

```
filter open, before:
  HTML         over=118px   overflow-y: hidden   ← locked, so it could not move
  .filter      over=222px   overflow-y: auto
  .list-view   over=4988px  overflow-y: auto
```

A swipe landed on whichever one happened to be under the finger. The document was locked by `overflow: hidden` — correct for the map view, where the map must own every gesture, but in the list view it pinned the filter panel in place and made the list feel stuck.

List mode now releases the lock and the document scrolls normally, with the filter above the results moving out of the way as you scroll:

```
filter open, after:
  scrollers: ['list-mode']     ← exactly one
  scrolled by 5106px, last card reachable: true
```

The list also gains bottom padding so the floating toggle cannot cover the last result.

`list-mode` is mirrored onto `<html>` from `setView()` because `:has()` is not available in every engine.

## Also fixed

The open panel's `max-height` was `70vh`, measured against the viewport with the browser chrome *hidden* — so its last line could sit below the fold. Now derived from `dvh` and the toggle position:

```
390x664  panel bottom=590  vh=664  fits=true  clearsToggle=true
375x553  panel bottom=479  vh=553  fits=true  clearsToggle=true
430x932  panel bottom=769  vh=932  fits=true  clearsToggle=true
```

## Tests

122 checks across 6 viewports, now also covering: no zoom control, toggle centred in **both** views, list scrolls, exactly one scroll container, last result clear of the toggle, and the open panel fitting the visible viewport.

Desktop verified unchanged.
