### PR TITLE
fix(geocoding): pin the last two clubs the sweep still reported

### DIFF
--- a/backend/pkg/clublocations/clublocations_test.go
+++ b/backend/pkg/clublocations/clublocations_test.go
@@ -268,7 +268,7 @@ func TestOverridesForReportedClubs(t *testing.T) {
 		{"Tus Berne e.V. Tennisabteilung", "Hamburg"},
 		{"Tennisclub Ellerbek e.V.", "Ellerbek"},
 		{"ETUF Tennisriege", "Essen"},
-		{"TSV Neuenkirchen (SFA)", "Neuenkirchen"},
+
 		{"Tennisclub am Falkenberg", "Norderstedt"},
 		{"Gemünden", "Gemünden am Main"},
 		{"TC Viktoria", "Köln"},
@@ -286,20 +286,69 @@ func TestOverridesForReportedClubs(t *testing.T) {
 	}
 }
 
-// TestAmbiguousNamesAreNotGuessed guards a decision rather than behaviour.
+// TestAmbiguousNamesArePinnedNotGuessed covers the two clubs whose names reach
+// the wrong place even when a place is found.
 //
-// "Neustadt" was reported by the same sweep, but Bavaria has several: Neustadt
-// an der Aisch, Neustadt an der Donau and Neustadt bei Coburg all match. A
-// wrong pin is worse than an obvious fallback, because it looks resolved, so
-// the entry was deliberately left out until the actual club is known.
-func TestAmbiguousNamesAreNotGuessed(t *testing.T) {
+// Both were left open in the first pass because guessing produces a confidently
+// wrong pin, which is worse than an obvious fallback. They were resolved from
+// evidence rather than by picking the most likely candidate, and both carry
+// explicit coordinates because no place name reaches them:
+//
+//   - BTV publishes a club as plain "Neustadt". Bavaria has several, but the
+//     tournament titles name the venue ("beim ASV Neustadt"), and ASV Neustadt
+//     is in Neustadt an der Waldnaab.
+//   - "TSV Neuenkirchen (SFA)" is in Delmsen in the Heidekreis, which is none
+//     of the three places called Neuenkirchen in Niedersachsen.
+func TestAmbiguousNamesArePinnedNotGuessed(t *testing.T) {
 	table, err := Default()
 	if err != nil {
 		t.Fatalf("loading the default table failed: %v", err)
 	}
 
-	if override, ok := table.Lookup("Neustadt"); ok {
-		t.Errorf("an override for the ambiguous name Neustadt was added (city %q); "+
-			"confirm which Neustadt the club plays in first", override.City)
+	cases := []struct {
+		organizer string
+		lat, lon  string
+	}{
+		{"Neustadt", "49.727316", "12.179680"},
+		{"TSV Neuenkirchen (SFA)", "53.027311", "9.705497"},
+	}
+
+	for _, tc := range cases {
+		override, ok := table.Lookup(tc.organizer)
+		if !ok {
+			t.Errorf("%q has no override", tc.organizer)
+			continue
+		}
+		if !override.HasCoordinates() {
+			t.Errorf("%q resolves via the city name %q, which does not reach the right place; "+
+				"it needs explicit coordinates", tc.organizer, override.City)
+			continue
+		}
+		if override.Lat != tc.lat || override.Lon != tc.lon {
+			t.Errorf("%q pinned at %s,%s want %s,%s",
+				tc.organizer, override.Lat, override.Lon, tc.lat, tc.lon)
+		}
+	}
+}
+
+// TestNeustadtDoesNotSwallowOtherClubs checks the match/contains distinction.
+//
+// "Neustadt" is matched exactly: as a `contains` rule it would capture every
+// club with Neustadt in its name across all federations and pin them all in
+// the Oberpfalz.
+func TestNeustadtDoesNotSwallowOtherClubs(t *testing.T) {
+	table, err := Default()
+	if err != nil {
+		t.Fatalf("loading the default table failed: %v", err)
+	}
+
+	for _, other := range []string{
+		"TC Neustadt an der Weinstraße",
+		"TSV Neustadt bei Coburg",
+		"SV Neustadt-Glewe",
+	} {
+		if override, ok := table.Lookup(other); ok && override.Lat == "49.727316" {
+			t.Errorf("%q was captured by the plain Neustadt override", other)
+		}
 	}
 }

--- a/backend/pkg/clublocations/data/club-locations.json
+++ b/backend/pkg/clublocations/data/club-locations.json
@@ -78,9 +78,10 @@
     },
     {
       "contains": "TSV Neuenkirchen",
-      "city": "Neuenkirchen",
       "state": "Niedersachsen",
-      "note": "The '(SFA)' suffix is the old Soltau-Fallingbostel district, now Heidekreis. Several places are called Neuenkirchen, so the state alone is not enough."
+      "note": "Niedersachsen alone has at least three places called Neuenkirchen (Schwafoerden, Land Hadeln, Samtgemeinde Neuenkirchen), and the club is in none of them: it plays at Kabenstrasse 19A in Delmsen, Heidekreis. The '(SFA)' suffix is the former Soltau-Fallingbostel district. Pinned explicitly because no place name reaches the right one.",
+      "lat": "53.027311",
+      "lon": "9.705497"
     },
     {
       "contains": "Tennisclub am Falkenberg",
@@ -99,6 +100,13 @@
       "city": "Köln",
       "state": "Nordrhein-Westfalen",
       "note": "TVM covers Köln and the club there is Tennisclub Viktoria Köln (Höhenberger Ring). Note a Tennisclub FC Viktoria 09 also exists in St. Ingbert, Saarland, so this entry is federation-specific."
+    },
+    {
+      "match": "Neustadt",
+      "state": "Bayern",
+      "lat": "49.727316",
+      "lon": "12.179680",
+      "note": "BTV publishes this club as plain 'Neustadt', which Bavaria has several of (an der Aisch, an der Donau, bei Coburg, an der Waldnaab). The tournament titles name the venue - '6. TennWa-LK-Turnier beim ASV Neustadt' - and ASV Neustadt is in Neustadt an der Waldnaab, confirmed by its Sportheim in OSM. Uses 'match' rather than 'contains' so it cannot swallow other Neustadt clubs."
     }
   ]
 }


