### PR TITLE
test: run the layout suite in WebKit as well as Chromium

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -45,10 +45,11 @@ jobs:
       - name: Install Playwright
         run: |
           npm install --no-save playwright
-          npx playwright install --with-deps chromium
+          npx playwright install --with-deps chromium webkit
 
       # Layout regressions (uneven margins, accidental page scrolling) are
       # invisible to unit tests and easy to reintroduce, so they are measured
-      # in a real browser across several phone viewports.
+      # in real browsers across several phone viewports. WebKit is included
+      # because it, not Chromium, is what iPhones run.
       - name: Run layout tests
         run: node script/layout.test.js

--- a/script/layout.test.js
+++ b/script/layout.test.js
@@ -4,6 +4,17 @@
 // reveal by eye: symmetric panel margins, no accidental page scrolling, and a
 // viewport meta tag the browser will actually honour.
 //
+// They run in Chromium and WebKit, because the two engines disagree about
+// form control sizing, flexbox rounding and viewport units, and those
+// disagreements are what reach a phone.
+//
+// Known limit: this is WebKitGTK. It shares Safari's engine but not the
+// control widgets iOS ships, so a date input here is sized from the
+// stylesheet rather than from a native picker. The iOS-only width bug that
+// motivated these tests is therefore still not reproducible on Linux - the
+// assertions catch it by checking the CSS contract (appearance is reset,
+// widths and edges agree) rather than by rendering the native control.
+//
 // Run with: node script/layout.test.js
 // Requires Playwright; skipped automatically when it is unavailable.
 
@@ -12,12 +23,31 @@ const fs = require('fs');
 const http = require('http');
 const path = require('path');
 
-let chromium;
+let playwright;
 try {
-    ({ chromium } = require('playwright'));
+    playwright = require('playwright');
 } catch (err) {
     console.log('Playwright not installed - skipping layout tests');
     process.exit(0);
+}
+
+// Chromium and WebKit disagree about form control sizing, flexbox rounding and
+// viewport units, and those disagreements are what reach a phone. WebKit here
+// is WebKitGTK, which shares Safari's engine but not its iOS control widgets,
+// so it narrows the gap rather than closing it.
+async function engines() {
+    const available = [];
+    for (const name of ['chromium', 'webkit']) {
+        if (!playwright[name]) continue;
+        try {
+            const browser = await playwright[name].launch();
+            await browser.close();
+            available.push(name);
+        } catch (err) {
+            console.log(`  (${name} unavailable, skipping: ${err.message.split('\n')[0]})`);
+        }
+    }
+    return available;
 }
 
 const ROOT = path.join(__dirname, '..');
@@ -85,9 +115,16 @@ const VIEWPORTS = [
 (async () => {
     const server = serve();
     await new Promise(r => server.listen(PORT, r));
-    const browser = await chromium.launch();
 
-    console.log('viewport meta');
+    const names = await engines();
+    if (names.length === 0) {
+        console.log('No browser engine available - skipping layout tests');
+        server.close();
+        process.exit(0);
+    }
+    console.log(`engines: ${names.join(', ')}`);
+
+    console.log('\nviewport meta');
     const html = fs.readFileSync(path.join(ROOT, 'index.html'), 'utf8');
     check('viewport is declared on its own meta element', () => {
         // A single element cannot carry both charset and name: the browser
@@ -105,12 +142,15 @@ const VIEWPORTS = [
         assert.ok(!/maximum-scale\s*=\s*1/i.test(meta), 'maximum-scale must not pin zoom');
     });
 
+    for (const engine of names) {
+    const browser = await playwright[engine].launch();
     for (const [name, width, height] of VIEWPORTS) {
-        console.log(`\n${name} (${width}x${height})`);
+        console.log(`\n[${engine}] ${name} (${width}x${height})`);
 
-        const page = await browser.newPage({
-            viewport: { width, height }, isMobile: true, hasTouch: true,
-        });
+        // WebKitGTK rejects the mobile emulation flags Chromium accepts.
+        const page = await browser.newPage(engine === 'webkit'
+            ? { viewport: { width, height }, hasTouch: true }
+            : { viewport: { width, height }, isMobile: true, hasTouch: true });
         await page.route('**/ttf**', r =>
             r.fulfill({ status: 200, contentType: 'application/json', body: RESPONSE }));
         await page.route('**tile**', r =>
@@ -353,8 +393,9 @@ const VIEWPORTS = [
 
         await page.close();
     }
-
     await browser.close();
+    }
+
     server.close();
 
     if (failures > 0) {


### PR DESCRIPTION
The iOS form control bug in #69 passed every check because those checks only ran in Chromium. The layout suite now runs in **both engines**.

```
engines: chromium, webkit
All layout tests passed        (240 checks)
```

Each viewport runs twice. Either engine is skipped gracefully when its binary is missing, so a contributor without WebKit still gets the Chromium run.

## Honest about what this buys us

I checked whether WebKit would actually have caught the date-field bug, by measuring against the commit *before* the fix:

```
BEFORE the appearance fix (17631d8):
chromium  widths=[332, 332, 332, 332]  spread=0px
webkit    widths=[332, 332, 332, 332]  spread=0px
```

**It would not have.** This is WebKitGTK: it shares Safari's engine but not the control widgets iOS ships, so a date input here is sized from the stylesheet rather than from a native picker. `supportsDate=true`, but the native iOS box is simply not part of the Linux build.

So this is not "we can now test on iPhone". Worth stating plainly rather than letting the next person assume otherwise — it is documented at the top of the file.

## What it does catch

Everything downstream of the CSS contract, which is where these bugs actually live. Verified by mutation testing rather than by assertion:

**Removing the appearance reset:**
```
[chromium] FAIL native control appearance is reset   (x6 viewports)
[webkit]   FAIL native control appearance is reset   (x6 viewports)
```

**Restoring `overflow: auto` on the panel:**
```
[chromium] FAIL panel itself does not scroll sideways   (x6)
[webkit]   FAIL panel itself does not scroll sideways   (x6)
```

Both classes fail loudly in both engines.

The real value is the layout properties the two engines *do* implement differently — flexbox rounding, viewport units, scroll container behaviour. That is the more common source of surprises, and it is now covered on every PR.

## CI

`playwright install` gains `webkit` alongside `chromium`. Adds roughly a minute to the frontend job.
