### PR TITLE
feat(geocoding): surface clubs that could not be placed (#55)

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -100,6 +100,10 @@ func main() {
 	diagMux.Handle(metrics.StatsPath, http.HandlerFunc(metrics.StatsHandler))
 	diagMux.Handle(metrics.DebugVarsPath, expvar.Handler())
 	diagMux.Handle(metrics.EnvPath, http.HandlerFunc(metrics.EnvHandler))
+	// Clubs whose location could not be determined, with paste-ready overrides
+	// for club-locations.json. Wrong pins are otherwise invisible: a tournament
+	// sitting in the middle of a state looks like a working map.
+	diagMux.Handle(metrics.UnresolvedClubsPath, http.HandlerFunc(metrics.UnresolvedClubsHandler))
 	diagAddr := "127.0.0.1:9090"
 	diagServer := newServer(diagAddr, diagMux)
 

--- a/backend/cmd/pincheck/main.go
+++ b/backend/cmd/pincheck/main.go
@@ -66,12 +66,8 @@ func main() {
 	fmt.Fprintf(os.Stderr, "Checking %s .. %s across %d federations (this is rate limited, please wait)\n\n",
 		dateFrom, dateTo, len(selected))
 
-	// Index federations so a tournament's pin can be compared against the
-	// federation default it would fall back to.
-	defaults := make(map[string]models.Geocoordinates, len(selected))
 	states := make(map[string]string, len(selected))
 	for _, fed := range selected {
-		defaults[fed.Id] = fed.Geocoordinates
 		states[fed.Id] = fed.State
 	}
 
@@ -86,12 +82,15 @@ func main() {
 			continue
 		}
 
-		def := defaults[fed.Id]
 		for _, t := range tournaments {
 			total++
-			// A tournament pinned exactly at the federation default did not
-			// resolve to a real place.
-			if t.Lat != def.Lat || t.Lon != def.Lon {
+			// Comparing against the federation default used to stand in for
+			// "did not resolve", but several defaults sit exactly on a major
+			// city: the BTV default is München and the WTV default is Dortmund,
+			// to seven decimal places. Clubs in those cities geocoded correctly
+			// and were still reported as failures, which was 17 of the 32 hits
+			// in a live sweep. The parser now records the outcome directly.
+			if !t.ApproximateLocation {
 				continue
 			}
 

--- a/backend/pkg/clublocations/clublocations_test.go
+++ b/backend/pkg/clublocations/clublocations_test.go
@@ -250,3 +250,56 @@ func TestOverrideNotesAreDocumented(t *testing.T) {
 		check(o)
 	}
 }
+
+// TestOverridesForReportedClubs pins the entries added after a live sweep found
+// them falling back to their federation's default pin. Each name here was
+// observed in production data, so a regression in matching would put real
+// tournaments back in the middle of a state.
+func TestOverridesForReportedClubs(t *testing.T) {
+	table, err := Default()
+	if err != nil {
+		t.Fatalf("loading the default table failed: %v", err)
+	}
+
+	cases := []struct {
+		organizer string
+		wantCity  string
+	}{
+		{"Tus Berne e.V. Tennisabteilung", "Hamburg"},
+		{"Tennisclub Ellerbek e.V.", "Ellerbek"},
+		{"ETUF Tennisriege", "Essen"},
+		{"TSV Neuenkirchen (SFA)", "Neuenkirchen"},
+		{"Tennisclub am Falkenberg", "Norderstedt"},
+		{"Gemünden", "Gemünden am Main"},
+		{"TC Viktoria", "Köln"},
+	}
+
+	for _, tc := range cases {
+		override, ok := table.Lookup(tc.organizer)
+		if !ok {
+			t.Errorf("%q has no override; it will fall back to the federation default", tc.organizer)
+			continue
+		}
+		if override.City != tc.wantCity {
+			t.Errorf("%q resolved to %q, want %q", tc.organizer, override.City, tc.wantCity)
+		}
+	}
+}
+
+// TestAmbiguousNamesAreNotGuessed guards a decision rather than behaviour.
+//
+// "Neustadt" was reported by the same sweep, but Bavaria has several: Neustadt
+// an der Aisch, Neustadt an der Donau and Neustadt bei Coburg all match. A
+// wrong pin is worse than an obvious fallback, because it looks resolved, so
+// the entry was deliberately left out until the actual club is known.
+func TestAmbiguousNamesAreNotGuessed(t *testing.T) {
+	table, err := Default()
+	if err != nil {
+		t.Fatalf("loading the default table failed: %v", err)
+	}
+
+	if override, ok := table.Lookup("Neustadt"); ok {
+		t.Errorf("an override for the ambiguous name Neustadt was added (city %q); "+
+			"confirm which Neustadt the club plays in first", override.City)
+	}
+}

--- a/backend/pkg/clublocations/data/README.md
+++ b/backend/pkg/clublocations/data/README.md
@@ -1,0 +1,49 @@
+# Correcting a map pin
+
+Federations publish a club name and nothing else. Most names contain a usable
+place ("TC Karlsruhe"); some do not ("Lohausener Sport-Verein"). When no place
+can be extracted, the tournament is pinned at the middle of the federation's
+state, which looks like a working map rather than a failure.
+
+`club-locations.json` is where those are corrected, without touching any code.
+
+## Finding what needs fixing
+
+The running service records every club it could not place:
+
+    curl -s http://127.0.0.1:9090/stats/unresolved-clubs | jq
+
+The response includes `club_locations_stubs`, which are entries ready to paste
+into this file with the city left as `TODO`. It is bound to the diagnostics
+port, which listens on localhost only.
+
+For a deliberate sweep rather than whatever the service happened to serve:
+
+    go run ./cmd/pincheck -days 45          # table of affected clubs
+    go run ./cmd/pincheck -days 45 -json    # the same as override stubs
+
+That makes live requests and is rate limited by Nominatim, so a full run across
+all federations takes a while. It is never run by CI.
+
+## Writing an entry
+
+    {
+      "contains": "Lohausener Sport-Verein",
+      "city": "Düsseldorf",
+      "state": "Nordrhein-Westfalen",
+      "note": "Lohausen is a district of Düsseldorf; not derivable from the name."
+    }
+
+* `contains` matches anywhere in the organizer name; `match` compares the whole
+  string. Both ignore case, punctuation and extra spaces.
+* Exact matches win over `contains`; among `contains` entries the longest
+  pattern wins, so a specific rule beats a generic one.
+* Prefer `city`, which is geocoded like any other place name. Use `lat`/`lon`
+  only when even the city is ambiguous.
+* `state` restricts the geocoding result and is worth setting whenever the same
+  place name exists in several states.
+* Write a `note` saying *why* the name is not resolvable. The next person
+  cannot tell a district from a typo without it.
+
+Leave the city as `TODO` rather than guessing: a wrong pin is worse than an
+obvious gap, because it looks resolved.

--- a/backend/pkg/clublocations/data/club-locations.json
+++ b/backend/pkg/clublocations/data/club-locations.json
@@ -57,6 +57,48 @@
       "city": "Sankt Leon-Rot",
       "state": "Baden-Württemberg",
       "note": "The club name carries the district 'Rot' only; the municipality is Sankt Leon-Rot, so nothing usable can be derived from the name."
+    },
+    {
+      "contains": "Tus Berne",
+      "city": "Hamburg",
+      "state": "Hamburg",
+      "note": "Berne is a district of Hamburg; the club's courts are at Alter Berner Weg, Sasel. The name reads as the Lower Saxony municipality Berne otherwise."
+    },
+    {
+      "contains": "Tennisclub Ellerbek",
+      "city": "Ellerbek",
+      "state": "Schleswig-Holstein",
+      "note": "Ellerbek in Kreis Pinneberg, confirmed by the club's address at Dubenhorst 7. There is also an Ellerbek district in Kiel."
+    },
+    {
+      "contains": "ETUF",
+      "city": "Essen",
+      "state": "Nordrhein-Westfalen",
+      "note": "ETUF is the Essener Turn- und Fechtclub; the abbreviation carries no place name at all."
+    },
+    {
+      "contains": "TSV Neuenkirchen",
+      "city": "Neuenkirchen",
+      "state": "Niedersachsen",
+      "note": "The '(SFA)' suffix is the old Soltau-Fallingbostel district, now Heidekreis. Several places are called Neuenkirchen, so the state alone is not enough."
+    },
+    {
+      "contains": "Tennisclub am Falkenberg",
+      "city": "Norderstedt",
+      "state": "Schleswig-Holstein",
+      "note": "Falkenberg is the neighbourhood, not the municipality: the club is at Am Exerzierplatz 30 in Norderstedt. Geocoding the name lands 100km away near Schleswig."
+    },
+    {
+      "contains": "Gemünden",
+      "city": "Gemünden am Main",
+      "state": "Bayern",
+      "note": "Several places are called Gemünden; the Bavarian tennis one is Gemünden am Main."
+    },
+    {
+      "contains": "TC Viktoria",
+      "city": "Köln",
+      "state": "Nordrhein-Westfalen",
+      "note": "TVM covers Köln and the club there is Tennisclub Viktoria Köln (Höhenberger Ring). Note a Tennisclub FC Viktoria 09 also exists in St. Ingbert, Saarland, so this entry is federation-specific."
     }
   ]
 }

--- a/backend/pkg/federation/federations_test.go
+++ b/backend/pkg/federation/federations_test.go
@@ -191,3 +191,38 @@ func contains(list []string, want string) bool {
 	}
 	return false
 }
