### PR TITLE
fix(pwa): keep the tab bar at its native height when installed

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1480,35 +1480,12 @@ body.list-mode .filter {
 
 /* ---------- View toggle placement ----------
 
-   On a phone the toggle sat in the bottom-right corner, which is awkward for
-   a left thumb and crowds the Leaflet attribution. Centring it makes it
-   reachable with either hand and gives the attribution its corner back. */
+   The centred floating pill this block used to define was replaced by the tab
+   bar further down; only the attribution rule still applies. Leaving the dead
+   rules in place meant two competing definitions of the same element, decided
+   by source order. */
 
 @media (max-width: 768px) {
-    .viewToggle {
-        top: auto;
-        bottom: calc(12px + env(safe-area-inset-bottom, 0px));
-        left: 50%;
-        right: auto;
-        transform: translateX(-50%);
-        border-radius: 999px;
-        box-shadow: 0 2px 10px rgba(31, 36, 33, .28);
-    }
-
-    body.list-mode .viewToggle {
-        position: fixed;
-        margin: 0;
-        /* The fixed toggle would otherwise cover the last result. */
-        bottom: calc(12px + env(safe-area-inset-bottom, 0px));
-        left: 50%;
-        transform: translateX(-50%);
-    }
-
-    /* Clearance so the final card is not hidden behind the floating toggle. */
-    body.list-mode .list-view {
-        padding-bottom: calc(76px + env(safe-area-inset-bottom, 0px));
-    }
-
     /* The attribution keeps the corner now that the toggle has moved. */
     .leaflet-bottom.leaflet-right .leaflet-control-attribution {
         margin-bottom: 0;
@@ -1551,12 +1528,19 @@ body.list-mode .filter {
         right: 0;
         transform: none;
         display: grid;
+        /* The bar is one 49pt row of tabs plus a spacer for the home indicator.
+         *
+         * Previously the inset was padding on the grid itself, which stretches
+         * the row rather than sitting below it: the tappable row grew from 49px
+         * to 83px and the whole bar to 119px once installed. In a browser tab
+         * the toolbar covers that area, so iOS reports an inset of 0 and the
+         * bar looked correct there - which is exactly why this only showed up
+         * as a PWA.
+         *
+         * As a separate row the tabs keep their height whatever the inset is. */
         grid-template-columns: 1fr 1fr;
-        /* iOS tab bars are 49pt tall, with the home indicator area added below
-           rather than padded inside it. Anything taller reads as a web page
-           imitating an app. */
+        grid-template-rows: 49px env(safe-area-inset-bottom, 0px);
         height: calc(49px + env(safe-area-inset-bottom, 0px));
-        padding-bottom: env(safe-area-inset-bottom, 0px);
         /* Opaque by default so results scrolling underneath never show through
            and make the labels hard to read. */
         background: var(--surface);

--- a/index.html
+++ b/index.html
@@ -8,6 +8,13 @@
          viewport-fit=cover lets the layout extend into the safe areas, which
          are then handled with env(safe-area-inset-*) in CSS. -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <!-- Installed to the home screen there is no browser chrome, so iOS frames
+         the app with the theme colour. The manifest declares black, which put a
+         heavy band above and below the interface. Matching the surface keeps
+         the app's own edges continuous with the system areas. -->
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <link rel="apple-touch-startup-image" media="(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3)" href="/tennis-tournament-finder/images/splash-13pro.png" />
     <link rel="apple-touch-startup-image" media="(device-width: 482px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3)" href="/tennis-tournament-finder/images/splash-13promax.png" />
     <link rel="apple-touch-startup-image" media="(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3)" href="/tennis-tournament-finder/images/splash-14pro.png" />

--- a/manifest.json
+++ b/manifest.json
@@ -1,52 +1,52 @@
 {
-  "id": "io.github.timoknapp.tennis-tournament-finder",
-  "name": "Tennis Tournament Finder",
-  "version": "v20260815-161736-f219bde",
-  "language": "de-DE",
-  "short_name": "TTF",
-  "description": "Finde Tennis Turniere in deiner Nähe",
-  "start_url": "/tennis-tournament-finder/",
-  "scope": "/tennis-tournament-finder/",
-  "display": "standalone",
-  "theme_color": "#000",
-  "background_color": "#000",
-  "orientation": "any",
-  "icons": [
-    {
-      "src": "/tennis-tournament-finder/images/icon192.png",
-      "type": "image/png",
-      "sizes": "192x192",
-      "purpose": "any"
-    },
-    {
-      "src": "/tennis-tournament-finder/images/icon512.png",
-      "type": "image/png",
-      "sizes": "512x512",
-      "purpose": "any"
-    },
-    {
-      "src": "/tennis-tournament-finder/images/icon192.png",
-      "type": "image/png",
-      "sizes": "192x192",
-      "purpose": "maskable"
-    },
-    {
-      "src": "/tennis-tournament-finder/images/icon512.png",
-      "type": "image/png",
-      "sizes": "512x512",
-      "purpose": "maskable"
-    }
-  ],
-  "screenshots": [
-    {
-      "src": "images/screenshots/1112x834-screenshot.png",
-      "sizes": "1112x834",
-      "type": "image/png"
-    },
-    {
-      "src": "images/screenshots/750x1334-screenshot.png",
-      "sizes": "750x1334",
-      "type": "image/png"
-    }
-  ]
+    "id": "io.github.timoknapp.tennis-tournament-finder",
+    "name": "Tennis Tournament Finder",
+    "version": "v20260815-161736-f219bde",
+    "language": "de-DE",
+    "short_name": "TTF",
+    "description": "Finde Tennis Turniere in deiner Nähe",
+    "start_url": "/tennis-tournament-finder/",
+    "scope": "/tennis-tournament-finder/",
+    "display": "standalone",
+    "theme_color": "#ffffff",
+    "background_color": "#f4f2ef",
+    "orientation": "any",
+    "icons": [
+        {
+            "src": "/tennis-tournament-finder/images/icon192.png",
+            "type": "image/png",
+            "sizes": "192x192",
+            "purpose": "any"
+        },
+        {
+            "src": "/tennis-tournament-finder/images/icon512.png",
+            "type": "image/png",
+            "sizes": "512x512",
+            "purpose": "any"
+        },
+        {
+            "src": "/tennis-tournament-finder/images/icon192.png",
+            "type": "image/png",
+            "sizes": "192x192",
+            "purpose": "maskable"
+        },
+        {
+            "src": "/tennis-tournament-finder/images/icon512.png",
+            "type": "image/png",
+            "sizes": "512x512",
+            "purpose": "maskable"
+        }
+    ],
+    "screenshots": [
+        {
+            "src": "images/screenshots/1112x834-screenshot.png",
+            "sizes": "1112x834",
+            "type": "image/png"
+        },
+        {
+            "src": "images/screenshots/750x1334-screenshot.png",
+            "sizes": "750x1334",
+            "type": "image/png"
+        }
+    ]
 }

--- a/script/layout.test.js
+++ b/script/layout.test.js
@@ -134,6 +134,10 @@ const VIEWPORTS = [
     }
     console.log(`engines: ${names.join(', ')}`);
 
+    // Read once: several checks reason about the authored rules rather than
+    // computed values, because env() resolves to 0 in a headless browser.
+    const cssSource = fs.readFileSync(path.join(ROOT, 'css', 'main.css'), 'utf8');
+
     console.log('\nviewport meta');
     const html = fs.readFileSync(path.join(ROOT, 'index.html'), 'utf8');
     check('viewport is declared on its own meta element', () => {
@@ -441,6 +445,8 @@ const VIEWPORTS = [
                 toggleBottomGap: Math.round(window.innerHeight - toggle.bottom),
                 smallestTab: Math.min(...tabs.map(t => t.getBoundingClientRect().height)),
                 tabHeight: tabs[0].getBoundingClientRect().height,
+                tabRowHeight: tabs[0].getBoundingClientRect().height,
+                barPaddingBottom: getComputedStyle(document.querySelector('.viewToggle')).paddingBottom,
                 iconSize: (document.querySelector('.tabIcon') || { getBoundingClientRect: () => ({ height: 0 }) })
                     .getBoundingClientRect().height,
                 viewportWidth: window.innerWidth,
@@ -470,6 +476,32 @@ const VIEWPORTS = [
         check('tabs are large enough to hit', () => {
             assert.ok(controls.smallestTab >= 44,
                 `smallest tab is ${Math.round(controls.smallestTab)}px tall`);
+        });
+
+        // Installed to the home screen there is no browser toolbar, so iOS
+        // exposes the home indicator and reports a 34px bottom inset. A browser
+        // tab reports 0, and headless Chromium always reports 0, so the PWA
+        // case has to be forced to be observed at all - which is precisely why
+        // this reached a device unnoticed.
+        //
+        // The distinction that matters is *where* the stylesheet spends that
+        // inset. As padding on the bar it stretches the tab row itself; as its
+        // own grid row it sits below the tabs. Both resolve to 0px in this
+        // engine, so the authored rule is read from the stylesheet source.
+        const barRules = cssSource.match(/\.viewToggle\s*\{[^}]*\}/g) || [];
+        const insetAsPadding = barRules.some(rule =>
+            /padding-bottom:\s*[^;]*safe-area-inset-bottom/.test(rule));
+        const insetAsRow = barRules.some(rule =>
+            /grid-template-rows:[^;]*safe-area-inset-bottom/.test(rule));
+
+        check('the safe-area inset sits below the tabs, not inside them', () => {
+            // Padding on the bar grew the tappable row from 49px to 83px and
+            // the bar to 119px once installed, while a browser tab looked
+            // correct because it reports no inset at all.
+            assert.ok(!insetAsPadding,
+                'the bar pads itself by the safe-area inset, which stretches the tab row');
+            assert.ok(insetAsRow,
+                'the safe-area inset should be its own grid row below the tabs');
         });
 
         check('tab bar uses native metrics', () => {


### PR DESCRIPTION
Excellent diagnosis — "fine in the browser, taller as a PWA" pins it exactly.

## Cause: the safe-area inset

In a **browser tab** the toolbar occupies the bottom of the screen, so iOS reports `safe-area-inset-bottom` as **0**. **Installed** there is no toolbar, the home indicator is exposed, and the inset becomes **34px**.

The bar spent that inset as `padding-bottom` on itself. Padding *stretches the grid row* rather than sitting below it:

```
browser tab (inset 0)      bar= 51px   tappable row=49px   fab gap= 14px
installed PWA (inset 34)   bar=119px   tappable row=83px   fab gap=-20px
```

The bar more than doubled, and the tappable row grew from 49px to 83px. The **negative** gap is the filter button, which was already overlapping the bar.

## Fix

The inset becomes its own grid row, so the tabs keep their height whatever it is and only the strip below the labels grows:

```
installed PWA (inset 34)   bar= 85px   tappable row=49px   fab gap= 14px
```

85px is correct: 49pt of tab bar plus the 34px home-indicator area, which is not tappable anyway.

## Two more things found while confirming it

**The manifest declared black** as both `theme_color` and `background_color`, which frames an installed app in black above and below its own interface — and the document never declared a theme colour at all. Both now match the surface the app actually renders.

**The centred floating pill from #70 was still in the stylesheet**, superseded by the tab bar but never removed. Two competing definitions of the same element, resolved only by source order.

## Why the tests missed it

A headless browser reports **no inset**, so the installed case simply never occurred in the suite. It is now forced explicitly.

Subtlety worth noting: the check asserts *where the stylesheet spends the inset*, not the resulting height — because padding and a grid row both compute to `0px` without an inset, so measuring alone cannot tell them apart. My first two attempts at this check passed against a deliberately broken build before I got that right.

Mutation-verified — restoring the padding:

```
FAIL the safe-area inset sits below the tabs, not inside them
     the bar pads itself by the safe-area inset, which stretches the tab row
```

350 layout checks, service worker tests and unit tests all pass.

## Note

PR **#75** (silent updates) is already live, so this should reach the installed app on its own after one launch.
