### PR TITLE
fix(mobile): centre the header title

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1709,6 +1709,15 @@ body.list-mode .filter {
        that the action has its own control near the thumb. */
     .filterToggleBtn { display: none; }
 
+    /* With that button gone the row holds one item, but space-between still
+       pushed it to the left edge as though something sat opposite it. On a
+       phone the app name is the only thing in the bar, so it is centred like a
+       native navigation title. */
+    .sideBar .title {
+        justify-content: center;
+        text-align: center;
+    }
+
     /* Anything floating over a scrolling list eventually sits on top of a link
        in it; measured against the real list, it covered "Auf Karte zeigen".
        The map needs a floating control because it has no header to put one in,

--- a/script/layout.test.js
+++ b/script/layout.test.js
@@ -440,6 +440,16 @@ const VIEWPORTS = [
             const tabs = [...document.querySelectorAll('.viewToggleBtn')];
             return {
                 zoomButtons: document.querySelectorAll('.leaflet-control-zoom').length,
+                titleCentre: (() => {
+                    const title = document.querySelector('.sideBarElement.title');
+                    // Measure the text node: the row spans the full width, so
+                    // its own box says nothing about where the words sit.
+                    const range = document.createRange();
+                    range.setStart(title.firstChild, 0);
+                    range.setEnd(title.firstChild, title.firstChild.length);
+                    const box = range.getBoundingClientRect();
+                    return (box.left + box.right) / 2;
+                })(),
                 toggleRole: document.querySelector('.viewToggle').getAttribute('role'),
                 toggleWidth: toggle.width,
                 toggleBottomGap: Math.round(window.innerHeight - toggle.bottom),
@@ -454,6 +464,15 @@ const VIEWPORTS = [
                 toggleTop: toggle.top,
                 viewportHeight: window.innerHeight,
             };
+        });
+
+        check('header title is centred', () => {
+            // The row keeps space-between for the desktop layout, where a
+            // filter button sits opposite the title. That button is hidden on a
+            // phone, so the title was pushed to the left edge as though
+            // something still sat across from it.
+            const off = Math.abs(controls.titleCentre - controls.viewportWidth / 2);
+            assert.ok(off <= 4, `title is ${off.toFixed(0)}px off centre`);
         });
 
         check('map has no zoom buttons', () => {


### PR DESCRIPTION
The title row uses `space-between` so the filter button can sit opposite the app name on desktop. That button is **hidden on a phone** — the filter has its own control near the thumb — but `space-between` still pushed the remaining item to the left edge, as though something sat across from it.

On a phone the app name is the only thing in the bar, so it is centred like a native navigation title.

```
iPhone 12  text centre 195, row centre 195, off 0px
iPhone SE  text centre 187, row centre 188, off 1px
desktop    unchanged, left aligned in the panel
```

Desktop is untouched: there the header belongs to the filter panel and its button is still present.

## Test

The check measures the **text node**, not the row — the row spans the full width and says nothing about where the words sit.

Mutation-verified — without the rule:

```
FAIL header title is centred
     title is 84px off centre
```

362 layout checks pass; unit tests unaffected.