+
+// TestDefaultsCollidingWithCitiesAreDocumented records a trap rather than a
+// requirement.
+//
+// A federation's default coordinates are its fallback for tournaments whose
+// location cannot be determined. Several of those defaults sit exactly on a
+// major city: BTV's is München and WTV's is Dortmund, to seven decimal places.
+//
+// That means a club in München geocodes correctly and still lands on the exact
+// coordinates BTV uses when it fails. Any code that infers "this did not
+// resolve" by comparing against the default will report those clubs as broken.
+// A live sweep did exactly that: 17 of 32 reported failures were tournaments
+// that had resolved perfectly well.
+//
+// The fix is to record the outcome where it is known, which is what
+// models.Tournament.ApproximateLocation now does. This test exists so the next
+// person meeting the same idea finds the reason it does not work.
+func TestDefaultsCollidingWithCitiesAreDocumented(t *testing.T) {
+	// Verified against Nominatim; the value is the city each default lands on.
+	knownCollisions := map[string]string{
+		"BTV": "München",
+		"WTV": "Dortmund",
+	}
+
+	byID := make(map[string]bool)
+	for _, fed := range GetFederations() {
+		byID[fed.Id] = true
+	}
+
+	for id := range knownCollisions {
+		if !byID[id] {
+			t.Errorf("federation %s disappeared; re-check whether the collision note still applies", id)
+		}
+	}
+}

