### PR TITLE
fix: make the filter sheet usable and the tab bar native

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1684,7 +1684,10 @@ body.list-mode .filter {
         transform: none;
         display: grid;
         grid-template-columns: 1fr 1fr;
-        height: calc(58px + env(safe-area-inset-bottom, 0px));
+        /* iOS tab bars are 49pt tall, with the home indicator area added below
+           rather than padded inside it. Anything taller reads as a web page
+           imitating an app. */
+        height: calc(49px + env(safe-area-inset-bottom, 0px));
         padding-bottom: env(safe-area-inset-bottom, 0px);
         /* Opaque by default so results scrolling underneath never show through
            and make the labels hard to read. */
@@ -1700,11 +1703,14 @@ body.list-mode .filter {
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        gap: 3px;
+        /* 2px label gap and a 10pt caption are the platform metrics; the icon
+           carries the recognition, the label only confirms it. */
+        gap: 2px;
         min-height: 0;
-        padding: 0;
+        padding: 4px 0 0;
         font-size: 10px;
-        font-weight: 600;
+        font-weight: 500;
+        letter-spacing: 0;
         color: var(--muted);
         background: none;
         border: none;
@@ -1731,14 +1737,14 @@ body.list-mode .filter {
 
     .tabIcon {
         display: block;
-        width: 22px;
-        height: 22px;
+        width: 25px;
+        height: 25px;
     }
 
     .filterFab {
         position: fixed;
-        right: 14px;
-        bottom: calc(58px + 14px + env(safe-area-inset-bottom, 0px));
+        right: 16px;
+        bottom: calc(49px + 16px + env(safe-area-inset-bottom, 0px));
         z-index: 10002;
         display: inline-flex;
         align-items: center;
@@ -1786,6 +1792,15 @@ body.list-mode .filter {
        and the scrim are the ways out. */
     .filterFab[aria-expanded="true"] {
         display: none;
+    }
+
+    /* .sideBar carries z-index: 10000, which makes it a stacking context: its
+       children are painted inside it and can never rise above a sibling with a
+       higher z-index. The scrim therefore covered the sheet and swallowed every
+       tap meant for a filter control. Raising the sidebar itself while the
+       sheet is open lifts the whole context above the scrim. */
+    .sideBar.sheet-open {
+        z-index: 10005;
     }
 
     /* The filter panel becomes a sheet: anchored to the bottom edge, with the
@@ -1855,7 +1870,7 @@ body.list-mode .filter {
 
     /* Only the tab bar overlays the list now. */
     body.list-mode .list-view {
-        padding-bottom: calc(76px + env(safe-area-inset-bottom, 0px));
+        padding-bottom: calc(65px + env(safe-area-inset-bottom, 0px));
     }
 
     body.list-mode .viewToggle {
@@ -1871,6 +1886,6 @@ body.list-mode .filter {
 
     /* The attribution sits above the tab bar rather than behind it. */
     .leaflet-bottom.leaflet-right .leaflet-control-attribution {
-        margin-bottom: calc(58px + env(safe-area-inset-bottom, 0px));
+        margin-bottom: calc(49px + env(safe-area-inset-bottom, 0px));
     }
 }

--- a/script/layout.test.js
+++ b/script/layout.test.js
@@ -157,10 +157,16 @@ const VIEWPORTS = [
     for (const [name, width, height] of VIEWPORTS) {
         console.log(`\n[${engine}] ${name} (${width}x${height})`);
 
-        // WebKitGTK rejects the mobile emulation flags Chromium accepts.
-        const page = await browser.newPage(engine === 'webkit'
-            ? { viewport: { width, height }, hasTouch: true }
-            : { viewport: { width, height }, isMobile: true, hasTouch: true });
+        // A fresh context per viewport. browser.newPage() reuses the default
+        // context, so the service worker registered by one run served cached
+        // responses to the next; under WebKit that produced failures which
+        // accumulated across viewports and looked like flakiness.
+        //
+        // WebKitGTK also rejects the mobile emulation flags Chromium accepts.
+        const context = await browser.newContext(engine === 'webkit'
+            ? { viewport: { width, height }, hasTouch: true, serviceWorkers: 'block' }
+            : { viewport: { width, height }, isMobile: true, hasTouch: true, serviceWorkers: 'block' });
+        const page = await context.newPage();
         await page.route('**/ttf**', r =>
             r.fulfill({ status: 200, contentType: 'application/json', body: RESPONSE }));
         await page.route('**tile**', r =>
@@ -189,8 +195,21 @@ const VIEWPORTS = [
             () => getComputedStyle(document.getElementById('filterContainer')).display);
 
         // The filter action moved out of the title row into its own control.
+        //
+        // The panel must be closed before this taps to open it. The initial
+        // load renders asynchronously, and on a slow run the auto-close had not
+        // yet applied when the tap landed, so the tap closed the panel instead
+        // and every following assertion failed. Waiting for the known start
+        // state removes the race rather than papering over it with a delay.
+        await page.waitForFunction(
+            () => getComputedStyle(document.getElementById('filterContainer')).display === 'none',
+            null, { timeout: 5000 }).catch(() => {});
+
         await page.click('#filterFab', { force: true });
-        await page.waitForTimeout(350);
+        await page.waitForFunction(
+            () => getComputedStyle(document.getElementById('filterContainer')).display !== 'none',
+            null, { timeout: 5000 }).catch(() => {});
+        await page.waitForTimeout(200);
         const filterAfterFirstTap = await page.evaluate(
             () => getComputedStyle(document.getElementById('filterContainer')).display);
 
@@ -199,12 +218,80 @@ const VIEWPORTS = [
             const rect = panel.getBoundingClientRect();
             const scrim = document.getElementById('sheetScrim');
             const fab = document.getElementById('filterFab');
+
+            // Visibility is not usability: the sheet was fully rendered while
+            // the scrim sat on top of it and swallowed every tap. Only
+            // elementFromPoint reveals that.
+            const unreachable = [];
+            let probed = 0;
+            ['#dateFrom', '#dateTo', '#compType', '#playerLK', '.sheetDone', '.checkboxLabel']
+                .forEach(sel => {
+                    const el = document.querySelector(sel);
+                    if (!el) return;
+                    const b = el.getBoundingClientRect();
+                    // Off-screen controls cannot be probed, but they must not
+                    // silently reduce this to a no-op either: `probed` is
+                    // asserted separately.
+                    if (!b.width || b.top < 0 || b.bottom > window.innerHeight) return;
+                    probed++;
+                    const hit = document.elementFromPoint(b.left + b.width / 2, b.top + b.height / 2);
+                    // A label wrapping its input counts as reached; an overlay
+                    // in front of it does not.
+                    if (!(hit === el || el.contains(hit))) {
+                        unreachable.push(`${sel} blocked by ${(hit && (hit.id || hit.className)) || 'nothing'}`);
+                    }
+                });
+
+            // The tab bar must not float above the sheet that covers it.
+            const tabbar = document.querySelector('.viewToggle').getBoundingClientRect();
+            const atTabbar = document.elementFromPoint(tabbar.left + 40, tabbar.top + tabbar.height / 2);
+            const tabbarOnTop = !!(atTabbar && atTabbar.nodeType === 1 && atTabbar.closest('.viewToggle'));
+
             return {
                 topGap: Math.round(rect.top),
                 scrimShown: scrim ? !scrim.hidden : false,
                 fabHidden: getComputedStyle(fab).display === 'none',
                 doneVisible: !!document.querySelector('.sheetDone'),
+                unreachable,
+                probed,
+                tabbarOnTop,
             };
+        });
+
+        check('sheet controls actually receive taps', () => {
+            // .sideBar carries a z-index, making it a stacking context: its
+            // children cannot paint above a sibling scrim however high their
+            // own z-index. Every control was rendered and visible but dead,
+            // which is why a visibility-only assertion missed it.
+            //
+            // The probe count is asserted too: if the sheet fails to open, its
+            // controls fall outside the viewport and this would otherwise pass
+            // by examining nothing.
+            assert.ok(sheet.probed >= 3,
+                `only ${sheet.probed} control(s) on screen; the sheet did not open`);
+            assert.strictEqual(sheet.unreachable.length, 0,
+                `unreachable: ${sheet.unreachable.join('; ')}`);
+        });
+
+        check('tab bar does not float above the open sheet', () => {
+            assert.ok(!sheet.tabbarOnTop,
+                'the tab bar paints over the sheet that covers it');
+        });
+
+        check('open sheet leaves the map visible above it', () => {
+            // A sheet filling the screen is a full-page takeover; keeping the
+            // map in view is what makes filtering feel in-context.
+            assert.ok(sheet.topGap > 40,
+                `sheet starts ${sheet.topGap}px from the top, covering the view`);
+        });
+
+        check('sheet dims the map and offers a way out', () => {
+            assert.ok(sheet.scrimShown, 'scrim should be shown behind the sheet');
+            assert.ok(sheet.doneVisible, 'sheet needs its own dismiss control');
+        });
+
+        check('filter button hides while its sheet is open', () => {
+            assert.ok(sheet.fabHidden, 'the filter button overlaps the open sheet');
         });
 
         await page.evaluate(() => {
@@ -353,6 +440,9 @@ const VIEWPORTS = [
                 toggleWidth: toggle.width,
                 toggleBottomGap: Math.round(window.innerHeight - toggle.bottom),
                 smallestTab: Math.min(...tabs.map(t => t.getBoundingClientRect().height)),
+                tabHeight: tabs[0].getBoundingClientRect().height,
+                iconSize: (document.querySelector('.tabIcon') || { getBoundingClientRect: () => ({ height: 0 }) })
+                    .getBoundingClientRect().height,
                 viewportWidth: window.innerWidth,
                 panelBottom: panel.bottom,
                 toggleTop: toggle.top,
@@ -380,6 +470,16 @@ const VIEWPORTS = [
         check('tabs are large enough to hit', () => {
             assert.ok(controls.smallestTab >= 44,
                 `smallest tab is ${Math.round(controls.smallestTab)}px tall`);
+        });
+
+        check('tab bar uses native metrics', () => {
+            // iOS tab bars are 49pt with the home indicator area added below,
+            // not padded inside. A taller bar reads as a web page imitating an
+            // app, and leaves a dead gap under the labels.
+            assert.ok(controls.tabHeight <= 52,
+                `tabs are ${Math.round(controls.tabHeight)}px tall, above the 49pt platform metric`);
+            assert.ok(controls.iconSize >= 24 && controls.iconSize <= 28,
+                `tab icons are ${Math.round(controls.iconSize)}px, outside the 25pt convention`);
         });
 
         check('open panel fits the visible viewport', () => {
@@ -461,6 +561,7 @@ const VIEWPORTS = [
         });
 
         await page.close();
+        await context.close();
     }
     await browser.close();
     }

--- a/script/main.js
+++ b/script/main.js
@@ -446,12 +446,20 @@ function toggleFilters() {
 function syncFilterSheet(isOpen) {
     const scrim = document.getElementById('sheetScrim');
     const fab = document.getElementById('filterFab');
+    const sideBar = document.querySelector('.sideBar');
 
     if (scrim) {
         scrim.hidden = !isOpen;
     }
     if (fab) {
         fab.setAttribute('aria-expanded', String(isOpen));
+    }
+    // .sideBar has a z-index of its own, which makes it a stacking context: the
+    // sheet inside it cannot paint above the scrim no matter what z-index the
+    // sheet is given. Raising the whole sidebar is what actually lifts it.
+    // Mirrors the :has() rule for engines that lack it.
+    if (sideBar) {
+        sideBar.classList.toggle('sheet-open', isOpen);
     }
 }
 


### PR DESCRIPTION
All three reported from the device. The second one was the serious one.

## 1. The sheet was unusable behind the scrim

`.sideBar` carries `z-index: 10000`, which makes it a **stacking context**. Its children are painted inside it and cannot rise above a sibling with a higher z-index — no matter what z-index they are given themselves.

The sheet lives inside `.sideBar`; the scrim sits outside it at `10003`. So the scrim covered the sheet and swallowed every tap:

```
#dateFrom       blocked by sheetScrim
#dateTo         blocked by sheetScrim
#compType       blocked by sheetScrim
#playerLK       blocked by sheetScrim
.sheetDone      blocked by sheetScrim
.checkboxLabel  blocked by sheetScrim
```

Raising `.sideBar` itself while the sheet is open lifts the whole context above the scrim.

**This is also your third point.** The tab bar was not *on top of* the sheet — the sheet was *below the scrim*, along with everything else. One cause, two symptoms.

## 2. The tab bar was too tall

It was `58px` plus the safe-area inset. iOS tab bars are **49pt**, with the home indicator area added *below* rather than padded inside — which is exactly the "too much space to the bottom" you saw.

```
before:  bar 58px + inset,  icons 22px,  gap 3px
after:   bar 49px + inset,  icons 25px,  gap 2px,  label 10pt
```

## Two testing problems this exposed — both real

**The suite asserted the sheet was *visible*, never that it could be *used*.** Different questions; only `elementFromPoint` answers the second. It now probes every control in the open sheet — and asserts the probe count too, so a sheet that fails to open cannot pass by examining nothing.

**The suite used `browser.newPage()`,** which reuses the default context. The service worker registered by one viewport then served cached responses to the next. Under WebKit this produced failures that *accumulated across viewports*:

```
run 1: fail=10
run 2: fail=15
run 3: fail=20
```

That looked like flakiness and was not — it was stale cached HTML. Each viewport now gets its own context with service workers blocked.

## Verification

Mutation-tested rather than assumed. Reverting the stacking fix:

```
FAIL sheet controls actually receive taps
     unreachable: #dateFrom blocked by sheetScrim; #dateTo blocked by
     sheetScrim; #compType blocked by sheetScrim; ...
```

A 72px bar:

```
FAIL tab bar uses native metrics
     tabs are 72px tall, above the 49pt platform metric
```

**338 checks** across six viewports and both engines, `fail=0` on three consecutive runs.
