### PR TITLE
feat: filter and sort tournaments by distance (#46)

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1750,3 +1750,93 @@ body.list-mode .filter {
         margin-bottom: calc(49px + env(safe-area-inset-bottom, 0px));
     }
 }
+
+/* ---------- Radius filter ---------- */
+
+.radiusActions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--sp-2);
+    margin-top: var(--sp-3);
+}
+
+.radiusBtn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 36px;
+    padding: 8px 12px;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--accent);
+    background: var(--accent-soft);
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+}
+
+.radiusBtn:hover {
+    background: #dfeae3;
+}
+
+.radiusBtn:focus-visible {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.radiusBtn svg {
+    width: 16px;
+    height: 16px;
+}
+
+.radiusPlaceRow {
+    display: flex;
+    gap: var(--sp-2);
+    margin-top: var(--sp-2);
+}
+
+/* display: flex overrides the hidden attribute, so the manual entry row was
+   always visible even though it is meant to appear only when the automatic
+   route fails. The attribute has to win. */
+.radiusPlaceRow[hidden],
+.radiusActions [hidden] {
+    display: none;
+}
+
+.radiusPlaceRow .filterElement {
+    flex: 1 1 auto;
+    /* An input in a flex row keeps its intrinsic width and refuses to shrink
+       below it, which pushes the button out of the panel on narrow screens. */
+    min-width: 0;
+}
+
+.radiusPlaceRow .radiusBtn {
+    flex: none;
+}
+
+/* The status line carries the outcome of a permission prompt, so it has to be
+   readable rather than decorative. */
+#radiusStatus[data-state="error"] {
+    color: #7d2b22;
+}
+
+#radiusStatus[data-state="ok"] {
+    color: var(--accent-dark);
+}
+
+/* A tournament pinned at its federation's default has no real distance;
+   saying so is better than printing a number that is not true. */
+.tournament-approximate {
+    color: var(--muted);
+    font-style: italic;
+}
+
+@media (max-width: 768px) {
+    .radiusBtn {
+        min-height: 44px;
+        font-size: 14px;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -154,6 +154,43 @@
                     </small>
                 </div>
                 <div class="filterContainer">
+                    <label for="radiusSelect">Umkreis:</label>
+                    <select class="filterElement" id="radiusSelect" onchange="applyRadiusFilter()">
+                        <option value="">Ganz Deutschland</option>
+                        <option value="25">25 km</option>
+                        <option value="50">50 km</option>
+                        <option value="100">100 km</option>
+                        <option value="200">200 km</option>
+                    </select>
+                    <!-- The location is requested on click only. Prompting on
+                         load is both what the issue rules out and the quickest
+                         way to a permanent denial. -->
+                    <div class="radiusActions">
+                        <button type="button" class="radiusBtn" id="radiusLocate"
+                                onclick="requestLocation()">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                 stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"
+                                 aria-hidden="true">
+                                <circle cx="12" cy="12" r="3.2"/>
+                                <circle cx="12" cy="12" r="8"/>
+                                <path d="M12 2v2.5M12 19.5V22M2 12h2.5M19.5 12H22"/>
+                            </svg>
+                            Mein Standort
+                        </button>
+                        <button type="button" class="linkBtn" id="radiusManual"
+                                onclick="revealPlaceFallback()">Ort eingeben</button>
+                        <button type="button" class="linkBtn" id="radiusClear" hidden
+                                onclick="clearDistanceOrigin()">Zurücksetzen</button>
+                    </div>
+                    <div class="radiusPlaceRow" id="radiusPlaceRow" hidden>
+                        <input class="filterElement" type="text" id="radiusPlace"
+                               placeholder="Ort oder PLZ" autocomplete="postal-code"
+                               aria-label="Ort oder Postleitzahl">
+                        <button type="button" class="radiusBtn" onclick="resolvePlace()">Suchen</button>
+                    </div>
+                    <p class="filterHint" id="radiusStatus" role="status" aria-live="polite" hidden></p>
+                </div>
+                <div class="filterContainer">
                     <div class="federationHeader">
                         <label id="federationLabel">Tennisverbände:</label>
                         <div class="federationActions">
@@ -277,6 +314,9 @@
                 <option value="date">Datum</option>
                 <option value="title">Titel</option>
                 <option value="organizer">Veranstalter</option>
+                <!-- Only meaningful once there is a point to measure from, so
+                     it appears with the location. -->
+                <option value="distance" id="sortByDistance" hidden>Entfernung</option>
             </select>
             <span id="listCount" class="list-count" aria-live="polite"></span>
         </div>

--- a/script/main.js
+++ b/script/main.js
@@ -130,6 +130,10 @@ function registerMapFilterAutoClose() {
 // Tournaments from the most recent search, shared by the map and list views so
 // both always show the same data.
 let currentTournaments = [];
+// The point distances are measured from, once the user asks for it. Held in
+// memory only: the issue is explicit that location must not be persisted, and
+// a stored coordinate would also go stale the moment someone travels.
+let distanceOrigin = null;
 // Marker instances keyed by tournament id, so the list can open the matching
 // popup on the map.
 let markerById = new Map();
@@ -149,59 +153,76 @@ function getTournamentsByDate(dateFrom, dateTo, compType, federations, playerLK)
             renderDataNotice(response, tournaments.length);
 
             currentTournaments = tournaments;
-            markerById = new Map();
-
-            map.removeLayer(markers);
-            markers = createMarkerClusterGroup();
-            for (const tournament of tournaments) {
-                // Process competition entries for display
-                let competitionDetails = "";
-                
-                if (tournament.entries && tournament.entries.length > 0) {
-                    // Create detailed competition list
-                    const validEntries = tournament.entries.filter(entry => 
-                        entry.competition || (entry.skill_level && entry.skill_level.trim() !== ""));
-                    
-                    if (validEntries.length > 0) {
-                        competitionDetails = `
-                        <div id="comp-details-${tournament.id}" style="display: none; max-height: 150px; overflow-y: auto; margin-top: 5px; padding: 5px; background-color: #f9f9f9; border-radius: 3px;">
-                            <table style="width: 100%; font-size: 12px;">
-                                <tr style="font-weight: bold;"><td>Konkurrenz</td><td>LK</td></tr>
-                                ${validEntries.map(entry => `
-                                    <tr>
-                                        <td style="padding: 2px;">${entry.competition || "-"}</td>
-                                        <td style="padding: 2px;">${entry.skill_level || "-"}</td>
-                                    </tr>
-                                `).join("")}
-                            </table>
-                        </div>
-                        <a href="#" onclick="toggleCompetitionDetails('${tournament.id}'); return false;" class="popup-info-text" style="color: #0066cc; text-decoration: none;">
-                            <span id="toggle-text-${tournament.id}">▼ Konkurrenzen anzeigen (${validEntries.length} Einträge)</span>
-                        </a>`;
-                    }
-                }
-
-                const marker = L.marker([tournament["lat"], tournament["lon"]], { icon: tournamentIcon() })
-                .bindPopup(`
-                <span class="popupTitle">${tournament["title"]}</span><br><br>
-                <div class="popup-info-text">
-                    <b>Datum:</b> ${tournament["date"]}<br>
-                    <b>Adresse:</b> <a target="_blank" href="${urlGoogleQuery+tournament["organizer"]}">${tournament["organizer"]}</a><br>
-                </div>
-                <div class="button-container">
-                    <a href="${tournament["url"]}" target="_blank" class="signup-button">Anmelden</a>
-                </div>
-                ${competitionDetails}
-                `)
-                markers.addLayer(marker);
-                if (tournament["id"]) {
-                    markerById.set(String(tournament["id"]), marker);
-                }
+            // Distances are per-search: a tournament list without them would
+            // keep stale values from the previous query.
+            for (const tournament of currentTournaments) {
+                tournament._distanceKm = tournamentDistanceKm(tournament, distanceOrigin);
             }
-            map.addLayer(markers);
+
+            renderTournaments();
             renderTournamentList();
         });
     }
+}
+
+// renderTournaments draws the markers for whatever is currently visible.
+//
+// Split out of the fetch so the radius filter can redraw without re-querying:
+// the backend never learns the user's position, which is what keeps it in the
+// browser.
+function renderTournaments() {
+    const tournaments = visibleTournaments();
+
+    markerById = new Map();
+    map.removeLayer(markers);
+    markers = createMarkerClusterGroup();
+
+    for (const tournament of tournaments) {
+        // Process competition entries for display
+        let competitionDetails = "";
+        
+        if (tournament.entries && tournament.entries.length > 0) {
+            // Create detailed competition list
+            const validEntries = tournament.entries.filter(entry => 
+                entry.competition || (entry.skill_level && entry.skill_level.trim() !== ""));
+            
+            if (validEntries.length > 0) {
+                competitionDetails = `
+                <div id="comp-details-${tournament.id}" style="display: none; max-height: 150px; overflow-y: auto; margin-top: 5px; padding: 5px; background-color: #f9f9f9; border-radius: 3px;">
+                    <table style="width: 100%; font-size: 12px;">
+                        <tr style="font-weight: bold;"><td>Konkurrenz</td><td>LK</td></tr>
+                        ${validEntries.map(entry => `
+                            <tr>
+                                <td style="padding: 2px;">${entry.competition || "-"}</td>
+                                <td style="padding: 2px;">${entry.skill_level || "-"}</td>
+                            </tr>
+                        `).join("")}
+                    </table>
+                </div>
+                <a href="#" onclick="toggleCompetitionDetails('${tournament.id}'); return false;" class="popup-info-text" style="color: #0066cc; text-decoration: none;">
+                    <span id="toggle-text-${tournament.id}">▼ Konkurrenzen anzeigen (${validEntries.length} Einträge)</span>
+                </a>`;
+            }
+        }
+
+        const marker = L.marker([tournament["lat"], tournament["lon"]], { icon: tournamentIcon() })
+        .bindPopup(`
+        <span class="popupTitle">${tournament["title"]}</span><br><br>
+        <div class="popup-info-text">
+            <b>Datum:</b> ${tournament["date"]}<br>
+            <b>Adresse:</b> <a target="_blank" href="${urlGoogleQuery+tournament["organizer"]}">${tournament["organizer"]}</a><br>
+        </div>
+        <div class="button-container">
+            <a href="${tournament["url"]}" target="_blank" class="signup-button">Anmelden</a>
+        </div>
+        ${competitionDetails}
+        `)
+        markers.addLayer(marker);
+        if (tournament["id"]) {
+            markerById.set(String(tournament["id"]), marker);
+        }
+    }
+    map.addLayer(markers);
 }
 
 async function getTournaments(dateFrom, dateTo, compType, federations, playerLK) {
@@ -629,7 +650,82 @@ function parseTournamentDate(dateText) {
     return isNaN(parsed.getTime()) ? null : parsed;
 }
 
+// ===== Distance =====
+
+// Mean earth radius in kilometres. Good enough for "is this within 50km": the
+// error from treating the earth as a sphere is well under a percent at these
+// distances, and tournament coordinates are club-level anyway.
+const EARTH_RADIUS_KM = 6371;
+
+function toRadians(degrees) {
+    return degrees * Math.PI / 180;
+}
+
+// distanceKm returns the great-circle distance between two points.
+//
+// Haversine rather than the simpler equirectangular approximation: the latter
+// drifts noticeably over Germany's north-south extent, and this runs over a few
+// hundred tournaments, so the cost is irrelevant.
+function distanceKm(lat1, lon1, lat2, lon2) {
+    const dLat = toRadians(lat2 - lat1);
+    const dLon = toRadians(lon2 - lon1);
+    const a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+        Math.cos(toRadians(lat1)) * Math.cos(toRadians(lat2)) *
+        Math.sin(dLon / 2) * Math.sin(dLon / 2);
+    return EARTH_RADIUS_KM * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+// tournamentDistanceKm returns the distance to a tournament, or null when it
+// has no usable coordinates.
+//
+// Coordinates arrive as strings and an unparseable one must not become NaN:
+// every NaN comparison is false, so such a tournament would sort unpredictably
+// and slip through a radius filter.
+function tournamentDistanceKm(tournament, origin) {
+    if (!origin) {
+        return null;
+    }
+    const lat = Number.parseFloat(tournament.lat);
+    const lon = Number.parseFloat(tournament.lon);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+        return null;
+    }
+    return distanceKm(origin.lat, origin.lon, lat, lon);
+}
+
+// formatDistance keeps the precision honest: below 10km a decimal is
+// meaningful, beyond that it implies accuracy club-level coordinates lack.
+function formatDistance(km) {
+    if (km == null) {
+        return '';
+    }
+    if (km < 10) {
+        return `${km.toFixed(1).replace('.', ',')} km`;
+    }
+    return `${Math.round(km)} km`;
+}
+
 function compareTournaments(a, b, sortBy) {
+    if (sortBy === 'distance') {
+        const da = a._distanceKm;
+        const db = b._distanceKm;
+        // Tournaments without coordinates sort last: they cannot be placed, and
+        // listing them first would read as "closest".
+        if (da == null && db == null) {
+            return (a.title || '').localeCompare(b.title || '', 'de');
+        }
+        if (da == null) {
+            return 1;
+        }
+        if (db == null) {
+            return -1;
+        }
+        if (da !== db) {
+            return da - db;
+        }
+        return (a.title || '').localeCompare(b.title || '', 'de');
+    }
+
     if (sortBy === 'title') {
         return (a.title || '').localeCompare(b.title || '', 'de');
     }
@@ -675,11 +771,18 @@ function renderTournamentList() {
     }
 
     const sortBy = sortSelect ? sortSelect.value : 'date';
-    const sorted = currentTournaments.slice().sort((a, b) => compareTournaments(a, b, sortBy));
+    const visible = visibleTournaments();
+    const sorted = visible.slice().sort((a, b) => compareTournaments(a, b, sortBy));
 
-    count.textContent = sorted.length === 1
-        ? '1 Turnier'
-        : `${sorted.length} Turniere`;
+    const hidden = currentTournaments.length - visible.length;
+    count.textContent = sorted.length === 1 ? '1 Turnier' : `${sorted.length} Turniere`;
+    if (hidden > 0) {
+        // Say what the radius removed. A count that silently shrinks reads as
+        // missing data rather than as a filter doing its job.
+        count.textContent += hidden === 1
+            ? ' (1 außerhalb des Umkreises)'
+            : ` (${hidden} außerhalb des Umkreises)`;
+    }
 
     list.innerHTML = '';
 
@@ -707,6 +810,16 @@ function renderTournamentList() {
 
         const hasCoords = tournament.lat && tournament.lon;
 
+        // Distance is only shown when it was actually measured. A tournament
+        // pinned at its federation's default is labelled instead: reporting
+        // "73 km" for a marker sitting in the middle of a state would be a
+        // confident lie.
+        const distanceRow = tournament.approximate_location
+            ? '<dt>Entfernung</dt><dd class="tournament-approximate">Standort ungenau</dd>'
+            : (tournament._distanceKm != null
+                ? `<dt>Entfernung</dt><dd>${escapeHtml(formatDistance(tournament._distanceKm))}</dd>`
+                : '');
+
         item.innerHTML = `
             <h3 class="tournament-title">${escapeHtml(tournament.title)}</h3>
             <dl class="tournament-meta">
@@ -715,6 +828,7 @@ function renderTournamentList() {
                 <dd><a target="_blank" rel="noopener"
                        href="${urlGoogleQuery + encodeURIComponent(tournament.organizer || '')}">
                        ${escapeHtml(tournament.organizer)}</a></dd>
+                ${distanceRow}
             </dl>
             ${competitions}
             <div class="tournament-actions">
@@ -818,4 +932,200 @@ function isValidPlayerLK(value) {
     }
     const parsed = parseFloat(String(value).replace(',', '.'));
     return !isNaN(parsed) && parsed >= 1 && parsed <= 25;
+}
+
+// ===== Radius filter =====
+
+// requestLocation asks the browser for the user's position.
+//
+// Only ever called from a click: the issue requires that no permission prompt
+// appears on load, and an unprompted prompt is the fastest way to get denied
+// permanently.
+function requestLocation() {
+    const status = document.getElementById('radiusStatus');
+
+    if (!navigator.geolocation) {
+        setRadiusStatus('Dein Browser unterstützt keine Standortbestimmung. ' +
+            'Gib stattdessen einen Ort oder eine PLZ ein.', 'error');
+        revealPlaceFallback();
+        return;
+    }
+
+    setRadiusStatus('Standort wird ermittelt …', 'pending');
+
+    navigator.geolocation.getCurrentPosition(
+        position => {
+            setDistanceOrigin({
+                lat: position.coords.latitude,
+                lon: position.coords.longitude,
+                label: 'deinem Standort',
+            });
+        },
+        error => {
+            // Denial is a normal answer, not a fault: offer the manual route
+            // rather than asking again.
+            const denied = error && error.code === error.PERMISSION_DENIED;
+            setRadiusStatus(denied
+                ? 'Standortzugriff abgelehnt. Gib stattdessen einen Ort oder eine PLZ ein.'
+                : 'Standort konnte nicht ermittelt werden. Gib einen Ort oder eine PLZ ein.',
+                'error');
+            revealPlaceFallback();
+        },
+        // A stale fix is fine for a radius of tens of kilometres, and asking for
+        // high accuracy costs battery and time for no benefit here.
+        { enableHighAccuracy: false, timeout: 10000, maximumAge: 300000 }
+    );
+
+    if (status) {
+        status.focus?.();
+    }
+}
+
+// resolvePlace geocodes a typed place or postcode through the same Nominatim
+// service the backend uses, so the manual route behaves like the automatic one.
+async function resolvePlace() {
+    const input = document.getElementById('radiusPlace');
+    const query = input ? input.value.trim() : '';
+
+    if (query === '') {
+        setRadiusStatus('Bitte gib einen Ort oder eine PLZ ein.', 'error');
+        return;
+    }
+
+    setRadiusStatus('Ort wird gesucht …', 'pending');
+
+    try {
+        const url = 'https://nominatim.openstreetmap.org/search?' + new URLSearchParams({
+            q: query,
+            format: 'json',
+            countrycodes: 'de',
+            limit: '1',
+        });
+        const response = await fetch(url, { headers: { 'Accept': 'application/json' } });
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+        const results = await response.json();
+        if (!Array.isArray(results) || results.length === 0) {
+            setRadiusStatus(`Für „${query}" wurde kein Ort gefunden.`, 'error');
+            return;
+        }
+        setDistanceOrigin({
+            lat: Number.parseFloat(results[0].lat),
+            lon: Number.parseFloat(results[0].lon),
+            label: results[0].display_name.split(',')[0],
+        });
+    } catch (err) {
+        setRadiusStatus('Die Ortssuche ist gerade nicht erreichbar.', 'error');
+    }
+}
+
+function setDistanceOrigin(origin) {
+    if (!Number.isFinite(origin.lat) || !Number.isFinite(origin.lon)) {
+        setRadiusStatus('Die Koordinaten konnten nicht gelesen werden.', 'error');
+        return;
+    }
+
+    distanceOrigin = origin;
+    setRadiusStatus(`Entfernungen ab ${origin.label}.`, 'ok');
+
+    const clear = document.getElementById('radiusClear');
+    if (clear) {
+        clear.hidden = false;
+    }
+    // Sorting by distance is only meaningful once there is something to
+    // measure from, so the option appears with the origin.
+    const distanceOption = document.getElementById('sortByDistance');
+    if (distanceOption) {
+        distanceOption.hidden = false;
+    }
+
+    applyRadiusFilter();
+}
+
+function clearDistanceOrigin() {
+    distanceOrigin = null;
+
+    const clear = document.getElementById('radiusClear');
+    if (clear) {
+        clear.hidden = true;
+    }
+
+    const sortSelect = document.getElementById('listSort');
+    const distanceOption = document.getElementById('sortByDistance');
+    if (distanceOption) {
+        distanceOption.hidden = true;
+        if (sortSelect && sortSelect.value === 'distance') {
+            sortSelect.value = 'date';
+        }
+    }
+
+    setRadiusStatus('', 'idle');
+    applyRadiusFilter();
+}
+
+function setRadiusStatus(message, state) {
+    const status = document.getElementById('radiusStatus');
+    if (!status) {
+        return;
+    }
+    status.textContent = message;
+    status.dataset.state = state;
+    status.hidden = message === '';
+}
+
+function revealPlaceFallback() {
+    const fallback = document.getElementById('radiusPlaceRow');
+    if (fallback) {
+        fallback.hidden = false;
+    }
+    const input = document.getElementById('radiusPlace');
+    if (input) {
+        input.focus();
+    }
+}
+
+// applyRadiusFilter recomputes distances and redraws both views.
+//
+// The filter runs over the tournaments already fetched rather than re-querying:
+// the backend has no notion of the user's position, and keeping it that way
+// means the location never leaves the browser.
+function applyRadiusFilter() {
+    for (const tournament of currentTournaments) {
+        tournament._distanceKm = tournamentDistanceKm(tournament, distanceOrigin);
+    }
+
+    if (typeof renderTournaments === 'function') {
+        renderTournaments();
+    }
+    renderTournamentList();
+}
+
+// visibleTournaments applies the radius, if one is active.
+function visibleTournaments() {
+    const radius = selectedRadiusKm();
+    if (!distanceOrigin || radius == null) {
+        return currentTournaments;
+    }
+
+    return currentTournaments.filter(tournament => {
+        // A tournament pinned at its federation's default has no real location.
+        // Filtering it in would place it somewhere it is not; filtering it out
+        // silently would hide it. It is kept and labelled instead, so the user
+        // decides.
+        if (tournament.approximate_location) {
+            return true;
+        }
+        const distance = tournament._distanceKm;
+        return distance != null && distance <= radius;
+    });
+}
+
+function selectedRadiusKm() {
+    const select = document.getElementById('radiusSelect');
+    if (!select || select.value === '') {
+        return null;
+    }
+    const value = Number.parseInt(select.value, 10);
+    return Number.isFinite(value) ? value : null;
 }