### PR DESCRIPTION
Re-ran the sweep against master. **The previous change is confirmed:**

```
before  32 tournaments on a fallback pin (2.5%), 14 clubs
after    5 tournaments                  (0.4%),   2 clubs
```

The 17 false alarms are gone and 6 of the 7 overrides work in production. This PR handles the two stragglers — both the same failure: **the override named a city, and the city name does not reach the club.**

## TSV Neuenkirchen — my mistake

The override resolved correctly to `"Neuenkirchen"` and still missed:

```
"Neuenkirchen, Niedersachsen" ->
  52.775  8.753   Samtgemeinde Schwaförden
  53.775  8.896   Samtgemeinde Land Hadeln
  52.416  7.840   Samtgemeinde Neuenkirchen
```

Niedersachsen has at least three, and the club is in **none** of them. It plays at Kabenstraße 19A in **Delmsen, Heidekreis** — which is exactly what the `(SFA)` suffix points at: the former Soltau-Fallingbostel district. I had the evidence in the first pass and used a city name anyway.

## Neustadt — solved from the data, not a guess

Left open deliberately last time, since Bavaria has several and guessing produces a confidently wrong pin.

Searching for the club got nowhere. The answer was in the tournaments themselves:

```
organizer="Neustadt"
  title="6. TennWa-LK-Turnier (Herren 40) beim ASV Neustadt"
```

**ASV Neustadt** → Neustadt an der Waldnaab, confirmed by its Sportheim in OSM:

```
49.727316  12.179680  ASV Neustadt, Mühlberg, Neustadt an der Waldnaab
49.727584  12.179020  ASV Neustadt Sportheim, Bildstraße
```

The federation publishes only `"Neustadt"` as the organizer, so the club name never carried this — the title did.

## Both now pin coordinates

Not a city: no place name reaches either. `Neustadt` uses `match` rather than `contains`, so it cannot capture other clubs with Neustadt in their names.

Tests cover both: that each entry carries **coordinates rather than a city** (which would silently miss again), and that the Neustadt rule does not swallow `TC Neustadt an der Weinstraße`, `TSV Neustadt bei Coburg` or `SV Neustadt-Glewe`.

`go test ./...` passes; `go vet` and `gofmt` clean.

Expected after merge: **0 tournaments on a fallback pin.**