--- a/backend/pkg/metrics/unresolved.go
+++ b/backend/pkg/metrics/unresolved.go
@@ -1,0 +1,88 @@
+package metrics
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/timoknapp/tennis-tournament-finder/pkg/unresolved"
+)
+
+// UnresolvedClubsPath serves the clubs whose location could not be determined.
+const UnresolvedClubsPath = "/stats/unresolved-clubs"
+
+// unresolvedResponse is the shape served at UnresolvedClubsPath.
+type unresolvedResponse struct {
+	// Count is the number of distinct clubs currently recorded.
+	Count int `json:"count"`
+	// Dropped is non-zero when the registry filled up, meaning the list is
+	// incomplete. Surfaced rather than hidden so a truncated list is never
+	// mistaken for a short one.
+	Dropped int `json:"dropped,omitempty"`
+	// Clubs is ordered by how many tournaments each one affects.
+	Clubs []unresolved.Entry `json:"clubs"`
+	// Stubs are ready to paste into club-locations.json, with the city left as
+	// TODO so it has to be filled in deliberately rather than guessed.
+	Stubs []stub `json:"club_locations_stubs"`
+}
+
+// stub mirrors an entry in club-locations.json.
+type stub struct {
+	Contains string `json:"contains"`
+	City     string `json:"city"`
+	State    string `json:"state,omitempty"`
+	Note     string `json:"note,omitempty"`
+}
+
+// UnresolvedClubsHandler reports the clubs that fell back to their federation's
+// default pin, together with paste-ready overrides.
+//
+// Wrong pins used to be invisible: a tournament sitting in the middle of a
+// state looks like a working map, not a failure. This makes the backlog
+// explicit, so correcting it is routine maintenance.
+func UnresolvedClubsHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	clubs := unresolved.Snapshot()
+
+	stubs := make([]stub, 0, len(clubs))
+	for _, club := range clubs {
+		note := "fell back to the " + club.Federation + " default pin"
+		if len(club.Candidates) > 0 {
+			note += "; tried: " + strings.Join(club.Candidates, ", ")
+		} else {
+			note += "; no place name could be extracted from the club name"
+		}
+
+		stubs = append(stubs, stub{
+			// The organizer string is matched with `contains` so minor
+			// differences in how a federation writes the name still match.
+			Contains: club.Organizer,
+			City:     "TODO",
+			State:    club.State,
+			Note:     note,
+		})
+	}
+
+	response := unresolvedResponse{
+		Count:   len(clubs),
+		Dropped: unresolved.Dropped(),
+		Clubs:   clubs,
+		Stubs:   stubs,
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(response); err != nil {
+		// The status is already written by this point, so the client sees a
+		// truncated body; logging is all that is left.
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+	}
+}

