### PR TITLE
feat: mobile tab bar with the filter as an action

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1601,6 +1601,15 @@ body.list-mode .filter {
     overflow: visible;
 }
 
+/* On phones the filter is a sheet in both views, so it keeps its own bounds
+   and its own scrolling regardless of list mode. */
+@media (max-width: 768px) {
+    body.list-mode .sideBar .filter {
+        max-height: 82dvh;
+        overflow: hidden;
+    }
+}
+
 /* ---------- View toggle placement ----------
 
    On a phone the toggle sat in the bottom-right corner, which is awkward for
@@ -1645,5 +1654,223 @@ body.list-mode .filter {
        left between the title and the floating view toggle. */
     .filter {
         max-height: calc(100dvh - 150px - env(safe-area-inset-bottom, 0px));
+    }
+}
+
+/* ---------- Mobile navigation ----------
+
+   The two views are destinations and become a bottom tab bar. Filtering is an
+   action applied to whichever view is open, so it stays a separate button that
+   raises the panel as a sheet. Making the filter a third tab tested worse: a
+   tab is a whole destination, so opening it hides the results being filtered.
+
+   Desktop keeps the existing layout; everything here is inside the phone
+   breakpoint. */
+
+.tabIcon { display: none; }
+
+.sheetHead { display: none; }
+
+.filterFab { display: none; }
+
+.sheetScrim { display: none; }
+
+@media (max-width: 768px) {
+    .viewToggle {
+        top: auto;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        transform: none;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        height: calc(58px + env(safe-area-inset-bottom, 0px));
+        padding-bottom: env(safe-area-inset-bottom, 0px);
+        /* Opaque by default so results scrolling underneath never show through
+           and make the labels hard to read. */
+        background: var(--surface);
+        border-top: 1px solid var(--line);
+        border-radius: 0;
+        box-shadow: none;
+        overflow: visible;
+    }
+
+    .viewToggleBtn {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 3px;
+        min-height: 0;
+        padding: 0;
+        font-size: 10px;
+        font-weight: 600;
+        color: var(--muted);
+        background: none;
+        border: none;
+    }
+
+    .viewToggleBtn:not(:last-child) { border-right: none; }
+
+    /* Where the browser can blur, the bar can be translucent without costing
+       legibility. */
+    @supports (backdrop-filter: blur(12px)) or (-webkit-backdrop-filter: blur(12px)) {
+        .viewToggle {
+            background: rgba(255, 255, 255, .88);
+            backdrop-filter: blur(14px);
+            -webkit-backdrop-filter: blur(14px);
+        }
+    }
+
+    /* The active tab is marked by colour and the icon, not a filled block:
+       a full-width highlight in a tab bar reads as a pressed button. */
+    .viewToggleBtn.active {
+        color: var(--accent);
+        background: none;
+    }
+
+    .tabIcon {
+        display: block;
+        width: 22px;
+        height: 22px;
+    }
+
+    .filterFab {
+        position: fixed;
+        right: 14px;
+        bottom: calc(58px + 14px + env(safe-area-inset-bottom, 0px));
+        z-index: 10002;
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        min-height: 44px;
+        padding: 11px 16px;
+        font-family: inherit;
+        font-size: 13px;
+        font-weight: 600;
+        color: #fff;
+        background: var(--accent);
+        border: none;
+        border-radius: 999px;
+        box-shadow: 0 3px 12px rgba(31, 36, 33, .26);
+    }
+
+    .filterFab svg {
+        width: 17px;
+        height: 17px;
+    }
+
+    /* The count is the panel's state made visible without opening it. */
+    .filterFabCount {
+        min-width: 20px;
+        padding: 0 6px;
+        font-size: 11px;
+        line-height: 19px;
+        text-align: center;
+        background: rgba(255, 255, 255, .22);
+        border-radius: 999px;
+    }
+
+    .sheetScrim {
+        display: block;
+        position: fixed;
+        inset: 0;
+        z-index: 10003;
+        background: rgba(31, 36, 33, .4);
+    }
+
+    .sheetScrim[hidden] { display: none; }
+
+    /* While the sheet is open the button has nothing left to do, and it would
+       otherwise sit on top of the sheet's own controls. The sheet's "Fertig"
+       and the scrim are the ways out. */
+    .filterFab[aria-expanded="true"] {
+        display: none;
+    }
+
+    /* The filter panel becomes a sheet: anchored to the bottom edge, with the
+       map still visible above it. .sideBar sets top: 0, which combined with
+       bottom: 0 stretches a fixed element to the full height and defeats
+       max-height, so top has to be released explicitly. */
+    .sideBar .filter {
+        position: fixed;
+        top: auto;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 10004;
+        width: 100%;
+        max-height: 82dvh;
+        margin: 0;
+        padding: 0;
+        border-radius: 18px 18px 0 0;
+        box-shadow: 0 -3px 20px rgba(31, 36, 33, .18);
+        display: flex;
+        flex-direction: column;
+    }
+
+    .sheetHead {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex: none;
+        padding: 14px 16px 10px;
+        border-bottom: 1px solid var(--line);
+    }
+
+    .sheetTitle {
+        font-size: 15px;
+        font-weight: 700;
+    }
+
+    .sheetDone {
+        padding: 8px 4px;
+        font-family: inherit;
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--accent);
+        background: none;
+        border: none;
+    }
+
+    .sideBar .filter form {
+        overflow-y: auto;
+        padding: 14px 16px calc(16px + env(safe-area-inset-bottom, 0px));
+    }
+
+    /* The title row keeps the app name; its old filter button is redundant now
+       that the action has its own control near the thumb. */
+    .filterToggleBtn { display: none; }
+
+    /* Anything floating over a scrolling list eventually sits on top of a link
+       in it; measured against the real list, it covered "Auf Karte zeigen".
+       The map needs a floating control because it has no header to put one in,
+       but the list does, so there the button joins the normal flow and scrolls
+       away with the content. */
+    body.list-mode .filterFab {
+        position: static;
+        display: flex;
+        margin: 0 0 12px auto;
+    }
+
+    /* Only the tab bar overlays the list now. */
+    body.list-mode .list-view {
+        padding-bottom: calc(76px + env(safe-area-inset-bottom, 0px));
+    }
+
+    body.list-mode .viewToggle {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        transform: none;
+        margin: 0;
+        width: auto;
+        max-width: none;
+    }
+
+    /* The attribution sits above the tab bar rather than behind it. */
+    .leaflet-bottom.leaflet-right .leaflet-control-attribution {
+        margin-bottom: calc(58px + env(safe-area-inset-bottom, 0px));
     }
 }

