### PR TITLE
fix: serve map tiles over https and credit OpenStreetMap (#41)

### DIFF
--- a/script/layout.test.js
+++ b/script/layout.test.js
@@ -138,6 +138,27 @@ const VIEWPORTS = [
     // computed values, because env() resolves to 0 in a headless browser.
     const cssSource = fs.readFileSync(path.join(ROOT, 'css', 'main.css'), 'utf8');
 
+    console.log('\nmap tiles');
+    const mainJs = fs.readFileSync(path.join(ROOT, 'script', 'main.js'), 'utf8');
+
+    check('tiles are requested over https', () => {
+        // The page is served over TLS, so http tiles are mixed content.
+        // Browsers currently upgrade them silently, but that is a courtesy and
+        // it logs a warning for every tile; the host answers https directly.
+        const httpTiles = mainJs.match(/L\.tileLayer\(\s*'http:\/\/[^']*'/g) || [];
+        assert.strictEqual(httpTiles.length, 0,
+            `tile layer uses http: ${httpTiles.join(', ')}`);
+    });
+
+    check('the map carries OpenStreetMap attribution', () => {
+        // ODbL obliges visible credit; this is a licence term, not decoration.
+        const layer = mainJs.match(/L\.tileLayer\([^)]*\)/s);
+        assert.ok(layer, 'no tile layer found');
+        assert.ok(/attribution:/.test(layer[0]), 'the tile layer declares no attribution');
+        assert.ok(/openstreetmap\.org\/copyright/.test(layer[0]),
+            'attribution must link to the OpenStreetMap copyright page');
+    });
+
     console.log('\nviewport meta');
     const html = fs.readFileSync(path.join(ROOT, 'index.html'), 'utf8');
     check('viewport is declared on its own meta element', () => {

--- a/script/main.js
+++ b/script/main.js
@@ -9,7 +9,17 @@ let map = L.map('map', {
   zoomControl: false
 }).setView([51.133481, 10.018343], 7);
 window.map = map; // expose map for gesture script
-L.tileLayer('http://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
+// Humanitarian OSM tiles. https rather than http: the page is served over TLS,
+// so http tiles are mixed content. Browsers currently upgrade them silently,
+// but that is a courtesy, not a guarantee, and it logs a warning for every
+// tile. The host answers https directly; the http URL only 301s to it.
+//
+// The attribution is a licence requirement, not decoration: OSM data is ODbL,
+// which obliges visible credit.
+L.tileLayer('https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
+  attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, ' +
+    'tiles courtesy of <a href="https://www.hotosm.org/">Humanitarian OpenStreetMap Team</a>',
+  maxZoom: 19,
   updateWhenZooming: true,   // fetch tiles during zoom animation
   keepBuffer: 3              // keep extra tiles around to reduce visible loads
 }).addTo(map);


### PR DESCRIPTION
Closes #41.

## Mixed content, confirmed on the live site

The tile layer requested `http://a.tile.openstreetmap.fr` from a page served over TLS. Chromium **upgrades** those rather than blocking them, so the map still drew — but the live site logs a warning for every tile:

```
Mixed Content: The page at 'https://timoknapp.github.io/tennis-tournament-finder/'
was loaded over HTTPS, but ...                                          (x12)
```

That upgrade is a browser courtesy, not a guarantee. And the insecure request bought nothing:

```
http://a.tile.openstreetmap.fr/hot/8/134/86.png   ->  301
https://a.tile.openstreetmap.fr/hot/8/134/86.png  ->  200
```

A redirect and a warning, for the same tile.

## No attribution at all

The layer declared none. OpenStreetMap data is **ODbL**, which requires visible credit — so this was a licence problem, not a cosmetic one.

Leaflet renders it in its own control, which the earlier mobile work already made room for above the tab bar.

Also sets `maxZoom: 19`; the layer had been left at Leaflet's default of 18 while these tiles go to 19.

## Verification

```
tile requests: 12   insecure: 0
first src: https://a.tile.openstreetmap.fr/hot/7/67/42.png
tiles rendered: 12 / 12
attribution: Leaflet | © OpenStreetMap contributors, tiles courtesy of Humanitarian OpenStree
links to OSM copyright: true
```

Two new layout checks, mutation-verified — reverting either fails:

```
FAIL tiles are requested over https
     tile layer uses http: L.tileLayer('http://a.tile.openstreetmap.fr/...
FAIL the map carries OpenStreetMap attribution
     the tile layer declares no attribution
```

364 layout checks pass.