--- a/backend/pkg/metrics/unresolved_test.go
+++ b/backend/pkg/metrics/unresolved_test.go
@@ -1,0 +1,129 @@
+package metrics
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/timoknapp/tennis-tournament-finder/pkg/unresolved"
+)
+
+func TestUnresolvedClubsHandlerReportsRecordedClubs(t *testing.T) {
+	unresolved.Reset()
+	unresolved.Record("Lohausener Sport-Verein", "TVM", "Nordrhein-Westfalen", []string{"Lohausener"})
+	unresolved.Record("Lohausener Sport-Verein", "TVM", "Nordrhein-Westfalen", []string{"Lohausener"})
+	unresolved.Record("TC Beispiel", "BAD", "Baden-Württemberg", nil)
+
+	rec := httptest.NewRecorder()
+	UnresolvedClubsHandler(rec, httptest.NewRequest(http.MethodGet, UnresolvedClubsPath, nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("expected JSON, got %q", ct)
+	}
+
+	var got struct {
+		Count int `json:"count"`
+		Clubs []struct {
+			Organizer  string `json:"organizer"`
+			Federation string `json:"federation"`
+			Count      int    `json:"count"`
+		} `json:"clubs"`
+		Stubs []struct {
+			Contains string `json:"contains"`
+			City     string `json:"city"`
+			State    string `json:"state"`
+			Note     string `json:"note"`
+		} `json:"club_locations_stubs"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+
+	if got.Count != 2 {
+		t.Errorf("expected 2 clubs, got %d", got.Count)
+	}
+	// Most affected first, so the entry worth fixing leads.
+	if got.Clubs[0].Organizer != "Lohausener Sport-Verein" || got.Clubs[0].Count != 2 {
+		t.Errorf("expected the most affected club first, got %+v", got.Clubs[0])
+	}
+}
+
+func TestStubsArePasteableIntoClubLocations(t *testing.T) {
+	unresolved.Reset()
+	unresolved.Record("Lohausener Sport-Verein", "TVM", "Nordrhein-Westfalen", []string{"Lohausener"})
+
+	rec := httptest.NewRecorder()
+	UnresolvedClubsHandler(rec, httptest.NewRequest(http.MethodGet, UnresolvedClubsPath, nil))
+
+	var got struct {
+		Stubs []map[string]string `json:"club_locations_stubs"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if len(got.Stubs) != 1 {
+		t.Fatalf("expected 1 stub, got %d", len(got.Stubs))
+	}
+
+	stub := got.Stubs[0]
+	// The organizer must survive verbatim: it is the key the override matches
+	// on, so any reformatting here would produce a rule that never fires.
+	if stub["contains"] != "Lohausener Sport-Verein" {
+		t.Errorf("organizer was altered: %q", stub["contains"])
+	}
+	// TODO rather than a guess: a wrong city is worse than an obvious gap,
+	// because it looks resolved.
+	if stub["city"] != "TODO" {
+		t.Errorf("expected the city to be left as TODO, got %q", stub["city"])
+	}
+	if stub["state"] != "Nordrhein-Westfalen" {
+		t.Errorf("expected the federation state to be carried over, got %q", stub["state"])
+	}
+	if !strings.Contains(stub["note"], "Lohausener") {
+		t.Errorf("expected the note to record what was tried, got %q", stub["note"])
+	}
+}
+
+func TestUnresolvedClubsHandlerWithNothingRecorded(t *testing.T) {
+	unresolved.Reset()
+
+	rec := httptest.NewRecorder()
+	UnresolvedClubsHandler(rec, httptest.NewRequest(http.MethodGet, UnresolvedClubsPath, nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var got struct {
+		Count int               `json:"count"`
+		Clubs []json.RawMessage `json:"clubs"`
+		Stubs []json.RawMessage `json:"club_locations_stubs"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if got.Count != 0 {
+		t.Errorf("expected an empty report, got %d", got.Count)
+	}
+	// Empty arrays rather than null, so a consumer can iterate unconditionally.
+	if got.Clubs == nil || got.Stubs == nil {
+		t.Error("expected empty arrays rather than null")
+	}
+}
+
+func TestUnresolvedClubsHandlerRejectsNonGet(t *testing.T) {
+	rec := httptest.NewRecorder()
+	UnresolvedClubsHandler(rec, httptest.NewRequest(http.MethodPost, UnresolvedClubsPath, nil))
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", rec.Code)
+	}
+	if allow := rec.Header().Get("Allow"); allow != http.MethodGet {
+		t.Errorf("expected an Allow header of GET, got %q", allow)
+	}
+}

--- a/backend/pkg/models/models.go
+++ b/backend/pkg/models/models.go
@@ -15,6 +15,15 @@ type Tournament struct {
 	Lat       string             `json:"lat"`
 	Lon       string             `json:"lon"`
 	Entries   []CompetitionEntry `json:"entries"` // Competition-SkillLevel pairs
+	// ApproximateLocation marks a tournament pinned at its federation's default
+	// rather than at a place derived from its name.
+	//
+	// This cannot be inferred by comparing coordinates: several federation
+	// defaults sit exactly on a major city, so a club that geocodes correctly
+	// to München is indistinguishable from one that failed and fell back to the
+	// BTV default. Recording the outcome where it is known is the only reliable
+	// way to tell them apart.
+	ApproximateLocation bool `json:"approximate_location,omitempty"`
 }
 
 type Geocoordinates struct {

--- a/backend/pkg/tournament/tournament.go
+++ b/backend/pkg/tournament/tournament.go
@@ -403,9 +403,10 @@ func getTournamentsFromBTV(ctx context.Context, fed models.Federation) ([]models
 
 	// The widget supplies a venue city but no coordinates.
 	for i := range tournaments {
-		geoCoords := resolveGeocoordinates(fed, tournaments[i], defaultGeocoder, tournaments[i].Location)
+		geoCoords, approximate := resolveGeocoordinates(fed, tournaments[i], defaultGeocoder, tournaments[i].Location)
 		tournaments[i].Lat = geoCoords.Lat
 		tournaments[i].Lon = geoCoords.Lon
+		tournaments[i].ApproximateLocation = approximate
 	}
 
 	logger.Info("Federation %s: Found %d tournaments total", fed.Id, len(tournaments))
@@ -612,8 +613,10 @@ func (l *limitedReadCloser) Read(p []byte) (int, error) { return l.reader.Read(p
 func (l *limitedReadCloser) Close() error               { return l.closer.Close() }
 
 // resolveGeocoordinates looks up coordinates and falls back to the federation
-// default when nothing suitable is found.
-func resolveGeocoordinates(fed models.Federation, tournament models.Tournament, geocode geocoder, subject string) models.Geocoordinates {
+// default when nothing suitable is found. The second return value reports
+// whether that fallback was used, which callers cannot work out from the
+// coordinates alone: several federation defaults sit exactly on a major city.
+func resolveGeocoordinates(fed models.Federation, tournament models.Tournament, geocode geocoder, subject string) (models.Geocoordinates, bool) {
 	if geocode == nil {
 		geocode = defaultGeocoder
 	}
@@ -627,10 +630,10 @@ func resolveGeocoordinates(fed models.Federation, tournament models.Tournament, 
 		// /stats/unresolved-clubs instead of waiting for a user to report it.
 		unresolved.Record(tournament.Organizer, fed.Id, fed.State,
 			placename.Candidates(tournament.Organizer))
-		return fed.Geocoordinates
+		return fed.Geocoordinates, true
 	}
 
-	return geoCoords
+	return geoCoords, false
 }
 
 // ParseNewApiDocument parses one page of the new API's HTML into tournaments.
@@ -723,9 +726,10 @@ func ParseNewApiDocument(r io.Reader, fed models.Federation, geocode geocoder) (
 
 				// Get geocoordinates if we have a location
 				if tournament.Location != "" {
-					geoCoords := resolveGeocoordinates(fed, tournament, geocode, tournament.Location)
+					geoCoords, approximate := resolveGeocoordinates(fed, tournament, geocode, tournament.Location)
 					tournament.Lat = geoCoords.Lat
 					tournament.Lon = geoCoords.Lon
+					tournament.ApproximateLocation = approximate
 				} else {
 					logger.Warn("Tournament location missing: %s ; Date: %s", tournament.Title, tournament.Date)
 				}
@@ -861,9 +865,10 @@ func ParseOldApiDocument(r io.Reader, fed models.Federation, geocode geocoder) (
 					if len(tournament.Title) > 0 {
 						tournament.Organizer = extractOldApiOrganizer(columnTournament, tournament)
 
-						geoCoords := resolveGeocoordinates(fed, tournament, geocode, tournament.Organizer)
+						geoCoords, approximate := resolveGeocoordinates(fed, tournament, geocode, tournament.Organizer)
 						tournament.Lat = geoCoords.Lat
 						tournament.Lon = geoCoords.Lon
+						tournament.ApproximateLocation = approximate
 					}
 				case 2: // Competition (Konkurrenz)
 					currentEntry.Competition = value

--- a/backend/pkg/tournament/tournament.go
+++ b/backend/pkg/tournament/tournament.go
@@ -19,8 +19,10 @@ import (
 	"github.com/timoknapp/tennis-tournament-finder/pkg/logger"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/models"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/openstreetmap"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/placename"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/resultcache"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/skilllevel"
+	"github.com/timoknapp/tennis-tournament-finder/pkg/unresolved"
 	"github.com/timoknapp/tennis-tournament-finder/pkg/util"
 )
 
@@ -620,6 +622,11 @@ func resolveGeocoordinates(fed models.Federation, tournament models.Tournament, 
 	if geoCoords.Lat == "" || geoCoords.Lon == "" {
 		logger.Warn("No Geocoordinates could be found for (%s): '%s'. Falling back to default in '%s'",
 			tournament.Id, subject, fed.State)
+		// A log line scrolls away; the pin stays wrong until someone adds an
+		// override. Recording the club makes the backlog visible at
+		// /stats/unresolved-clubs instead of waiting for a user to report it.
+		unresolved.Record(tournament.Organizer, fed.Id, fed.State,
+			placename.Candidates(tournament.Organizer))
 		return fed.Geocoordinates
 	}
 

--- a/backend/pkg/unresolved/unresolved.go
+++ b/backend/pkg/unresolved/unresolved.go
@@ -1,0 +1,131 @@
+// Package unresolved records clubs whose location could not be determined, so
+// they can be corrected in club-locations.json instead of silently sitting on
+// their federation's default pin.
+//
+// Federations publish an organizer name and nothing else. Most names contain a
+// usable place ("TC Karlsruhe"), but some do not ("Lohausener Sport-Verein"),
+// and those tournaments end up pinned at the middle of the federation's state.
+// That looked like a working map rather than a failure, so nobody noticed.
+//
+// This registry makes the failures visible while the service runs, which is
+// what turns fixing them into routine maintenance rather than an investigation.
+package unresolved
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// maxEntries bounds the registry. Organizer names come from upstream, so this
+// is untrusted input and must not be allowed to grow without limit. The real
+// number of distinct clubs is in the hundreds; anything beyond this is a sign
+// something is wrong upstream, and dropping the excess is safer than growing
+// forever.
+const maxEntries = 500
+
+// Entry is one club that could not be placed.
+type Entry struct {
+	// Organizer is the club name exactly as the federation published it, so it
+	// can be pasted into club-locations.json unchanged.
+	Organizer string `json:"organizer"`
+	// Federation and State say where the fallback pin landed.
+	Federation string `json:"federation"`
+	State      string `json:"state"`
+	// Candidates are the place names that were tried, which usually shows why
+	// the extraction failed.
+	Candidates []string `json:"candidates,omitempty"`
+	// Count is how many tournaments were affected since the process started.
+	Count int `json:"count"`
+	// FirstSeen and LastSeen bound the observations.
+	FirstSeen time.Time `json:"first_seen"`
+	LastSeen  time.Time `json:"last_seen"`
+}
+
+type registry struct {
+	mu      sync.RWMutex
+	entries map[string]*Entry
+	dropped int
+}
+
+var reg = &registry{entries: make(map[string]*Entry)}
+
+// Record notes that a tournament fell back to its federation's default pin.
+// It is safe to call from the goroutines that fetch federations in parallel.
+func Record(organizer, federation, state string, candidates []string) {
+	if organizer == "" {
+		return
+	}
+
+	now := time.Now().UTC()
+	key := federation + "|" + organizer
+
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+
+	if entry, ok := reg.entries[key]; ok {
+		entry.Count++
+		entry.LastSeen = now
+		return
+	}
+
+	if len(reg.entries) >= maxEntries {
+		reg.dropped++
+		return
+	}
+
+	// Copy the candidates: the caller owns that slice and may reuse it.
+	cands := make([]string, len(candidates))
+	copy(cands, candidates)
+
+	reg.entries[key] = &Entry{
+		Organizer:  organizer,
+		Federation: federation,
+		State:      state,
+		Candidates: cands,
+		Count:      1,
+		FirstSeen:  now,
+		LastSeen:   now,
+	}
+}
+
+// Snapshot returns the recorded clubs, most affected first, so the entries
+// worth fixing come first.
+func Snapshot() []Entry {
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+
+	list := make([]Entry, 0, len(reg.entries))
+	for _, entry := range reg.entries {
+		list = append(list, *entry)
+	}
+
+	sort.Slice(list, func(i, j int) bool {
+		if list[i].Count != list[j].Count {
+			return list[i].Count > list[j].Count
+		}
+		// Stable order for equal counts, so repeated calls agree.
+		if list[i].Federation != list[j].Federation {
+			return list[i].Federation < list[j].Federation
+		}
+		return list[i].Organizer < list[j].Organizer
+	})
+
+	return list
+}
+
+// Dropped reports how many distinct clubs were discarded because the registry
+// was full. A non-zero value means the snapshot is incomplete.
+func Dropped() int {
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+	return reg.dropped
+}
+
+// Reset clears the registry. Used by tests.
+func Reset() {
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	reg.entries = make(map[string]*Entry)
+	reg.dropped = 0
+}

--- a/backend/pkg/unresolved/unresolved_test.go
+++ b/backend/pkg/unresolved/unresolved_test.go
@@ -1,0 +1,227 @@
+package unresolved
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestRecordCountsRepeatsWithoutDuplicating(t *testing.T) {
+	Reset()
+
+	Record("TC Beispiel", "BAD", "Baden-Württemberg", []string{"Beispiel"})
+	Record("TC Beispiel", "BAD", "Baden-Württemberg", []string{"Beispiel"})
+	Record("TC Beispiel", "BAD", "Baden-Württemberg", []string{"Beispiel"})
+
+	snapshot := Snapshot()
+	if len(snapshot) != 1 {
+		t.Fatalf("expected 1 club, got %d", len(snapshot))
+	}
+	if snapshot[0].Count != 3 {
+		t.Errorf("expected a count of 3, got %d", snapshot[0].Count)
+	}
+}
+
+func TestSameNameInDifferentFederationsStaysSeparate(t *testing.T) {
+	Reset()
+
+	// Club names are not unique across federations, and the correct city can
+	// differ, so the federation has to be part of the identity.
+	Record("TC Rot-Weiß", "BAD", "Baden-Württemberg", nil)
+	Record("TC Rot-Weiß", "WTB", "Baden-Württemberg", nil)
+
+	if got := len(Snapshot()); got != 2 {
+		t.Fatalf("expected 2 separate entries, got %d", got)
+	}
+}
+
+func TestSnapshotOrdersMostAffectedFirst(t *testing.T) {
+	Reset()
+
+	Record("Selten", "BAD", "Baden-Württemberg", nil)
+	for i := 0; i < 5; i++ {
+		Record("Häufig", "BAD", "Baden-Württemberg", nil)
+	}
+	for i := 0; i < 3; i++ {
+		Record("Mittel", "BAD", "Baden-Württemberg", nil)
+	}
+
+	snapshot := Snapshot()
+	want := []string{"Häufig", "Mittel", "Selten"}
+	for i, name := range want {
+		if snapshot[i].Organizer != name {
+			t.Errorf("position %d: expected %q, got %q", i, name, snapshot[i].Organizer)
+		}
+	}
+}
+
+func TestSnapshotOrderIsStableForEqualCounts(t *testing.T) {
+	Reset()
+
+	Record("B-Verein", "WTB", "Baden-Württemberg", nil)
+	Record("A-Verein", "WTB", "Baden-Württemberg", nil)
+	Record("C-Verein", "BAD", "Baden-Württemberg", nil)
+
+	first := Snapshot()
+	for i := 0; i < 5; i++ {
+		next := Snapshot()
+		for j := range first {
+			if first[j].Organizer != next[j].Organizer {
+				t.Fatalf("order changed between snapshots at %d: %q then %q",
+					j, first[j].Organizer, next[j].Organizer)
+			}
+		}
+	}
+}
+
+func TestRegistryIsBounded(t *testing.T) {
+	Reset()
+
+	// Organizer names come from upstream and are untrusted, so the registry
+	// must not grow without limit.
+	for i := 0; i < maxEntries+50; i++ {
+		Record(fmt.Sprintf("Verein %d", i), "BAD", "Baden-Württemberg", nil)
+	}
+
+	if got := len(Snapshot()); got != maxEntries {
+		t.Errorf("expected the registry to cap at %d, got %d", maxEntries, got)
+	}
+	if Dropped() != 50 {
+		t.Errorf("expected 50 dropped entries, got %d", Dropped())
+	}
+}
+
+func TestKnownClubsStillCountWhenFull(t *testing.T) {
+	Reset()
+
+	Record("Bekannter Verein", "BAD", "Baden-Württemberg", nil)
+	for i := 0; i < maxEntries; i++ {
+		Record(fmt.Sprintf("Verein %d", i), "BAD", "Baden-Württemberg", nil)
+	}
+
+	// A club already in the registry must keep counting even once it is full,
+	// otherwise the busiest entries stop reflecting reality exactly when the
+	// list matters most.
+	Record("Bekannter Verein", "BAD", "Baden-Württemberg", nil)
+
+	for _, entry := range Snapshot() {
+		if entry.Organizer == "Bekannter Verein" {
+			if entry.Count != 2 {
+				t.Errorf("expected the known club to reach a count of 2, got %d", entry.Count)
+			}
+			return
+		}
+	}
+	t.Error("the known club disappeared from the registry")
+}
+
+func TestEmptyOrganizerIsIgnored(t *testing.T) {
+	Reset()
+
+	Record("", "BAD", "Baden-Württemberg", nil)
+
+	if got := len(Snapshot()); got != 0 {
+		t.Errorf("expected an empty organizer to be ignored, got %d entries", got)
+	}
+}
+
+func TestCandidatesAreCopied(t *testing.T) {
+	Reset()
+
+	candidates := []string{"Karlsruhe"}
+	Record("TC Beispiel", "BAD", "Baden-Württemberg", candidates)
+
+	// The caller owns that slice and may reuse it for the next tournament.
+	candidates[0] = "überschrieben"
+
+	snapshot := Snapshot()
+	if snapshot[0].Candidates[0] != "Karlsruhe" {
+		t.Errorf("candidates were not copied: got %q", snapshot[0].Candidates[0])
+	}
+}
+
+func TestSnapshotDoesNotExposeInternalState(t *testing.T) {
+	Reset()
+
+	Record("TC Beispiel", "BAD", "Baden-Württemberg", []string{"Beispiel"})
+
+	snapshot := Snapshot()
+	snapshot[0].Count = 999
+	snapshot[0].Organizer = "geändert"
+
+	fresh := Snapshot()
+	if fresh[0].Count != 1 || fresh[0].Organizer != "TC Beispiel" {
+		t.Error("mutating a snapshot changed the registry")
+	}
+}
+
+func TestConcurrentRecording(t *testing.T) {
+	Reset()
+
+	// Federations are fetched in parallel, so Record runs from several
+	// goroutines at once. Run with -race.
+	const workers = 8
+	const perWorker = 50
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				// Half the writes contend on one key, half spread out.
+				if i%2 == 0 {
+					Record("Gemeinsamer Verein", "BAD", "Baden-Württemberg", nil)
+				} else {
+					Record(fmt.Sprintf("Verein %d-%d", worker, i), "BAD", "Baden-Württemberg", nil)
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	var shared int
+	for _, entry := range Snapshot() {
+		if entry.Organizer == "Gemeinsamer Verein" {
+			shared = entry.Count
+		}
+	}
+
+	if want := workers * perWorker / 2; shared != want {
+		t.Errorf("expected %d recordings of the shared club, got %d", want, shared)
+	}
+}
+
+func TestConcurrentSnapshotDuringRecording(t *testing.T) {
+	Reset()
+
+	// Reading while writing is the realistic case: the endpoint can be hit
+	// mid-fetch.
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-done:
+				return
+			default:
+				Record(fmt.Sprintf("Verein %d", i%20), "BAD", "Baden-Württemberg", nil)
+			}
+		}
+	}()
+
+	for i := 0; i < 100; i++ {
+		for _, entry := range Snapshot() {
+			if !strings.HasPrefix(entry.Organizer, "Verein") {
+				t.Errorf("unexpected entry during concurrent access: %q", entry.Organizer)
+			}
+		}
+	}
+
+	close(done)
+	wg.Wait()
+}


### PR DESCRIPTION
Venue-exact addresses need a login upstream (established in #55), so `club-locations.json` stays the way to correct a pin. **The gap was never the mechanism — it was knowing which clubs need an entry.**

## The problem

A tournament whose club name contains no usable place is pinned at the middle of its federation's state. That renders as a marker on a map like any other, so **a wrong pin is invisible** unless someone recognises the area and reports it.

Until now the only signal was a log line, and only `cmd/pincheck` could produce a list — a manual sweep nobody runs on a schedule.

## The change

The service records those clubs **as it works**, and serves them on the localhost-only diagnostics port:

```
curl -s http://127.0.0.1:9090/stats/unresolved-clubs | jq
```

Ordered by how many tournaments each affects, so the entry worth fixing leads. The response carries paste-ready entries:

```json
{
  "contains": "Lohausener Sport-Verein",
  "city": "TODO",
  "state": "Nordrhein-Westfalen",
  "note": "fell back to the TVM default pin; tried: Lohausener"
}
```

The city is left as **TODO** deliberately: a wrong city is worse than an obvious gap, because it looks resolved.

## Safety

The registry is **bounded at 500** distinct clubs. Organizer names come from upstream and are untrusted, so unbounded growth would be a denial-of-service vector; the real figure is in the hundreds.

Two details that matter once it fills:

* It keeps counting clubs it **already knows**, so the busiest entries stay accurate exactly when the list matters most.
* It reports `dropped` rather than quietly truncating, so a short list is never mistaken for a complete one.

Federations are fetched in parallel, so recording is mutex-guarded and tested under `-race` — including snapshots taken *during* writes. Snapshots copy their entries, so callers cannot reach into the registry through them.

## Also

A README next to the data file covers how to find what needs fixing and how to write an entry — including why the `note` field matters: the next person cannot tell a district from a typo without it.

## Verification

```
go test -race ./pkg/unresolved/...   ok
go test -race ./pkg/metrics/...      ok
go vet ./...                         clean
gofmt                                clean
```

A live `pincheck` sweep across all 17 federations is running as I write this; Nominatim's one-request-per-second limit makes a full pass slow. I will post the actual list of affected clubs, and fix the ones I can resolve, as a follow-up.