--- a/index.html
+++ b/index.html
@@ -197,6 +197,13 @@
             <button id="filterToggle" class="filterToggleBtn" onclick="toggleFilters()">Filter ⚙️</button>
         </div>
         <div class="sideBarElement filter" id="filterContainer">
+            <!-- Only shown when the panel acts as a sheet on phones. The old
+                 toggle lives in the title row, which is off-screen behind the
+                 sheet, so the sheet needs its own way out. -->
+            <div class="sheetHead">
+                <span class="sheetTitle">Filter</span>
+                <button type="button" class="sheetDone" onclick="toggleFilters()">Fertig</button>
+            </div>
             <form name="searchForm" action="javascript:getTournamentsByDate(dateFrom.value, dateTo.value, compType.value, getSelectedFederations(), playerLK.value)">
                 <div class="filterContainer">
                     <label for="dateFrom">Zeitraum von:</label>
@@ -305,12 +312,44 @@
     </div>
     <div id="dataNotice" class="data-notice" role="status" aria-live="polite" style="display: none;"></div>
 
-    <div class="viewToggle" role="group" aria-label="Ansicht wählen">
-        <button type="button" id="viewMapBtn" class="viewToggleBtn active"
-                onclick="setView('map')" aria-pressed="true">Karte</button>
-        <button type="button" id="viewListBtn" class="viewToggleBtn"
-                onclick="setView('list')" aria-pressed="false">Liste</button>
+    <!-- The two views of the same results. On phones this becomes a bottom tab
+         bar; on wider screens it stays the small toggle in the corner. It is a
+         real tablist so assistive technology announces it as navigation. -->
+    <div class="viewToggle" role="tablist" aria-label="Ansicht wählen">
+        <button type="button" id="viewMapBtn" class="viewToggleBtn active" role="tab"
+                onclick="setView('map')" aria-pressed="true" aria-selected="true">
+            <svg class="tabIcon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M9 3 3 6v15l6-3 6 3 6-3V3l-6 3-6-3z"/><path d="M9 3v15M15 6v15"/>
+            </svg>
+            <span>Karte</span>
+        </button>
+        <button type="button" id="viewListBtn" class="viewToggleBtn" role="tab"
+                onclick="setView('list')" aria-pressed="false" aria-selected="false">
+            <svg class="tabIcon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/>
+            </svg>
+            <span>Liste</span>
+        </button>
     </div>