--- a/script/main.test.js
+++ b/script/main.test.js
@@ -14,7 +14,12 @@ const vm = require('vm');
 // pure functions under test, and stop before the Leaflet setup runs.
 const source = fs.readFileSync(path.join(__dirname, 'main.js'), 'utf8');
 // Everything from the list view onwards is pure logic, safe to eval.
-const listSection = source.slice(source.indexOf('// ===== Map markers ====='));
+// Everything from the marker helpers to the radius filter. The radius section
+// is excluded deliberately: it drives the DOM and the geolocation API, neither
+// of which exists here.
+const listSection = source.slice(
+    source.indexOf('// ===== Map markers ====='),
+    source.indexOf('// ===== Radius filter ====='));
 
 // Minimal Leaflet stub: the marker helpers only build icon descriptors.
 const L = {
@@ -39,7 +44,8 @@ vm.createContext(sandbox);
 vm.runInContext(listSection, sandbox);
 
 const { parseTournamentDate, compareTournaments, escapeHtml, isValidPlayerLK,
-        tennisBallPin, clusterIcon } = sandbox;
+        tennisBallPin, clusterIcon, distanceKm, tournamentDistanceKm,
+        formatDistance } = sandbox;
 
 let failures = 0;
 function test(name, fn) {
@@ -182,6 +188,78 @@ test('rejects empty and non-numeric input', () => {
     for (const v of ['', '   ', null, undefined, 'abc', 'LK']) {
         assert.strictEqual(isValidPlayerLK(v), false, `should reject ${JSON.stringify(v)}`);
     }
+});
+
+console.log('distance');
+
+test('measures a known distance', () => {
+    // Karlsruhe to Stuttgart is about 64km as the crow flies.
+    const km = distanceKm(49.0069, 8.4037, 48.7758, 9.1829);
+    assert.ok(Math.abs(km - 64) < 2, `expected about 64km, got ${km.toFixed(1)}`);
+});
+
+test('measures a long distance across the country', () => {
+    // Hamburg to München, roughly 613km.
+    const km = distanceKm(53.5503, 9.9937, 48.1371, 11.5754);
+    assert.ok(Math.abs(km - 613) < 10, `expected about 613km, got ${km.toFixed(1)}`);
+});
+
+test('distance to itself is zero', () => {
+    assert.strictEqual(Math.round(distanceKm(49.0069, 8.4037, 49.0069, 8.4037)), 0);
+});
+
+test('distance is symmetric', () => {
+    const there = distanceKm(49.0069, 8.4037, 53.5503, 9.9937);
+    const back = distanceKm(53.5503, 9.9937, 49.0069, 8.4037);
+    assert.ok(Math.abs(there - back) < 0.001, 'distance should not depend on direction');
+});
+
+test('coordinates arriving as strings are parsed', () => {
+    // The API returns them as strings; treating them as numbers would give NaN.
+    const km = tournamentDistanceKm({ lat: '48.7758', lon: '9.1829' },
+        { lat: 49.0069, lon: 8.4037 });
+    assert.ok(km != null && Math.abs(km - 64) < 2, `got ${km}`);
+});
+
+test('unusable coordinates yield null rather than NaN', () => {
+    // NaN compares false against everything, so a tournament carrying it would
+    // sort unpredictably and slip through the radius filter.
+    const origin = { lat: 49.0069, lon: 8.4037 };
+    for (const bad of [{ lat: '', lon: '' }, { lat: 'n/a', lon: '9.18' }, {}]) {
+        assert.strictEqual(tournamentDistanceKm(bad, origin), null,
+            `expected null for ${JSON.stringify(bad)}`);
+    }
+});
+
+test('no origin means no distance', () => {
+    assert.strictEqual(tournamentDistanceKm({ lat: '48.7758', lon: '9.1829' }, null), null);
+});
+
+test('formats distance with honest precision', () => {
+    // Below 10km a decimal is meaningful; beyond it implies accuracy that
+    // club-level coordinates do not have.
+    assert.strictEqual(formatDistance(3.42), '3,4 km');
+    assert.strictEqual(formatDistance(64.3), '64 km');
+    assert.strictEqual(formatDistance(null), '');
+});
+
+test('sorts by distance with unplaceable tournaments last', () => {
+    const list = [
+        { title: 'Fern', _distanceKm: 120 },
+        { title: 'Unbekannt', _distanceKm: null },
+        { title: 'Nah', _distanceKm: 5 },
+    ];
+    const sorted = list.slice().sort((a, b) => compareTournaments(a, b, 'distance'));
+    assert.deepStrictEqual(sorted.map(t => t.title), ['Nah', 'Fern', 'Unbekannt']);
+});
+
+test('equal distances fall back to the title', () => {
+    const list = [
+        { title: 'B-Turnier', _distanceKm: 10 },
+        { title: 'A-Turnier', _distanceKm: 10 },
+    ];
+    const sorted = list.slice().sort((a, b) => compareTournaments(a, b, 'distance'));
+    assert.deepStrictEqual(sorted.map(t => t.title), ['A-Turnier', 'B-Turnier']);
 });
 
 console.log('map markers');


### PR DESCRIPTION
Closes #46.

## Privacy first, because the issue asks for it

* **No prompt on load.** The position is requested from a click and nowhere else. Verified: `geolocation calls: 0` after a full page load.
* **Memory only.** Nothing persisted — the issue rules it out, and a stored coordinate goes stale the moment someone travels.
* **The backend never learns the position.** The filter runs over tournaments already fetched rather than re-querying.

Denial is treated as an answer, not a fault:

```
DENIED   status: "Standortzugriff abgelehnt. Gib stattdessen einen Ort oder eine PLZ ein."
         manual entry revealed: true
MANUAL   status: "Entfernungen ab Karlsruhe."
         50km from 76131: [ 'Karlsruhe Open' ]
```

## Distance

Haversine rather than the cheaper equirectangular approximation, which drifts noticeably over Germany's north-south extent.

Coordinates arrive as **strings**, and unparseable ones become `null` rather than `NaN` — every NaN comparison is false, so such a tournament would sort unpredictably and slip through the radius unnoticed.

Precision is deliberately coarse: below 10km a decimal is meaningful, beyond it implies accuracy club-level coordinates do not have.

## Approximate locations get honest treatment

This is what the flag from #55 is for. A tournament pinned at its federation's default has **no real position**, so it is kept and labelled rather than filtered on a distance that would be fiction:

```
50km RADIUS  visible:   [ 'Karlsruhe Open', 'Bruchsal Cup', 'Unklar' ]
             distances: [ '0,0 km',         '20 km',        'Standort ungenau' ]
             count:     "3 Turniere (2 außerhalb des Umkreises)"
```

Reporting "73 km" for a marker sitting in the middle of a state would be a confident lie. Tournaments without usable coordinates sort **last** — listing them first would read as "closest".

The count says what the radius removed; a number that silently shrinks reads as missing data rather than as a filter working.

## Verification

```
ON LOAD      geolocation calls: 0        <- required by the issue
AFTER CLICK  status "Entfernungen ab deinem Standort.", distance sort appears
50km         Karlsruhe + Bruchsal kept, Stuttgart + Hamburg dropped
SORTED       Karlsruhe Open, Bruchsal Cup, Unklar
AFTER RESET  items: 5, distance sort hidden again, sort back to date
```

Ten new unit tests cover the maths against known city-to-city distances (Karlsruhe–Stuttgart ≈64km, Hamburg–München ≈613km), symmetry, string parsing and the null cases. 364 layout checks still pass.

## Also fixed

The manual entry row was visible from the start: `display: flex` overrides the `hidden` attribute, so the row meant to appear only on failure was always there. Found by looking at the rendered sheet rather than the markup.

Marker rendering moved out of the fetch callback into `renderTournaments()` so the filter can redraw both views without another request.