+
+    <!-- Filtering is an action applied to the current view, not a third place
+         to be, so it sits outside the tab bar. Hidden on desktop, where the
+         panel is always visible anyway. -->
+    <button type="button" id="filterFab" class="filterFab" onclick="toggleFilters()"
+            aria-controls="filterContainer" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9"
+             stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M3 5h18M6 12h12M10 19h4"/>
+        </svg>
+        <span>Filter</span>
+        <span class="filterFabCount" id="filterFabCount">3</span>
+    </button>
+
+    <!-- Dims the map while the filter sheet is open and gives a tap target for
+         dismissing it. -->
+    <div class="sheetScrim" id="sheetScrim" onclick="toggleFilters()" hidden></div>
 
     <div id="map">
         <div id="loading" class="loading">Loading&#8230;</div>

--- a/script/layout.test.js
+++ b/script/layout.test.js
@@ -66,13 +66,23 @@ const TILE = Buffer.from(
     'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk' +
     'YPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==', 'base64');
 
+// Enough results that the list overflows every viewport under test; the
+// scrolling assertions are meaningless against a list that fits on screen.
+const TOURNAMENTS = Array.from({ length: 20 }, (_, i) => ({
+    id: String(i + 1),
+    title: `Testturnier ${i + 1}`,
+    url: '#',
+    date: '22.08. bis 23.08.',
+    location: 'Karlsruhe',
+    organizer: `TC Karlsruhe ${i + 1}`,
+    lat: String(49.0069 + i * 0.02),
+    lon: String(8.4037 + i * 0.02),
+    entries: [{ competition: 'Herren Einzel', skill_level: 'LK 12,0' }],
+}));
+
 const RESPONSE = JSON.stringify({
-    tournaments: [{
-        id: '1', title: 'Testturnier', url: '#', date: '22.08. bis 23.08.',
-        location: 'Karlsruhe', organizer: 'TC Karlsruhe',
-        lat: '49.0069', lon: '8.4037', entries: [],
-    }],
-    federations: [{ id: 'BAD', status: 'ok', count: 1 }],
+    tournaments: TOURNAMENTS,
+    federations: [{ id: 'BAD', status: 'ok', count: TOURNAMENTS.length }],
     partial: false,
 });
 
@@ -178,10 +188,24 @@ const VIEWPORTS = [
         const initialFilterDisplay = await page.evaluate(
             () => getComputedStyle(document.getElementById('filterContainer')).display);
 
-        await page.click('#filterToggle', { force: true });
-        await page.waitForTimeout(300);
+        // The filter action moved out of the title row into its own control.
+        await page.click('#filterFab', { force: true });
+        await page.waitForTimeout(350);
         const filterAfterFirstTap = await page.evaluate(
             () => getComputedStyle(document.getElementById('filterContainer')).display);
+
+        const sheet = await page.evaluate(() => {
+            const panel = document.getElementById('filterContainer');
+            const rect = panel.getBoundingClientRect();
+            const scrim = document.getElementById('sheetScrim');
+            const fab = document.getElementById('filterFab');
+            return {
+                topGap: Math.round(rect.top),
+                scrimShown: scrim ? !scrim.hidden : false,
+                fabHidden: getComputedStyle(fab).display === 'none',
+                doneVisible: !!document.querySelector('.sheetDone'),
+            };
+        });
 
         await page.evaluate(() => {
             document.getElementById('filterContainer').style.display = 'block';
@@ -322,10 +346,14 @@ const VIEWPORTS = [
         const controls = await page.evaluate(() => {
             const toggle = document.querySelector('.viewToggle').getBoundingClientRect();
             const panel = document.getElementById('filterContainer').getBoundingClientRect();
+            const tabs = [...document.querySelectorAll('.viewToggleBtn')];
             return {
                 zoomButtons: document.querySelectorAll('.leaflet-control-zoom').length,
-                toggleCentre: (toggle.left + toggle.right) / 2,
-                viewportCentre: window.innerWidth / 2,
+                toggleRole: document.querySelector('.viewToggle').getAttribute('role'),
+                toggleWidth: toggle.width,
+                toggleBottomGap: Math.round(window.innerHeight - toggle.bottom),
+                smallestTab: Math.min(...tabs.map(t => t.getBoundingClientRect().height)),
+                viewportWidth: window.innerWidth,
                 panelBottom: panel.bottom,
                 toggleTop: toggle.top,
                 viewportHeight: window.innerHeight,
@@ -338,19 +366,29 @@ const VIEWPORTS = [
             assert.strictEqual(controls.zoomButtons, 0, 'zoom control should be disabled');
         });
 
-        check('view toggle is horizontally centred', () => {
-            const off = Math.abs(controls.toggleCentre - controls.viewportCentre);
-            assert.ok(off <= 2, `toggle is ${off.toFixed(1)}px off centre`);
+        check('view toggle is a tab bar across the bottom', () => {
+            // Two destinations, full width, anchored to the bottom edge where
+            // the thumb rests.
+            assert.strictEqual(controls.toggleRole, 'tablist',
+                'the view switcher should expose a tablist');
+            assert.ok(controls.toggleWidth >= controls.viewportWidth - 1,
+                `tab bar is ${Math.round(controls.toggleWidth)}px of ${controls.viewportWidth}px`);
+            assert.ok(controls.toggleBottomGap <= 1,
+                `tab bar sits ${controls.toggleBottomGap}px above the bottom edge`);
+        });
+
+        check('tabs are large enough to hit', () => {
+            assert.ok(controls.smallestTab >= 44,
+                `smallest tab is ${Math.round(controls.smallestTab)}px tall`);
         });
 
         check('open panel fits the visible viewport', () => {
             // A max-height in vh is measured against the viewport with the
             // browser chrome hidden, so the panel could extend past what the
-            // user can see and clip its last line.
-            assert.ok(controls.panelBottom <= controls.viewportHeight,
+            // user can see and clip its last line. The sheet is anchored to the
+            // bottom edge, so it ends exactly there rather than above the tabs.
+            assert.ok(controls.panelBottom <= controls.viewportHeight + 1,
                 `panel ends ${Math.round(controls.panelBottom - controls.viewportHeight)}px below the fold`);
-            assert.ok(controls.panelBottom <= controls.toggleTop,
-                'panel runs underneath the floating view toggle');
         });
 
         // The list view is a normal scrolling page; the map view is not. Both
@@ -372,11 +410,24 @@ const VIEWPORTS = [
             const toggle = document.querySelector('.viewToggle').getBoundingClientRect();
             const nested = [...document.querySelectorAll('.list-view, .filter')]
                 .filter(el => el.scrollHeight > el.clientHeight + 2).length;
+            // Anything fixed that sits on top of a result is a defect.
+            let covered = 0;
+            const floating = [...document.querySelectorAll('.filterFab, .viewToggle')]
+                .filter(el => getComputedStyle(el).position === 'fixed');
+            document.querySelectorAll('.tournament-item a, .tournament-item button').forEach(el => {
+                const r = el.getBoundingClientRect();
+                if (!r.width) return;
+                if (floating.some(f => {
+                    const c = f.getBoundingClientRect();
+                    return !(r.right < c.left || r.left > c.right || r.bottom < c.top || r.top > c.bottom);
+                })) covered++;
+            });
+
             return {
-                reach, scrolled, nested,
+                reach, scrolled, nested, covered,
                 lastHiddenByToggle: last.bottom > toggle.top,
-                toggleCentre: (toggle.left + toggle.right) / 2,
-                viewportCentre: window.innerWidth / 2,
+                toggleWidth: toggle.width,
+                viewportWidth: window.innerWidth,
             };
         });
 
@@ -396,9 +447,17 @@ const VIEWPORTS = [
             assert.ok(!list.lastHiddenByToggle, 'the floating toggle covers the last result');
         });
 
-        check('view toggle stays centred in the list view', () => {
-            const off = Math.abs(list.toggleCentre - list.viewportCentre);
-            assert.ok(off <= 2, `toggle is ${off.toFixed(1)}px off centre`);
+        check('tab bar spans the list view too', () => {
+            assert.ok(list.toggleWidth >= list.viewportWidth - 1,
+                'the tab bar should stay full width in the list');
+        });
+
+        check('nothing floats over the results', () => {
+            // A control floating above a scrolling list eventually covers a
+            // link in it; measured against the real list, it covered
+            // "Auf Karte zeigen".
+            assert.strictEqual(list.covered, 0,
+                `${list.covered} interactive element(s) sit under floating chrome`);
         });
 
         await page.close();

--- a/script/main.js
+++ b/script/main.js
@@ -103,6 +103,7 @@ function closeFiltersForMapInteraction() {
 
     filterContainer.style.display = 'none';
     toggleBtn.innerHTML = 'Filter ▼';
+    syncFilterSheet(false);
 }
 
 function registerMapFilterAutoClose() {
@@ -125,6 +126,10 @@ let markerById = new Map();
 let currentView = 'map';
 
 function getTournamentsByDate(dateFrom, dateTo, compType, federations, playerLK) {
+    // On a phone the filter is a sheet covering the results, so submitting it
+    // should reveal what was just asked for.
+    closeFiltersForMapInteraction();
+
     if (dateFrom != "" && dateTo != "") {
         dateFrom = formatDateToAPI(dateFrom);
         dateTo = formatDateToAPI(dateTo);
@@ -360,6 +365,14 @@ function updateFederationCount(selected, total) {
     } else {
         el.textContent = `${selected} von ${total} Verbänden ausgewählt.`;
     }
+
+    // The same number on the filter button, so the current selection is legible
+    // on a phone without opening the sheet.
+    const badge = document.getElementById('filterFabCount');
+    if (badge) {
+        badge.textContent = String(selected);
+        badge.hidden = selected === 0;
+    }
 }
 
 // renderDataNotice surfaces stale or failed federations.
@@ -413,11 +426,32 @@ function toggleFilters() {
     const hidden = getComputedStyle(filterContainer).display === 'none';
 
     if (hidden) {
-        filterContainer.style.display = 'block';
+        // The sheet uses flex on phones, so let the stylesheet decide the value
+        // rather than pinning it to block.
+        filterContainer.style.display = '';
+        if (getComputedStyle(filterContainer).display === 'none') {
+            filterContainer.style.display = 'block';
+        }
         toggleBtn.innerHTML = 'Filter ▲';
     } else {
         filterContainer.style.display = 'none';
         toggleBtn.innerHTML = 'Filter ▼';
+    }
+
+    syncFilterSheet(hidden);
+}
+
+// Keeps the sheet's companions in step with the panel: the scrim that dims the
+// map behind it, and the button's expanded state.
+function syncFilterSheet(isOpen) {
+    const scrim = document.getElementById('sheetScrim');
+    const fab = document.getElementById('filterFab');
+
+    if (scrim) {
+        scrim.hidden = !isOpen;
+    }
+    if (fab) {
+        fab.setAttribute('aria-expanded', String(isOpen));
     }
 }
 
@@ -742,6 +776,10 @@ function setView(view) {
     listBtn.classList.toggle('active', showList);
     mapBtn.setAttribute('aria-pressed', String(!showList));
     listBtn.setAttribute('aria-pressed', String(showList));
+    // The buttons are tabs on phones, where aria-selected is what conveys the
+    // active view; aria-pressed alone would announce them as toggle buttons.
+    mapBtn.setAttribute('aria-selected', String(!showList));
+    listBtn.setAttribute('aria-selected', String(showList));
 
     if (showList) {
         renderTournamentList();


### PR DESCRIPTION
Implements **variant D** from the navigation spike.

> Note: #72 was already merged when this came in, so this is a follow-up branch off master rather than an addition to that PR.

## The change

The two views become a **bottom tab bar**. Filtering becomes a **labelled action** that raises the panel as a sheet over whichever view is open.

Desktop is untouched — everything lives inside the phone breakpoint.

## Why the filter is not a third tab

A tab bar is for **destinations**. Karte and Liste are two views of the same results; filtering is a tool applied to them.

That distinction is measurable. With the filter as a tab:

```
refine filters while reading results:
A (filter as tab)     resultsStayVisible: false   ← results disappear
D (filter as sheet)   resultsStayVisible: true
```

A tab is a whole destination, so opening it hides what you are narrowing down.

The old button also sat at **6% of screen height** — the corner hardest to reach one-handed — with a 70×30 target. The new control is 44px and sits by the thumb.

## Three things testing found, not design

**The sheet stretched to full height.** `.sideBar` sets `top: 0`; combined with `bottom: 0` that defeats `max-height` on a fixed element:

```
before:  sheet height 544px, top=0    bottom=0   → no map visible
after:   sheet height 544px, top=120  bottom=0   → 120px of map visible
```

**The floating button covered a link.** Measured against a real list:

```
interactive elements covered by the filter button: 1
  - Auf Karte zeigen
```

Anything floating over a scrolling list eventually lands on a link in it. In the list the button now joins the normal flow and scrolls with the content; only the map, which has no header, keeps a floating control. Now `0`.

**The button sat on top of its own sheet.** It hides while the sheet is open — `Fertig` and the scrim are the ways out.

Also: the tab bar is opaque by default and only translucent where `backdrop-filter` is supported, so results scrolling underneath cannot make the labels muddy. And `setView()` now sets `aria-selected` as well as `aria-pressed` — inside a tablist that is what conveys the active view.

## Verification

```
tabbar: role=tablist bottom=0px tabs=[Karte 58px selected, Liste 58px]
filterFab: visible h=44 label="Filter 3" badge=3
sheet open: top=120/664 mapVisibleAbove=true scrim=true done=true fab=hidden
after search: filter=none scrim=false
list: scrolled=true blockedByTabbar=false covered=0
errors=0
```

Layout tests updated for the new chrome and extended with six new assertions. **266 checks** across six viewports and both engines, stable across repeated runs.

Two existing assertions were relaxed deliberately, and only after checking the code was right: the sheet is anchored to the bottom edge so it no longer ends *above* the toggle, and the list fixture needed 20 results rather than 1 for the scrolling assertions to mean anything.

The spike is in `spike-nav/` with the measurements and the three rejected variants.
